### PR TITLE
coalesce in Parse when args is null

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -128,7 +128,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_no_options_are_specified_then_an_error_is_returned()
         {
-            Action create = () => new Parser();
+            Action create = () => new Parser(Array.Empty<Symbol>());
 
             create.Should()
                   .Throw<ArgumentException>()
@@ -1188,6 +1188,18 @@ namespace System.CommandLine.Tests
             result.ValueForOption("-x").Should().Be("23");
             result.ValueForOption("-y").Should().Be("42");
             result.UnmatchedTokens.Should().BeEquivalentTo("unmatched-token");
+        }
+
+        [Fact]
+        public void Parse_can_be_called_with_null_args()
+        {
+            var parser = new Parser();
+
+            var result = parser.Parse(null);
+
+            _output.WriteLine(result.Diagram());
+
+            result.CommandResult.Command.Name.Should().Be(RootCommand.ExeName);
         }
     }
 }

--- a/src/System.CommandLine/Parser.cs
+++ b/src/System.CommandLine/Parser.cs
@@ -18,9 +18,15 @@ namespace System.CommandLine
         {
         }
 
+        public Parser() : this(new RootCommand())
+        {
+        }
+
         internal CommandLineConfiguration Configuration { get; }
 
-        public virtual ParseResult Parse(IReadOnlyCollection<string> arguments, string rawInput = null)
+        public virtual ParseResult Parse(
+            IReadOnlyCollection<string> arguments, 
+            string rawInput = null)
         {
             var rawTokens = arguments;  // allow a more user-friendly name for callers of Parse
             var lexResult = NormalizeRootCommand(rawTokens).Lex(Configuration);
@@ -207,6 +213,11 @@ namespace System.CommandLine
 
         internal IReadOnlyCollection<string> NormalizeRootCommand(IReadOnlyCollection<string> args)
         {
+            if (args == null)
+            {
+                args = Array.Empty<string>();
+            }
+
             var firstArg = args.FirstOrDefault();
 
             var commandName = Configuration.RootCommand.Name;


### PR DESCRIPTION
Since `Main(string[])` can receive a null input, this avoids a gotcha when someone passes that directly to `Parser.Parse`.