### PR TITLE
Debug directive

### DIFF
--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -53,6 +53,7 @@ namespace System.CommandLine.DragonFruit
         {
             var builder = new CommandLineBuilder()
                           .ConfigureFromMethod(method, @object)
+                          .UseDebugDirective()
                           .UseParseErrorReporting()
                           .UseParseDirective()
                           .UseHelp()

--- a/src/System.CommandLine/Invocation/InvocationExtensions.cs
+++ b/src/System.CommandLine/Invocation/InvocationExtensions.cs
@@ -26,6 +26,33 @@ namespace System.CommandLine.Invocation
             return builder;
         }
 
+        public static CommandLineBuilder UseDebugDirective(
+            this CommandLineBuilder builder)
+        {
+            builder.AddMiddleware(async (context, next) =>
+            {
+                if (context.ParseResult.Tokens.Contains("[debug]"))
+                {
+                    var minusDirective = context.ParseResult
+                                                .Tokens
+                                                .Where(t => t != "[debug]")
+                                                .ToArray();
+
+                    context.ParseResult = context.Parser.Parse(minusDirective);
+
+                    var processId = Diagnostics.Process.GetCurrentProcess().Id;
+
+                    context.Console.Out.WriteLine($"Attach your debugger to process {processId} and then press any key.");
+
+                    Console.ReadKey();
+                }
+
+                await next(context);
+            }, CommandLineBuilder.MiddlewareOrder.Preprocessing);
+
+            return builder;
+        }
+
         public static CommandLineBuilder UseExceptionHandler(
             this CommandLineBuilder builder)
         {


### PR DESCRIPTION
This allows a debugger to be attached before core parsing happens, for example:

```
> RenderingPlayground.exe [debug] --sample dir
Attach your debugger to process 19388 and then press any key.
```



