### PR TITLE
Set TreatWarningsAsErrors to true

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,11 @@
 
     <RepositoryUrl>https://github.com/dotnet/System.CommandLine</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
+
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <DebugType>portable</DebugType>
+    <!-- Show full paths in errors in VSCode so links are clickable in the terminal. -->
+    <GenerateFullPaths Condition="'$(VSCODE_PID)' != ''">true</GenerateFullPaths>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fix https://github.com/dotnet/System.CommandLine/issues/15 and a few other things, like debugging in IDEs that don't support embedded symbols