### PR TITLE
Support aliases of param in Xml doc

### DIFF
--- a/samples/DragonFruit/Program.cs
+++ b/samples/DragonFruit/Program.cs
@@ -10,7 +10,7 @@ namespace DragonFruit
         /// <summary>
         /// DragonFruit simple example program
         /// </summary>
-        /// <param name="verbose">Show verbose output</param>
+        /// <param name="verbose" alias="v">Show verbose output</param>
         /// <param name="flavor">Which flavor to use</param>
         /// <param name="count">How many smoothies?</param>
         static int Main(

--- a/src/System.CommandLine.DragonFruit.Tests/XmlDocReaderTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/XmlDocReaderTests.cs
@@ -1,6 +1,7 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
 using System.Linq;
@@ -26,11 +27,12 @@ namespace System.CommandLine.DragonFruit.Tests
         <name>DragonFruit</name>
     </assembly>
     <members>
-        <member name=""M:System.CommandLine.DragonFruit.Tests." + nameof(XmlDocReaderTests) + @".Program.Main(System.Boolean,System.String,System.Nullable{System.Int32})"">
+        <member name=""M:System.CommandLine.DragonFruit.Tests." + nameof(XmlDocReaderTests) +
+                               @".Program.Main(System.Boolean,System.String,System.Nullable{System.Int32})"">
             <summary>
             Hello
             </summary>
-            <param name=""verbose"">Show verbose output</param>
+            <param name=""verbose"" alias=""v"">Show verbose output</param>
             <param name=""flavor"">Which flavor to use</param>
             <param name=""count"">How many smoothies?</param>
         </member>
@@ -43,9 +45,11 @@ namespace System.CommandLine.DragonFruit.Tests
 
             docReader.TryGetMethodDescription(action.Method, out var helpMetadata).Should().BeTrue();
             helpMetadata.Description.Should().Be("Hello");
-            helpMetadata.ParameterDescriptions["verbose"].Should().Be("Show verbose output");
-            helpMetadata.ParameterDescriptions["flavor"].Should().Be("Which flavor to use");
-            helpMetadata.ParameterDescriptions["count"].Should().Be("How many smoothies?");
+            helpMetadata.ParameterDescriptions.Should().HaveCount(3);
+            helpMetadata.ParameterDescriptions.Should().BeEquivalentTo(
+                new ParameterMetadata("verbose", "Show verbose output", "v"),
+                new ParameterMetadata("flavor", "Which flavor to use"),
+                new ParameterMetadata("count", "How many smoothies?"));
         }
     }
 }

--- a/src/System.CommandLine.DragonFruit/CommandHelpMetadata.cs
+++ b/src/System.CommandLine.DragonFruit/CommandHelpMetadata.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -11,6 +11,6 @@ namespace System.CommandLine.DragonFruit
 
         public string Name { get; set; }
 
-        public Dictionary<string, string> ParameterDescriptions { get; } = new Dictionary<string, string>();
+        public List<ParameterMetadata> ParameterDescriptions { get; } = new List<ParameterMetadata>();
     }
 }

--- a/src/System.CommandLine.DragonFruit/ParameterMetadata.cs
+++ b/src/System.CommandLine.DragonFruit/ParameterMetadata.cs
@@ -1,0 +1,18 @@
+﻿namespace System.CommandLine.DragonFruit
+{
+    public class ParameterMetadata
+    {
+        public ParameterMetadata(string name, string description, string alias = null)
+        {
+            Name = name;
+            Description = description;
+            Alias = alias;
+        }
+
+        public string Name { get; }
+
+        public string Description { get; }
+
+        public string Alias { get; }
+    }
+}

--- a/src/System.CommandLine.DragonFruit/XmlDocReader.cs
+++ b/src/System.CommandLine.DragonFruit/XmlDocReader.cs
@@ -94,7 +94,11 @@ namespace System.CommandLine.DragonFruit
                         commandHelpMetadata.Description = element.Value?.Trim();
                         break;
                     case "param":
-                        commandHelpMetadata.ParameterDescriptions.Add(element.Attribute("name")?.Value, element.Value?.Trim());
+                        commandHelpMetadata.ParameterDescriptions.Add(
+                            new ParameterMetadata(
+                                element.Attribute("name")?.Value,
+                                element.Value?.Trim(),
+                                element.Attribute("alias")?.Value));
                         break;
                 }
             }


### PR DESCRIPTION
Thanks to this PR you can create aliases of `<param>` in XML doc. E. g.:

```xml
<param name="verbose" alias="v">Show verbose output</param>
```

Output for DragonFruit application now looks like:
```ini
C:\Work\command-line-api\samples\DragonFruit (support_param_aliases_in_xml_doc -> origin)
λ dotnet run -- -h
DragonFruit:
  DragonFruit simple example program

Usage:
  DragonFruit [options]

Options:
  -v, --verbose    Show verbose output
  --flavor         Which flavor to use
  --count          How many smoothies?
  --version        Display version information
```

I wanted to support multiple aliases but they generate a hint in Visual Studio:
![image](https://user-images.githubusercontent.com/17333903/50341754-5c787000-0520-11e9-8c5c-9e319f8b2273.png)
