### PR TITLE
handle quoted args when argument delimiter is present

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1032,45 +1032,57 @@ namespace System.CommandLine.Tests
                   .BeEquivalentTo(option2);
         }
 
-        [Fact]
-        public void Empty_string_can_be_accepted_as_a_command_line_argument_when_enclosed_in_double_quotes()
+        [Theory]
+        [InlineData("-x \"hello\"", "hello")]
+        [InlineData("-x=\"hello\"", "hello")]
+        [InlineData("-x:\"hello\"", "hello")]
+        [InlineData("-x \"\"", "")]
+        [InlineData("-x=\"\"", "")]
+        [InlineData("-x:\"\"", "")]
+        public void When_an_argument_is_enclosed_in_double_quotes_its_value_has_the_quotes_removed(string input, string expected)
         {
             ParseResult parseResult = new Parser(
                     new OptionDefinition(
                         "-x",
                         "",
-                        argumentDefinition: new ArgumentDefinitionBuilder().ZeroOrMore()))
-                .Parse("-x \"\"");
+                        new ArgumentDefinitionBuilder().ZeroOrMore()))
+                .Parse(input);
 
             parseResult["x"].Arguments
                             .Should()
-                            .BeEquivalentTo(new[] { "" });
+                            .BeEquivalentTo(new[] { expected });
         }
 
-        [Fact]
-        public void Arguments_can_start_with_prefixes_that_make_them_look_like_options()
+        [Theory]
+        [InlineData("-x -y")]
+        [InlineData("-x=-y")]
+        [InlineData("-x:-y")]
+        public void Arguments_can_start_with_prefixes_that_make_them_look_like_options(string input)
         {
             var parser = new ParserBuilder()
                          .AddOption("-x", "", args => args.ZeroOrOne())
                          .AddOption("-z", "", args => args.ZeroOrOne())
                          .Build();
 
-            var result = parser.Parse("-x=-y");
+            var result = parser.Parse(input);
 
             var valueForOption = result.ValueForOption("-x");
 
             valueForOption.Should().Be("-y");
         }
 
-        [Fact]
-        public void Arguments_can_match_the_aliases_of_sibling_options()
+        [Theory]
+        [InlineData("-x -y", Skip="Issue #108")]
+        [InlineData("-x=-y")]
+        [InlineData("-x:-y")]
+        public void Arguments_can_match_the_aliases_of_sibling_options(string input)
         {
             var parser = new ParserBuilder()
                          .AddOption("-x", "", args => args.ZeroOrOne())
                          .AddOption("-y", "", args => args.ZeroOrOne())
                          .Build();
 
-            var result = parser.Parse("-x=-y");
+            var result = parser.Parse(input);
 
             var valueForOption = result.ValueForOption("-x");
 

--- a/src/System.CommandLine/StringExtensions.cs
+++ b/src/System.CommandLine/StringExtensions.cs
@@ -46,7 +46,7 @@ namespace System.CommandLine
             var errorList = new List<ParseError>();
 
             SymbolDefinition currentSymbol = null;
-            bool foundEndOfArguments = false;
+            var foundEndOfArguments = false;
             var argList = args.ToList();
 
             var argumentDelimiters = configuration.ArgumentDelimiters.ToArray();
@@ -69,7 +69,8 @@ namespace System.CommandLine
                     foundEndOfArguments = true;
                     continue;
                 }
-                else if (configuration.ResponseFileHandling != ResponseFileHandling.Disabled && arg.StartsWith("@"))
+
+                if (configuration.ResponseFileHandling != ResponseFileHandling.Disabled && arg.StartsWith("@"))
                 {
                     var filePath = arg.Substring(1);
                     if (!string.IsNullOrWhiteSpace(filePath))
@@ -86,15 +87,15 @@ namespace System.CommandLine
                         catch (FileNotFoundException)
                         {
                             errorList.Add(new ParseError(configuration.ValidationMessages.ResponseFileNotFound(filePath),
-                                null,
-                                false));
+                                                         null,
+                                                         false));
                         }
                         catch (IOException e)
                         {
                             errorList.Add(new ParseError(
-                                configuration.ValidationMessages.ErrorReadingResponseFile(filePath, e),
-                                null,
-                                false));
+                                              configuration.ValidationMessages.ErrorReadingResponseFile(filePath, e),
+                                              null,
+                                              false));
                         }
 
                         continue;
@@ -113,7 +114,9 @@ namespace System.CommandLine
 
                         if (parts.Length > 1)
                         {
-                            tokenList.Add(Argument(parts[1]));
+                            // trim outer quotes in case of, e.g., -x="why"
+                            var secondPartWithOuterQuotesRemoved = parts[1].Trim('"');
+                            tokenList.Add(Argument(secondPartWithOuterQuotesRemoved));
                         }
                     }
                     else


### PR DESCRIPTION
The tokenizer implementation is intended to match the behavior of tokenization used in calls to `Program.Main`. This means that our lexer has to handle cases such as `-x="arg"`. This change fixes this gap.