### PR TITLE
Unnamed options

### DIFF
--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -4,7 +4,6 @@
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Builder;
-using System.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -138,6 +137,80 @@ namespace System.CommandLine.Tests
                   .Should()
                   .BeEquivalentTo("-h", "--help", "/?");
         }
+
+        [Fact]
+        public void When_option_argument_is_provided_without_option_name_argument_position_is_assumed()
+        {
+            var result = new CommandLineBuilder()
+                .AddOption("-a", "", a => a.ExactlyOne())
+                .Build()
+                .Parse("value-for-a");
+
+            result.ValueForOption("-a").Should().Be("value-for-a");
+        }
+
+        [Fact]
+        public void When_multiple_option_arguments_are_provided_without_option_name_argument_positions_are_assumed()
+        {
+            var result = new CommandLineBuilder()
+                .AddOption("-a", "", a => a.ExactlyOne())
+                .AddOption("-b", "")
+                .AddOption("-c", "", a => a.ExactlyOne())
+                .Build()
+                .Parse("value-for-a value-for-c");
+
+            result.ValueForOption("-a").Should().Be("value-for-a");
+            result.ValueForOption("-c").Should().Be("value-for-c");
+            result.HasOption("-b").Should().BeFalse();
+        }
+
+        [Fact]
+        public void When_multiple_option_arguments_are_provided_with_first_option_name_argument_positions_are_assumed()
+        {
+            var result = new CommandLineBuilder()
+                .AddOption("-a", "", a => a.ExactlyOne())
+                .AddOption("-b", "")
+                .AddOption("-c", "", a => a.ExactlyOne())
+                .Build()
+                .Parse("-a value-for-a value-for-c");
+
+            result.ValueForOption("-a").Should().Be("value-for-a");
+            result.ValueForOption("-c").Should().Be("value-for-c");
+            result.HasOption("-b").Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("-")]
+        [InlineData("--")]
+        [InlineData("/")]
+        public void When_option_use_differnt_prefixes_they_still_work(string prefix)
+        {
+            var result = new CommandLineBuilder()
+                .AddOption(prefix + "a", "", a => a.ExactlyOne())
+                .AddOption(prefix + "b", "")
+                .AddOption(prefix + "c", "", a => a.ExactlyOne())
+                .Build()
+                .Parse(prefix + "c value-for-c " + prefix + "a value-for-a");
+
+            result.ValueForOption(prefix + "a").Should().Be("value-for-a");
+            result.ValueForOption(prefix + "c").Should().Be("value-for-c");
+            result.HasOption(prefix + "b").Should().BeFalse();
+        }
+
+        [Fact]
+        public void When_multiple_option_arguments_are_provided_with_second_option_is_first_positions_are_assumed()
+        {
+            var result = new CommandLineBuilder()
+                .AddOption("-a", "", a => a.ExactlyOne())
+                .AddOption("-b", "")
+                .AddOption("-c", "", a => a.ExactlyOne())
+                .Build()
+                .Parse("-c value-for-c value-for-a");
+
+            result.ValueForOption("-a").Should().Be("value-for-a");
+            result.ValueForOption("-c").Should().Be("value-for-c");
+            result.HasOption("-b").Should().BeFalse();
+        }
         
         [Theory]
         [InlineData(":", "-x{0}")]
@@ -179,5 +252,5 @@ namespace System.CommandLine.Tests
             result.ValueForOption(prefix + "c").Should().Be("value-for-c");
             result.HasOption(prefix + "b").Should().BeFalse();
         }
-   }
+    }
 }

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -1,7 +1,8 @@
+using System.Collections.Generic;
 using System.CommandLine.Builder;
 using System.IO;
-using FluentAssertions;
 using System.Linq;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,7 +18,8 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void When_an_option_accepts_only_specific_arguments_but_a_wrong_one_is_supplied_then_an_informative_error_is_returned()
+        public void
+            When_an_option_accepts_only_specific_arguments_but_a_wrong_one_is_supplied_then_an_informative_error_is_returned()
         {
             var builder = new ArgumentDefinitionBuilder();
             var parser = new Parser(
@@ -29,8 +31,8 @@ namespace System.CommandLine.Tests
             var result = parser.Parse("-x none-of-those");
 
             result.Errors
-                  .Should()
-                  .Contain(e => e.Message == "Required argument missing for option: -x");
+                .Should()
+                .Contain(e => e.Message == "Required argument missing for option: -x");
         }
 
         [Fact]
@@ -47,9 +49,9 @@ namespace System.CommandLine.Tests
             var result = parser.Parse("-x something_else");
 
             result.Errors
-                  .Where(e => e.Symbol != null)
-                  .Should()
-                  .Contain(e => e.Symbol.Name == option.Name);
+                .Where(e => e.Symbol != null)
+                .Should()
+                .Contain(e => e.Symbol.Name == option.Name);
         }
 
         [Fact]
@@ -57,15 +59,15 @@ namespace System.CommandLine.Tests
         {
             var builder = new ArgumentDefinitionBuilder();
             var parser = new Parser(new OptionDefinition(
-                                        "-x",
-                                        "",
-                                        builder.ExactlyOne()));
+                "-x",
+                "",
+                builder.ExactlyOne()));
 
             var result = parser.Parse("-x");
 
             result.Errors
-                  .Should()
-                  .Contain(e => e.Message == "Required argument missing for option: -x");
+                .Should()
+                .Contain(e => e.Message == "Required argument missing for option: -x");
         }
 
         [Fact]
@@ -80,9 +82,9 @@ namespace System.CommandLine.Tests
             _output.WriteLine(result.ToString());
 
             result.Errors
-                  .Select(e => e.Message)
-                  .Should()
-                  .ContainSingle(e => e == "Unrecognized command or argument 'some-arg'");
+                .Select(e => e.Message)
+                .Should()
+                .ContainSingle(e => e == "Unrecognized command or argument 'some-arg'");
         }
 
         [Fact]
@@ -127,8 +129,8 @@ namespace System.CommandLine.Tests
             var result = command.Parse($"the-command {invalidCharacters}");
 
             result.UnmatchedTokens
-                  .Should()
-                  .BeEquivalentTo(invalidCharacters);
+                .Should()
+                .BeEquivalentTo(invalidCharacters);
         }
 
         [Fact]
@@ -153,25 +155,27 @@ namespace System.CommandLine.Tests
             commandDefinitionBuilder.Arguments.ExistingFilesOnly().ExactlyOne();
             var command = commandDefinitionBuilder.BuildCommandDefinition();
 
-            var result = command.Parse($@"move ""{Guid.NewGuid()}.txt"" ""{Path.Combine(Directory.GetCurrentDirectory(), ".trash")}""");
+            var result =
+                command.Parse(
+                    $@"move ""{Guid.NewGuid()}.txt"" ""{Path.Combine(Directory.GetCurrentDirectory(), ".trash")}""");
 
             _output.WriteLine(result.Diagram());
 
             result.Command
-                  .Arguments
-                  .Should()
-                  .BeEmpty();
+                .Arguments
+                .Should()
+                .BeEmpty();
         }
 
         [Fact]
         public void An_argument_can_be_invalid_based_on_directory_existence()
         {
             var parser = new CommandLineBuilder()
-                         .AddCommand("move", "",
-                                     toArgs => toArgs.AddOption("--to", "", args => args.ExactlyOne()),
-                                     moveArgs => moveArgs.ExistingFilesOnly()
-                                                         .ExactlyOne())
-                         .Build();
+                .AddCommand("move", "",
+                    toArgs => toArgs.AddOption("--to", "", args => args.ExactlyOne()),
+                    moveArgs => moveArgs.ExistingFilesOnly()
+                        .ExactlyOne())
+                .Build();
 
             var currentDirectory = Directory.GetCurrentDirectory();
             var trash = Path.Combine(currentDirectory, ".trash");
@@ -185,30 +189,31 @@ namespace System.CommandLine.Tests
             _output.WriteLine(result.Diagram());
 
             result.Command
-                  .Arguments
-                  .Should()
-                  .BeEquivalentTo(currentDirectory);
+                .Arguments
+                .Should()
+                .BeEquivalentTo(currentDirectory);
         }
 
         [Fact]
         public void When_there_are_subcommands_and_options_then_a_subcommand_must_be_provided()
         {
             var command = new CommandDefinitionBuilder("outer")
-                          .AddCommand("inner", "",
-                                      inner => inner.AddCommand("inner-er", ""))
-                          .BuildCommandDefinition();
+                .AddCommand("inner", "",
+                    inner => inner.AddCommand("inner-er", ""))
+                .BuildCommandDefinition();
 
             var result = command.Parse("outer inner arg");
 
             result.Errors
-                  .Should()
-                  .ContainSingle(
-                      e => e.Message.Equals(ValidationMessages.Instance.RequiredCommandWasNotProvided()) &&
-                           e.Symbol.Name.Equals("inner"));
+                .Should()
+                .ContainSingle(
+                    e => e.Message.Equals(ValidationMessages.Instance.RequiredCommandWasNotProvided()) &&
+                         e.Symbol.Name.Equals("inner"));
         }
 
         [Fact]
-        public void When_an_option_is_specified_more_than_once_but_only_allowed_once_then_an_informative_error_is_returned()
+        public void
+            When_an_option_is_specified_more_than_once_but_only_allowed_once_then_an_informative_error_is_returned()
         {
             var parser = new Parser(
                 new OptionDefinition(
@@ -219,9 +224,9 @@ namespace System.CommandLine.Tests
             var result = parser.Parse("-x 1 -x 2");
 
             result.Errors
-                  .Select(e => e.Message)
-                  .Should()
-                  .Contain("Option '-x' cannot be specified more than once.");
+                .Select(e => e.Message)
+                .Should()
+                .Contain("Option '-x' cannot be specified more than once.");
         }
 
         [Fact]
@@ -236,9 +241,9 @@ namespace System.CommandLine.Tests
             var result = parser.Parse("-x 1 -x 2");
 
             result.Errors
-                  .Select(e => e.Message)
-                  .Should()
-                  .Contain("Option '-x' cannot be specified more than once.");
+                .Select(e => e.Message)
+                .Should()
+                .Contain("Option '-x' cannot be specified more than once.");
         }
 
         [Fact]
@@ -254,27 +259,193 @@ namespace System.CommandLine.Tests
             var result = parser.Parse("-x");
 
             result.Errors
-                  .Select(e => e.Message)
-                  .Should()
-                  .Contain("Required argument missing for option: -x");
+                .Select(e => e.Message)
+                .Should()
+                .Contain("Required argument missing for option: -x");
         }
 
         [Fact]
-        public void When_an_option_has_a_default_value_then_the_option_token_must_be_applied()
+        public void When_an_option_has_a_default_value_then_the_default_should_apply_if_not_specified()
         {
             var parser = new Parser(
-                new OptionDefinition(
-                    "-x", "",
-                    new ArgumentDefinitionBuilder()
-                        .WithDefaultValue(() => "123")
-                        .ParseArgumentsAs<int>()));
+                    new OptionDefinition(
+                            "-x",
+                            "",
+                            new ArgumentDefinitionBuilder()
+                                    .WithDefaultValue(() => "123")
+                                    .ParseArgumentsAs<int>()),
+                    new OptionDefinition(
+                            "-y",
+                            "",
+                            new ArgumentDefinitionBuilder()
+                                    .WithDefaultValue(() => "456")
+                                    .ParseArgumentsAs<int>())
+            );
 
-            var result = parser.Parse("456");
+            var result = parser.Parse("");
 
-            result.Errors
-                  .Select(e => e.Message)
-                  .Should()
-                  .ContainSingle("Unrecognized command or argument '456'");
+            result.Errors.Should().BeEmpty();
+            result.RootCommand.ValueForOption("-x").Should().Be(123);
+            result.RootCommand.ValueForOption("-y").Should().Be(456);
+        }
+
+        [Fact]
+        public void When_an_option_has_a_default_value_then_a_given_positional_value_should_override()
+        {
+            var parser = new Parser(
+                    new OptionDefinition(
+                            "-x",
+                            "",
+                            new ArgumentDefinitionBuilder()
+                                    .WithDefaultValue(() => "123")
+                                    .ParseArgumentsAs<int>()),
+                    new OptionDefinition(
+                            "-y",
+                            "",
+                            new ArgumentDefinitionBuilder()
+                                    .WithDefaultValue(() => "456")
+                                    .ParseArgumentsAs<int>())
+            );
+
+            var result = parser.Parse("42");
+
+            result.Errors.Should().BeEmpty();
+            result.RootCommand.ValueForOption("-x").Should().Be(42);
+            result.RootCommand.ValueForOption("-y").Should().Be(456);
+        }
+
+        [Fact]
+        public void When_an_option_has_a_default_value_then_a_given_positional_value_should_override_with_other_specified()
+        {
+            var parser = new Parser(
+                    new OptionDefinition(
+                            "-x",
+                            "",
+                            new ArgumentDefinitionBuilder()
+                                    .WithDefaultValue(() => "123")
+                                    .ParseArgumentsAs<int>()),
+                    new OptionDefinition(
+                            "-y",
+                            "",
+                            new ArgumentDefinitionBuilder()
+                                    .WithDefaultValue(() => "456")
+                                    .ParseArgumentsAs<int>())
+            );
+
+            var result = parser.Parse("-y 23 42");
+
+            result.Errors.Should().BeEmpty();
+            result.RootCommand.ValueForOption("-x").Should().Be(42);
+            result.RootCommand.ValueForOption("-y").Should().Be(23);
+        }
+
+        [Fact]
+        public void When_a_command_line_has_unmatched_tokens_they_are_not_applied_to_subsequent_options()
+        {
+            var parser = new CommandLineBuilder()
+                        .AddOption("-x", "",
+                            argument => argument.ExactlyOne())
+                        .AddOption("-y", "",
+                            argument => argument.ExactlyOne())
+                        .TreatUnmatchedTokensAsErrors(false)
+                        .Build();
+
+            var result = parser.Parse("-x 23 unmatched-token -y 42");
+
+            result.ValueForOption("-x").Should().Be("23");
+            result.ValueForOption("-y").Should().Be("42");
+            result.UnmatchedTokens.Should().BeEquivalentTo("unmatched-token");
+        }
+
+        [Fact]
+        public void When_a_subcommand_has_options_they_can_be_positional()
+        {
+            var parser = new CommandLineBuilder()
+                .AddCommand("subcommand", symbols: b =>
+                    b.AddOption("-annon1", arguments: argumentsBuilder => argumentsBuilder.ExactlyOne())
+                        .AddOption("-annon2", arguments: argumentsBuilder => argumentsBuilder.ExactlyOne())
+                )
+                .Build();
+
+            ParseResult result = parser.Parse("subcommand anon1-value anon2-value");
+
+            result.Errors.Should().BeEmpty();
+            result.Command["-annon1"].GetValueOrDefault<string>().Should().Be("anon1-value");
+            result.Command["-annon2"].GetValueOrDefault<string>().Should().Be("anon2-value");
+        }
+
+        [Fact]
+        public void When_a_sibling_commands_have_options_with_the_same_name_it_matches_based_on_command()
+        {
+            var parser = new CommandLineBuilder()
+                .AddCommand("command1", symbols: b =>
+                    b.AddOption("-annon", arguments: argumentsBuilder => argumentsBuilder.ExactlyOne())
+                )
+                .AddCommand("command2", symbols: b =>
+                    b.AddOption("-annon", arguments: argumentsBuilder => argumentsBuilder.ExactlyOne())
+                )
+                .Build();
+
+            ParseResult result = parser.Parse("command2 anon-value");
+
+            result.Errors.Should().BeEmpty();
+            result.Command.Name.Should().Be("command2");
+            result.Command["-annon"].GetValueOrDefault<string>().Should().Be("anon-value");
+        }
+
+        [Theory]
+        [InlineData(2, 0)]
+        [InlineData(1, 1)]
+        [InlineData(0, 2)]
+        public void When_nested_subcommands_have_options_they_can_be_positional(int subcommand1Options,
+            int subcommand2Options)
+        {
+            var parser = new CommandLineBuilder()
+                .AddCommand("subcommand1", symbols: b => {
+                    foreach (int optionIndex in Enumerable.Range(1, subcommand1Options))
+                    {
+                        b.AddOption($"-annon{optionIndex}", arguments: argumentsBuilder => argumentsBuilder.ExactlyOne());
+                    }
+
+                    b.AddCommand("subcommand2", symbols: subCommandBuilder => {
+                        foreach (int optionIndex in Enumerable.Range(1, subcommand2Options))
+                        {
+                            subCommandBuilder.AddOption($"-annon{optionIndex}",
+                                arguments: argumentsBuilder => argumentsBuilder.ExactlyOne());
+                        }
+                    });
+                })
+                .Build();
+
+            string commandLine = string.Join(' ', GetCommandLineParts());
+            _output.WriteLine($"Parsing {commandLine}");
+
+            ParseResult result = parser.Parse(commandLine);
+
+            result.Errors.Should().BeEmpty();
+            for (Command command = result.Command; command != null; command = command.Parent)
+            {
+                int index = 1;
+                foreach (Option option in command.Children.OfType<Option>())
+                {
+                    option.GetValueOrDefault<string>().Should().Be($"annon{index++}-value");
+                }
+            }
+
+            IEnumerable<string> GetCommandLineParts()
+            {
+                yield return "subcommand1";
+                foreach (int optionIndex in Enumerable.Range(1, subcommand1Options))
+                {
+                    yield return $"annon{optionIndex}-value";
+                }
+
+                yield return "subcommand2";
+                foreach (int optionIndex in Enumerable.Range(1, subcommand2Options))
+                {
+                    yield return $"annon{optionIndex}-value";
+                }
+            }
         }
     }
 }

--- a/src/System.CommandLine/AliasedSet.cs
+++ b/src/System.CommandLine/AliasedSet.cs
@@ -43,6 +43,11 @@ namespace System.CommandLine
             _items.Add(item);
         }
 
+        internal void Remove(T item)
+        {
+            _items.Remove(item);
+        }
+
         protected abstract IReadOnlyCollection<string> GetAliases(T item);
 
         public bool Contains(string alias) =>

--- a/src/System.CommandLine/Parser.cs
+++ b/src/System.CommandLine/Parser.cs
@@ -20,15 +20,18 @@ namespace System.CommandLine
 
         internal CommandLineConfiguration Configuration { get; }
 
-        public virtual ParseResult Parse(IReadOnlyCollection<string> rawTokens, string rawInput = null)
+        public virtual ParseResult Parse(IReadOnlyCollection<string> arguments, string rawInput = null)
         {
+            var rawTokens = arguments;  // allow a more user-friendly name for callers of Parse
             var lexResult = NormalizeRootCommand(rawTokens).Lex(Configuration);
             var unparsedTokens = new Queue<Token>(lexResult.Tokens);
             var allSymbols = new List<Symbol>();
             var errors = new List<ParseError>(lexResult.Errors);
-            var unmatchedTokens = new List<string>();
+            var unmatchedTokens = new List<Token>();
             Command rootCommand = null;
             Command innermostCommand = null;
+
+            IList<OptionDefinition> optionQueue = GatherOptions(Configuration.SymbolDefinitions);
 
             while (unparsedTokens.Any())
             {
@@ -55,7 +58,7 @@ namespace System.CommandLine
                         {
                             symbol = Symbol.Create(symbolDefinition, token.Value, validationMessages: Configuration.ValidationMessages);
 
-                            rootCommand = (Command) symbol;
+                            rootCommand = (Command)symbol;
                         }
 
                         allSymbols.Add(symbol);
@@ -66,25 +69,34 @@ namespace System.CommandLine
 
                 var added = false;
 
-                foreach (var symbol in Enumerable.Reverse(allSymbols))
+                foreach (var topLevelSymbol in Enumerable.Reverse(allSymbols))
                 {
-                    var symbolForToken = symbol.TryTakeToken(token);
+                    var symbolForToken = topLevelSymbol.TryTakeToken(token);
 
                     if (symbolForToken != null)
                     {
                         allSymbols.Add(symbolForToken);
-
+                        added = true;
                         if (symbolForToken is Command command)
                         {
+                            ProcessImplicitTokens();
                             innermostCommand = command;
                         }
 
-                        added = true;
+                        if (token.Type == TokenType.Option)
+                        {
+                            var existing = optionQueue.FirstOrDefault(symdef => symdef.Name == symbolForToken.Name);
+                            if (existing != null)
+                            {
+                                // we've used this option - don't use it again
+                                optionQueue.Remove(existing);
+                            }
+                        }
                         break;
                     }
 
                     if (token.Type == TokenType.Argument &&
-                        symbol.SymbolDefinition is CommandDefinition)
+                        topLevelSymbol.SymbolDefinition is CommandDefinition)
                     {
                         break;
                     }
@@ -92,14 +104,16 @@ namespace System.CommandLine
 
                 if (!added)
                 {
-                    unmatchedTokens.Add(token.Value);
+                    unmatchedTokens.Add(token);
                 }
             }
+
+            ProcessImplicitTokens();
 
             if (Configuration.RootCommandDefinition.TreatUnmatchedTokensAsErrors)
             {
                 errors.AddRange(
-                    unmatchedTokens.Select(token => new ParseError(Configuration.ValidationMessages.UnrecognizedCommandOrArgument(token))));
+                    unmatchedTokens.Select(token => new ParseError(Configuration.ValidationMessages.UnrecognizedCommandOrArgument(token.Value))));
             }
 
             return new ParseResult(
@@ -107,9 +121,66 @@ namespace System.CommandLine
                 innermostCommand ?? rootCommand,
                 rawTokens,
                 unparsedTokens.Select(t => t.Value).ToArray(),
-                unmatchedTokens,
+                unmatchedTokens.Select(t => t.Value).ToArray(),
                 errors,
                 rawInput);
+
+            void ProcessImplicitTokens()
+            {
+                Command currentCommand = innermostCommand ?? rootCommand;
+                if (currentCommand == null) return;
+
+                Token[] tokensToAttemptByPosition =
+                    Enumerable.Reverse(unmatchedTokens)
+                    .TakeWhile(x => x.Type != TokenType.Command)
+                    .Reverse()
+                    .ToArray();
+
+                foreach (Token token in tokensToAttemptByPosition)
+                {
+                    SymbolDefinition optionSymdef = optionQueue.FirstOrDefault();
+                    if (optionSymdef != null)
+                    {
+                        var newToken = new Token(optionSymdef.RawAliases.First(), TokenType.Option);
+                        Symbol optionSymbol = currentCommand.TryTakeToken(newToken);
+                        Symbol optionArgument = optionSymbol?.TryTakeToken(token);
+                        if (optionArgument != null)
+                        {
+                            optionQueue.RemoveAt(0);
+                            allSymbols.Add(optionSymbol);
+                            if (optionSymbol != optionArgument)
+                            {
+                                allSymbols.Add(optionArgument);
+                            }
+                            unmatchedTokens.Remove(token);
+                        }
+                        else if (optionSymbol != null)
+                        {
+                            currentCommand.Children.Remove(optionSymbol);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static IList<OptionDefinition> GatherOptions(SymbolDefinitionSet symbolDefinitions)
+        {
+            var optionList = new List<OptionDefinition>();
+            foreach (SymbolDefinition symbolDefinition in symbolDefinitions)
+            {
+                if (symbolDefinition is OptionDefinition optionDefinition)
+                {
+                    var validator = optionDefinition.ArgumentDefinition.Parser.ArityValidator;
+                    if (validator?.MaximumNumberOfArguments == 1 &&
+                        validator.MinimumNumberOfArguments == 1)    // Exactly One
+                    {
+                        optionList.Add(optionDefinition);
+                    }
+                }
+
+                optionList.AddRange(GatherOptions(symbolDefinition.SymbolDefinitions));
+            }
+            return optionList;
         }
 
         internal IReadOnlyCollection<string> NormalizeRootCommand(IReadOnlyCollection<string> args)


### PR DESCRIPTION
Fixes #29 

Initial implementation of resolving options by position. The key here is in ProcessImplicitTokens() method. After matching all named options it will re-attempt to match unmatched tokens for the current command as positional options.