### PR TITLE
Refactor to extract SymbolCannotContainDelimiterException

### DIFF
--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -131,13 +131,13 @@ namespace System.CommandLine.Tests
                     commandWithDelimiter, "",
                     new ArgumentBuilder().ExactlyOne()));
 
-            create.Should().Throw<CommandLineConfiguration.SymbolCannotContainDelimiterException>();
+            create.Should().Throw<SymbolCannotContainDelimiterArgumentException>();
         }
 
         [Fact]
         public void When_a_command_name_contains_a_delimiter_then_the_error_is_informative()
         {
-            var subject = new CommandLineConfiguration.SymbolCannotContainDelimiterException('ツ');
+            var subject = new SymbolCannotContainDelimiterArgumentException('ツ');
             subject.Message.Should()
                 .Be(@"Symbol cannot contain delimiter: ""ツ""");
         }

--- a/src/System.CommandLine/CommandLineConfiguration.SymbolCannotContainDelimiterException.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.SymbolCannotContainDelimiterException.cs
@@ -1,18 +1,15 @@
 namespace System.CommandLine
 {
-    public partial class CommandLineConfiguration
+    public class SymbolCannotContainDelimiterArgumentException : ArgumentException
     {
-        public class SymbolCannotContainDelimiterException : ArgumentException
+        public SymbolCannotContainDelimiterArgumentException(char delimiter)
+
         {
-            public SymbolCannotContainDelimiterException(char delimiter)
-
-            {
-                Delimiter = delimiter;
-            }
-
-            public char Delimiter { get; }
-
-            public override string Message => $"Symbol cannot contain delimiter: \"{Delimiter}\"";
+            Delimiter = delimiter;
         }
+
+        public char Delimiter { get; }
+
+        public override string Message => $"Symbol cannot contain delimiter: \"{Delimiter}\"";
     }
 }

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -40,7 +40,7 @@ namespace System.CommandLine
                     {
                         if (alias.Contains(delimiter))
                         {
-                            throw new SymbolCannotContainDelimiterException(delimiter);
+                            throw new SymbolCannotContainDelimiterArgumentException(delimiter);
                         }
                     }
                 }


### PR DESCRIPTION
Applying this idea: https://jbazuzicode.blogspot.com/2015/01/exceptions-are-primitive-type.html

