### PR TITLE
remove SystemConsole.Instance

### DIFF
--- a/src/System.CommandLine.Tests/Rendering/Views/ScreenViewTests.cs
+++ b/src/System.CommandLine.Tests/Rendering/Views/ScreenViewTests.cs
@@ -32,7 +32,7 @@ namespace System.CommandLine.Tests.Rendering.Views
         [Fact]
         public void Clearing_child_view_unregisters_from_updated_event()
         {
-            var screen = new ScreenView(_renderer, _console, _synchronizationContext);
+            var screen = new ScreenView(_renderer, _synchronizationContext);
             var view = new TestView();
             
             screen.Child = view;
@@ -45,7 +45,7 @@ namespace System.CommandLine.Tests.Rendering.Views
         [Fact]
         public void Rendering_without_a_child_view_should_not_throw()
         {
-            var screen = new ScreenView(_renderer, _console, _synchronizationContext);
+            var screen = new ScreenView(_renderer, _synchronizationContext);
 
             Action renderAction = () => screen.Render();
 
@@ -59,7 +59,7 @@ namespace System.CommandLine.Tests.Rendering.Views
             _console.Width = 100;
             _console.CursorLeft = _console.CursorTop = 20;
 
-            var screen = new ScreenView(_renderer, _console, _synchronizationContext);
+            var screen = new ScreenView(_renderer, _synchronizationContext);
             var view = new TestView();
             screen.Child = view;
 
@@ -78,7 +78,7 @@ namespace System.CommandLine.Tests.Rendering.Views
             _console.Width = 100;
             _console.CursorLeft = _console.CursorTop = 20;
 
-            var screen = new ScreenView(_renderer, _console, _synchronizationContext);
+            var screen = new ScreenView(_renderer, _synchronizationContext);
             var view = new TestView();
             screen.Child = view;
 
@@ -100,7 +100,7 @@ namespace System.CommandLine.Tests.Rendering.Views
             _console.Width = 100;
             _console.CursorLeft = _console.CursorTop = 20;
 
-            var screen = new ScreenView(_renderer, _console, _synchronizationContext);
+            var screen = new ScreenView(_renderer, _synchronizationContext);
             var view = new TestView();
             void BeforeRenderAction()
             {

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -21,7 +21,7 @@ namespace System.CommandLine.Invocation
             }
             else
             {
-                Console = new SystemConsole();
+                Console = SystemConsole.Create();
                 _onDispose = Console;
             }
         }

--- a/src/System.CommandLine/Invocation/SystemConsole.cs
+++ b/src/System.CommandLine/Invocation/SystemConsole.cs
@@ -18,8 +18,6 @@ namespace System.CommandLine.Invocation
             _initialBackgroundColor = Console.BackgroundColor;
         }
 
-        public static IConsole Instance { get; } = new SystemConsole();
-
         public void SetOut(TextWriter writer) => Console.SetOut(writer);
 
         public TextWriter Error => Console.Error;
@@ -109,5 +107,7 @@ namespace System.CommandLine.Invocation
         {
             ResetConsole();
         }
+
+        public static IConsole Create() => new SystemConsole();
     }
 }

--- a/src/System.CommandLine/Rendering/ConsoleRenderer.cs
+++ b/src/System.CommandLine/Rendering/ConsoleRenderer.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Rendering
             OutputMode mode = OutputMode.Auto,
             bool resetAfterRender = false)
         {
-            Console = console ?? SystemConsole.Instance;
+            Console = console ?? SystemConsole.Create();
             _resetAfterRender = resetAfterRender;
             Mode = mode == OutputMode.Auto
                        ? Console.DetectOutputMode()

--- a/src/System.CommandLine/Rendering/Views/ScreenView.cs
+++ b/src/System.CommandLine/Rendering/Views/ScreenView.cs
@@ -10,11 +10,13 @@ namespace System.CommandLine.Rendering.Views
         private int _renderInProgress;
         private readonly SynchronizationContext _context;
 
-        public ScreenView(ConsoleRenderer renderer, IConsole console = null, SynchronizationContext synchronizationContext = null)
+        public ScreenView(
+            ConsoleRenderer renderer, 
+            SynchronizationContext synchronizationContext = null)
         {
             Renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
             _context = synchronizationContext ?? SynchronizationContext.Current ?? new SynchronizationContext();
-            Console = console ?? SystemConsole.Instance;   
+            Console = renderer.Console;   
         }
 
         private IConsole Console { get; }


### PR DESCRIPTION
The singleton doesn't make sense since `IConsole` is now `IDisposable`. 