### PR TITLE
conform to expected Program.Main tokenization

### DIFF
--- a/src/System.CommandLine.Tests/TokenizeTests.cs
+++ b/src/System.CommandLine.Tests/TokenizeTests.cs
@@ -38,17 +38,23 @@ namespace System.CommandLine.Tests
         }
 
         [Theory]
-        [InlineData('=')]
-        [InlineData(':')]
-        public void Tokenize_does_not_split_double_quote_delimited_values_when_a_non_whitespace_argument_delimiter_is_used(char delimiter)
+        [InlineData("-", '=')]
+        [InlineData("-", ':')]
+        [InlineData("--", '=')]
+        [InlineData("--", ':')]
+        [InlineData("/", '=')]
+        [InlineData("/", ':')]
+        public void Tokenize_does_not_split_double_quote_delimited_values_when_a_non_whitespace_argument_delimiter_is_used(
+            string prefix,
+            char delimiter)
         {
-            var optionAndArgument = $@"-r{delimiter}""c:\temp files\""";
+            var optionAndArgument = $@"{prefix}the-option{delimiter}""c:\temp files\""";
 
-            var commandLine = $"rm {optionAndArgument}";
+            var commandLine = $"the-command {optionAndArgument}";
 
             commandLine.Tokenize()
                        .Should()
-                       .BeEquivalentTo("rm", optionAndArgument);
+                       .BeEquivalentTo("the-command", optionAndArgument.Replace("\"", ""));
         }
 
         [Fact]

--- a/src/System.CommandLine/StringExtensions.cs
+++ b/src/System.CommandLine/StringExtensions.cs
@@ -15,15 +15,13 @@ namespace System.CommandLine
         private static readonly string[] _optionPrefixStrings = { "--", "-", "/" };
 
         private static readonly Regex _tokenizer = new Regex(
-            @"(?<token>[^""\s]+""[^""]+"")     # token + quoted argument with non-space argument delimiter, ex: --opt:""c:\path with\spaces""
-               |                                
-              (""(?<token>[^""]*)"")           # tokens surrounded by spaces, ex: ""c:\path with\spaces""
-               |
-              (?<token>\S+)                    # tokens containing no quotes or spaces
-",                   
-            RegexOptions.Compiled |
-            RegexOptions.ExplicitCapture |
-            RegexOptions.IgnorePatternWhitespace
+            @"((?<opt>[^""\s]+)""(?<arg>[^""]+)"") # token + quoted argument with non-space argument delimiter, ex: --opt:""c:\path with\spaces""
+              |                                
+              (""(?<token>[^""]*)"")               # tokens surrounded by spaces, ex: ""c:\path with\spaces""
+              |
+              (?<token>\S+)                        # tokens containing no quotes or spaces
+              ",                   
+            RegexOptions.ExplicitCapture | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace
         );
 
         internal static bool ContainsCaseInsensitive(
@@ -259,9 +257,18 @@ namespace System.CommandLine
 
             foreach (Match match in matches)
             {
-                foreach (var capture in match.Groups["token"].Captures)
+                if (match.Groups["arg"].Captures.Count > 0)
                 {
-                    yield return capture.ToString();
+                    var opt = match.Groups["opt"];
+                    var arg = match.Groups["arg"];
+                    yield return $"{opt}{arg}";
+                }
+                else
+                {
+                    foreach (var capture in match.Groups["token"].Captures)
+                    {
+                        yield return capture.ToString();
+                    }
                 }
             }
         }


### PR DESCRIPTION
This changes the tokenization of `--opt<delimiter>"arg"` from `[ '--opt', '"arg"' ]` to `[ '--opt', 'arg' ]` for non-space delimiters, to match the behavior of the tokenization that supplies `Program.Main`.