### PR TITLE
Changed suggestions for var

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -304,6 +304,6 @@ csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 
 csharp_style_throw_expression = true:suggestion
 
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = false
 csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false


### PR DESCRIPTION
Change the editor suggestions so that it suggests when the data type of var is obvious only.