### PR TITLE
do not include empty-named arguments in help output

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -594,9 +594,9 @@ namespace System.CommandLine.Tests.Help
                 .BuildCommand();
 
             var expected =
-                $"Arguments:{NewLine}" +
-                $"{_indentation}<outer-command-arg>    {_columnPadding}The argument for the outer command{NewLine}" +
-                $"{_indentation}<the-inner-command-arg>{_columnPadding}The argument for the inner command";
+            $"Arguments:{NewLine}" +
+            $"{_indentation}<outer-command-arg>    {_columnPadding}The argument for the outer command{NewLine}" +
+            $"{_indentation}<the-inner-command-arg>{_columnPadding}The argument for the inner command";
 
             commandLineBuilder
                 .Subcommand("outer")
@@ -604,6 +604,63 @@ namespace System.CommandLine.Tests.Help
                 .WriteHelp(_console);
 
             GetHelpText().Should().Contain(expected);
+        }
+
+        [Fact]
+        public void Arguments_section_is_not_included_with_only_unnamed_command_arguments()
+        {
+            var commandLineBuilder = new CommandLineBuilder
+                {
+                    HelpBuilder = _helpBuilder,
+                }
+                .AddCommand(
+                    "outer", "HelpDefinition text for the outer command",
+                    arguments: args => args.ExactlyOne())
+                .BuildCommand();
+
+            commandLineBuilder
+                .Subcommand("outer")
+                .WriteHelp(_console);
+
+            GetHelpText().Should().NotContain("Arguments:");
+            GetHelpText().Should().NotContain("<>");
+        }
+
+        [Fact]
+        public void Arguments_section_does_not_include_unnamed_subcommand_arguments()
+        {
+            var commandLineBuilder = new CommandLineBuilder
+                {
+                    HelpBuilder = _helpBuilder,
+                }
+                .AddCommand(
+                    "outer", "HelpDefinition text for the outer command",
+                    arguments: args => args
+                        .WithHelp(
+                            name: "outer-command-arg",
+                            description: "The argument for the outer command")
+                        .ExactlyOne(),
+                    symbols: outer => outer
+                        .AddCommand(
+                            "inner", "HelpDefinition text for the inner command",
+                            arguments: innerArgs => innerArgs
+                                .WithHelp(
+                                    name: "",
+                                    description: "The argument for the inner command")
+                                .ExactlyOne()))
+                .BuildCommand();
+
+            var expected =
+            $"Arguments:{NewLine}" +
+            $"{_indentation}<outer-command-arg>{_columnPadding}The argument for the outer command{NewLine}{NewLine}";
+
+            commandLineBuilder
+                .Subcommand("outer")
+                .Subcommand("inner")
+                .WriteHelp(_console);
+
+            GetHelpText().Should().Contain(expected);
+            GetHelpText().Should().NotContain("<>");
         }
 
         [Fact]

--- a/src/System.CommandLine/Help/Builders/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/Builders/HelpBuilder.cs
@@ -348,7 +348,7 @@ namespace System.CommandLine
                 var subcommandArgHelp = GetArgumentHelp(subcommand);
                 if (subcommand != command && subcommandArgHelp != null)
                 {
-                    usage.Add($"<{subcommandArgHelp}>");
+                    usage.Add($"<{subcommandArgHelp.Name}>");
                 }
             }
 
@@ -364,7 +364,7 @@ namespace System.CommandLine
             var commandArgHelp = GetArgumentHelp(command);
             if (commandArgHelp != null)
             {
-                usage.Add($"<{commandArgHelp}>");
+                usage.Add($"<{commandArgHelp.Name}>");
             }
 
             var hasCommandHelp = command.Symbols
@@ -392,12 +392,12 @@ namespace System.CommandLine
         {
             var arguments = new List<Command>();
 
-            if (command.Parent?.HasArguments == true && command.Parent.HasHelp)
+            if (GetArgumentHelp(command.Parent) != null)
             {
                 arguments.Add(command.Parent);
             }
 
-            if (command.HasArguments && command.HasHelp)
+            if (GetArgumentHelp(command) != null)
             {
                 arguments.Add(command);
             }
@@ -447,17 +447,15 @@ namespace System.CommandLine
             HelpSection.Write(this, AdditionalArguments.Title, AdditionalArguments.Description);
         }
 
-        private string GetArgumentHelp(Symbol symbolDef)
+        private static HelpDefinition GetArgumentHelp(Symbol symbolDef)
         {
-            var argDef = symbolDef?.Argument;
-            var argHelp = argDef?.Help?.Name;
-
-            if (argDef?.HasHelp != true || string.IsNullOrEmpty(argHelp))
+            if (symbolDef?.HasArguments != true || symbolDef.Argument?.HasHelp != true)
             {
                 return null;
             }
 
-            return argHelp;
+            var argHelp = symbolDef.Argument.Help;
+            return string.IsNullOrEmpty(argHelp.Name) ? null : argHelp;
         }
 
         /// <summary>


### PR DESCRIPTION
fixes #147 