### PR TITLE
indicate presence of parsing errors in parse diagram

### DIFF
--- a/src/System.CommandLine.Tests/ParseDiagramTests.cs
+++ b/src/System.CommandLine.Tests/ParseDiagramTests.cs
@@ -35,7 +35,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Parse_result_diagram_helps_explain_partial_parse_operation()
+        public void Parse_result_diagram_displays_unmatched_tokens()
         {
             var parser = new Parser(
                 new CommandDefinition("command", "", new[] {
@@ -51,7 +51,22 @@ namespace System.CommandLine.Tests
 
             result.Diagram()
                   .Should()
-                  .Be("[ command [ -x ] ]   ???--> ar");
+                  .Be("[ command [ ! -x ] ]   ???--> ar");
+        }
+
+        [Fact]
+        public void Parse_diagram_shows_type_conversion_errors()
+        {
+            var parser = new CommandLineBuilder()
+                         .AddOption("-f", "",
+                                    args => args.ParseArgumentsAs<int>())
+                         .Build();
+
+            var result = parser.Parse("-f not-an-int");
+
+            result.Diagram()
+                  .Should()
+                  .Be($"[ {CommandLineBuilder.ExeName} [ ! -f <not-an-int> ] ]");
         }
     }
 }

--- a/src/System.CommandLine/ParseResultExtensions.cs
+++ b/src/System.CommandLine/ParseResultExtensions.cs
@@ -50,7 +50,7 @@ namespace System.CommandLine
         {
             var builder = new StringBuilder();
 
-            builder.Diagram(result.RootCommand);
+            builder.Diagram(result.RootCommand, result);
 
             if (result.UnmatchedTokens.Any())
             {
@@ -66,23 +66,32 @@ namespace System.CommandLine
             return builder.ToString();
         }
 
-        internal static void Diagram(
+        private static void Diagram(
             this StringBuilder builder,
-            Symbol symbol)
+            Symbol symbol,
+            ParseResult parseResult)
         {
-            builder.Append("[ ");
+            builder.Append("[");
+
+            if (parseResult.Errors.Any(e => e.Symbol == symbol))
+            {
+                builder.Append(" !");
+            }
+
+            builder.Append(" ");
 
             builder.Append(symbol.SymbolDefinition.Token());
 
             foreach (var child in symbol.Children)
             {
                 builder.Append(" ");
-                builder.Diagram(child);
+                builder.Diagram(child, parseResult);
             }
 
             foreach (var arg in symbol.Arguments)
             {
                 builder.Append(" <");
+
                 builder.Append(arg);
                 builder.Append(">");
             }


### PR DESCRIPTION
I'd welcome any thoughts on how to make the diagram more readable. This PR is a bit of a jumping off point for a discussion about what this should look like.