### PR TITLE
parse directives as key/value pairs

### DIFF
--- a/src/System.CommandLine.Tests/AssertionExtensions.cs
+++ b/src/System.CommandLine.Tests/AssertionExtensions.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
 using System.Linq;
 using FluentAssertions.Collections;
 using FluentAssertions.Execution;

--- a/src/System.CommandLine.Tests/DirectiveTests.cs
+++ b/src/System.CommandLine.Tests/DirectiveTests.cs
@@ -114,5 +114,15 @@ namespace System.CommandLine.Tests
 
             result.Directives.Should().BeEmpty();
         }
+
+        [Fact]
+        public void When_a_directive_is_specified_more_than_once_then_its_value_is_overwritten()
+        {
+            var option = new Option("-a");
+
+            var result = option.Parse("[directive:one] [directive:two] -a");
+
+            result.Directives["directive"].Should().Be("two");
+        }
     }
 }

--- a/src/System.CommandLine.Tests/DirectiveTests.cs
+++ b/src/System.CommandLine.Tests/DirectiveTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 
@@ -26,7 +25,7 @@ namespace System.CommandLine.Tests
 
             var result = option.Parse("[parse] -y");
 
-            result.Directives.Keys.Should().Contain("parse");
+            result.Directives.Contains("parse").Should().BeTrue();
             result.Tokens.Should().Contain("[parse]");
         }
 
@@ -37,7 +36,7 @@ namespace System.CommandLine.Tests
 
             var result = option.Parse("[parse] -y");
 
-            result.Directives.Keys.Should().Contain("parse");
+            result.Directives.Contains("parse").Should().BeTrue();
         }
 
         [Fact]
@@ -47,8 +46,8 @@ namespace System.CommandLine.Tests
 
             var result = option.Parse("[parse] [suggest] -y");
 
-            result.Directives.Keys.Should().Contain("parse");
-            result.Directives.Keys.Should().Contain("suggest");
+            result.Directives.Contains("parse").Should().BeTrue();
+            result.Directives.Contains("suggest").Should().BeTrue();
         }
 
         [Fact]
@@ -74,9 +73,8 @@ namespace System.CommandLine.Tests
 
             var result = option.Parse($"{directive} -y");
 
-            result.Directives
-                  .Should()
-                  .Contain(new KeyValuePair<string, string>(expectedKey, expectedValue));
+            result.Directives.TryGetValues(expectedKey, out var values).Should().BeTrue();
+            values.Should().BeEquivalentTo(expectedValue);
         }
 
         [Fact]
@@ -86,7 +84,8 @@ namespace System.CommandLine.Tests
 
             var result = option.Parse("[parse] -y");
 
-            result.Directives.Should().Contain(new KeyValuePair<string, string>("parse", ""));
+            result.Directives.TryGetValues("parse", out var values).Should().BeTrue();
+            values.Should().BeEquivalentTo("");
         }
 
         [Theory]
@@ -116,13 +115,14 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void When_a_directive_is_specified_more_than_once_then_its_value_is_overwritten()
+        public void When_a_directive_is_specified_more_than_once_then_its_values_are_aggregated()
         {
             var option = new Option("-a");
 
             var result = option.Parse("[directive:one] [directive:two] -a");
 
-            result.Directives["directive"].Should().Be("two");
+            result.Directives.TryGetValues("directive", out var values).Should().BeTrue();
+            values.Should().BeEquivalentTo("one", "two");
         }
     }
 }

--- a/src/System.CommandLine.Tests/DirectiveTests.cs
+++ b/src/System.CommandLine.Tests/DirectiveTests.cs
@@ -62,17 +62,17 @@ namespace System.CommandLine.Tests
         }
 
         [Theory]
-        [InlineData("key:value", "key", "value")]
-        [InlineData("key:value:more", "key", "value:more")]
-        [InlineData("key:", "key", "")]
+        [InlineData("[key:value]", "key", "value")]
+        [InlineData("[key:value:more]", "key", "value:more")]
+        [InlineData("[key:]", "key", "")]
         public void Directives_can_have_a_value_which_is_everything_after_the_first_colon(
-            string directiveContent,
+            string directive,
             string expectedKey,
             string expectedValue)
         {
             var option = new Option("-y");
 
-            var result = option.Parse($"[{directiveContent}] -y");
+            var result = option.Parse($"{directive} -y");
 
             result.Directives
                   .Should()

--- a/src/System.CommandLine/DirectiveCollection.cs
+++ b/src/System.CommandLine/DirectiveCollection.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace System.CommandLine
+{
+    internal class DirectiveCollection : IDirectiveCollection
+    {
+        private readonly Dictionary<string, List<string>> _directives = new Dictionary<string, List<string>>();
+
+        public void Add(string name, string value)
+        {
+            if (_directives.TryGetValue(name, out var values))
+            {
+                values.Add(value);
+            }
+            else
+            {
+                _directives.Add(name, new List<string> { value });
+            }
+        }
+
+        public bool Contains(string name)
+        {
+            return _directives.ContainsKey(name);
+        }
+
+        public bool TryGetValues(string name, out IEnumerable<string> values)
+        {
+            if (_directives.TryGetValue(name, out var v))
+            {
+                values = v;
+                return true;
+            }
+            else
+            {
+                values = null;
+                return false;
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, IEnumerable<string>>> GetEnumerator() =>
+            _directives
+                .OfType<KeyValuePair<string, IEnumerable<string>>>()
+                .GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/System.CommandLine/IDirectiveCollection.cs
+++ b/src/System.CommandLine/IDirectiveCollection.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.CommandLine
+{
+    public interface IDirectiveCollection : IEnumerable<KeyValuePair<string, IEnumerable<string>>>
+    {
+        bool Contains(string name);
+
+        bool TryGetValues(string name, out IEnumerable<string> values);
+    }
+}

--- a/src/System.CommandLine/Invocation/InvocationExtensions.cs
+++ b/src/System.CommandLine/Invocation/InvocationExtensions.cs
@@ -153,7 +153,7 @@ namespace System.CommandLine.Invocation
             this CommandLineBuilder builder)
         {
             builder.AddMiddleware(async (context, next) => {
-                if (context.ParseResult.Directives.ContainsKey("parse"))
+                if (context.ParseResult.Directives.Contains("parse"))
                 {
                     context.InvocationResult = new ParseDirectiveResult();
                 }
@@ -170,7 +170,7 @@ namespace System.CommandLine.Invocation
             this CommandLineBuilder builder)
         {
             builder.AddMiddleware(async (context, next) => {
-                if (context.ParseResult.Directives.ContainsKey("suggest"))
+                if (context.ParseResult.Directives.Contains("suggest"))
                 {
                     context.InvocationResult = new SuggestDirectiveResult();
                 }

--- a/src/System.CommandLine/Invocation/InvocationExtensions.cs
+++ b/src/System.CommandLine/Invocation/InvocationExtensions.cs
@@ -153,7 +153,7 @@ namespace System.CommandLine.Invocation
             this CommandLineBuilder builder)
         {
             builder.AddMiddleware(async (context, next) => {
-                if (context.ParseResult.Directives.Contains("parse"))
+                if (context.ParseResult.Directives.ContainsKey("parse"))
                 {
                     context.InvocationResult = new ParseDirectiveResult();
                 }
@@ -170,7 +170,7 @@ namespace System.CommandLine.Invocation
             this CommandLineBuilder builder)
         {
             builder.AddMiddleware(async (context, next) => {
-                if (context.ParseResult.Directives.Contains("suggest"))
+                if (context.ParseResult.Directives.ContainsKey("suggest"))
                 {
                     context.InvocationResult = new SuggestDirectiveResult();
                 }

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine
         internal ParseResult(
             CommandResult rootCommandResult,
             CommandResult commandResult,
-            IReadOnlyCollection<string> directives,
+            IReadOnlyDictionary<string, string> directives,
             IReadOnlyCollection<string> tokens,
             IReadOnlyCollection<string> unparsedTokens,
             IReadOnlyCollection<string> unmatchedTokens,
@@ -42,7 +42,7 @@ namespace System.CommandLine
 
         public IReadOnlyCollection<ParseError> Errors => _errors;
 
-        public IReadOnlyCollection<string> Directives { get; }
+        public IReadOnlyDictionary<string, string> Directives { get; }
         
         public IReadOnlyCollection<string> Tokens { get; }
 

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine
         internal ParseResult(
             CommandResult rootCommandResult,
             CommandResult commandResult,
-            IReadOnlyDictionary<string, string> directives,
+            IDirectiveCollection directives,
             IReadOnlyCollection<string> tokens,
             IReadOnlyCollection<string> unparsedTokens,
             IReadOnlyCollection<string> unmatchedTokens,
@@ -42,8 +42,8 @@ namespace System.CommandLine
 
         public IReadOnlyCollection<ParseError> Errors => _errors;
 
-        public IReadOnlyDictionary<string, string> Directives { get; }
-        
+        public IDirectiveCollection Directives { get; }
+
         public IReadOnlyCollection<string> Tokens { get; }
 
         public IReadOnlyCollection<string> UnmatchedTokens { get; }

--- a/src/System.CommandLine/Parser.cs
+++ b/src/System.CommandLine/Parser.cs
@@ -30,7 +30,7 @@ namespace System.CommandLine
         {
             var rawTokens = arguments;  // allow a more user-friendly name for callers of Parse
             var lexResult = NormalizeRootCommand(rawTokens).Lex(Configuration);
-            var directives = new Dictionary<string, string>();
+            var directives = new DirectiveCollection();
             var unparsedTokens = new Queue<Token>(lexResult.Tokens);
             var allSymbolResults = new List<SymbolResult>();
             var errors = new List<ParseError>(lexResult.Errors);
@@ -82,7 +82,9 @@ namespace System.CommandLine
                     var value = keyAndValue.Length == 2
                                     ? keyAndValue[1]
                                     : string.Empty;
-                    directives[key] = value;
+
+                    directives.Add(key, value);
+
                     continue;
                 }
 
@@ -247,4 +249,9 @@ namespace System.CommandLine
             return args;
         }
     }
+
+
+    //
+    // Summary:
+    //     A collection of headers and their values as defined in RFC 2616.
 }

--- a/src/System.CommandLine/Parser.cs
+++ b/src/System.CommandLine/Parser.cs
@@ -30,7 +30,7 @@ namespace System.CommandLine
         {
             var rawTokens = arguments;  // allow a more user-friendly name for callers of Parse
             var lexResult = NormalizeRootCommand(rawTokens).Lex(Configuration);
-            var directives = new List<string>();
+            var directives = new Dictionary<string, string>();
             var unparsedTokens = new Queue<Token>(lexResult.Tokens);
             var allSymbolResults = new List<SymbolResult>();
             var errors = new List<ParseError>(lexResult.Errors);
@@ -77,7 +77,12 @@ namespace System.CommandLine
                 if (token.Type == TokenType.Directive)
                 {
                     var withoutBrackets = token.Value.Substring(1, token.Value.Length - 2);
-                    directives.Add(withoutBrackets);
+                    var keyAndValue = withoutBrackets.Split(new[] { ':' }, 2);
+                    var key = keyAndValue[0];
+                    var value = keyAndValue.Length == 2
+                                    ? keyAndValue[1]
+                                    : string.Empty;
+                    directives.Add(key, value);
                     continue;
                 }
 

--- a/src/System.CommandLine/Parser.cs
+++ b/src/System.CommandLine/Parser.cs
@@ -82,7 +82,7 @@ namespace System.CommandLine
                     var value = keyAndValue.Length == 2
                                     ? keyAndValue[1]
                                     : string.Empty;
-                    directives.Add(key, value);
+                    directives[key] = value;
                     continue;
                 }
 

--- a/src/System.CommandLine/StringExtensions.cs
+++ b/src/System.CommandLine/StringExtensions.cs
@@ -79,16 +79,18 @@ namespace System.CommandLine
                     continue;
                 }
 
-                if (!foundEndOfDirectives && arg.StartsWith("[") && arg.EndsWith("]"))
+                if (!foundEndOfDirectives)
                 {
-                    tokenList.Add(Directive(arg));
-                    continue;
-                }
+                    if (arg.StartsWith("[") && arg.EndsWith("]") && arg[1] != ']' && arg[1] != ':')
+                    {
+                        tokenList.Add(Directive(arg));
+                        continue;
+                    }
 
-                if (!foundEndOfDirectives && 
-                    !configuration.RootCommand.HasRawAlias(arg))
-                {
-                    foundEndOfDirectives = true;
+                    if (!configuration.RootCommand.HasRawAlias(arg))
+                    {
+                        foundEndOfDirectives = true;
+                    }
                 }
 
                 if (configuration.ResponseFileHandling != ResponseFileHandling.Disabled &&


### PR DESCRIPTION
This changes parsed directives (`ParseResult.Directives`) from `IReadOnlyCollection<string>` to `IReadOnlyDictionary<string, string>`. The only allowed delimiter is `:`.  This is intended to enable things like this:

```console
> myApp [render=ansi] -x -y -z
```

Thoughts on the general approach and design?