### PR TITLE
Add sign exe to dotnet-suggest

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -10,6 +10,13 @@
       ]
     },
     {
+      "certificate": "Microsoft402",
+      "values": [
+        "bin/dotnet-suggest/shims/netcoreapp2.1/win-x64/dotnet-suggest.exe",
+        "bin/dotnet-suggest/shims/netcoreapp2.1/win-x86/dotnet-suggest.exe"
+      ]
+    },
+    {
       "certificate": null,
       "strongName": null,
       "values": [

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -20,6 +20,7 @@
   <!-- Toolset Dependencies -->
   <PropertyGroup>
     <DotNetCliVersion>2.1.400</DotNetCliVersion>
+    <RoslynToolsSignToolVersion>1.0.0-beta2-63127-01</RoslynToolsSignToolVersion>
     <RoslynToolsRepoToolsetVersion>1.0.0-beta-62503-02</RoslynToolsRepoToolsetVersion>
     <VSWhereVersion>2.1.4</VSWhereVersion>
   </PropertyGroup>

--- a/src/System.CommandLine.Suggest/dotnet-suggest.csproj
+++ b/src/System.CommandLine.Suggest/dotnet-suggest.csproj
@@ -7,6 +7,8 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>dotnet-suggest</PackageId>
     <ToolCommandName>dotnet-suggest</ToolCommandName>
+    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
+    <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
   </PropertyGroup>
   
   <PropertyGroup Condition=" $(Build_BuildId) != '' " >


### PR DESCRIPTION
Pin higher version of RoslynToolsSignTool, there is a bug in current sign tool

Higher version of repotool set cannot build. So I won't update that


Proof of it will work this time :p https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=2214179&view=logs