### PR TITLE
start to differentiate VT vs non-VT behavior in TestTerminal

### DIFF
--- a/src/System.CommandLine.Rendering.Tests/TestTerminalTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/TestTerminalTests.cs
@@ -48,7 +48,7 @@ namespace System.CommandLine.Rendering.Tests
         {
             var terminal = (TestTerminal)GetTerminal();
 
-            terminal.VirtualTerminalMode = true;
+            terminal.IsVirtualTerminalModeEnabled = true;
 
             terminal.Out.Write($"before move{Ansi.Cursor.Move.ToLocation(3, 5).EscapeSequence}after move");
 
@@ -65,7 +65,7 @@ namespace System.CommandLine.Rendering.Tests
         {
             var terminal = (TestTerminal)GetTerminal();
             
-            terminal.VirtualTerminalMode = false;
+            terminal.IsVirtualTerminalModeEnabled = false;
 
             var stringWithEscapeSequence = $"before move{Ansi.Cursor.Move.ToLocation(3, 5).EscapeSequence}after move";
 

--- a/src/System.CommandLine.Rendering.Tests/TestTerminalTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/TestTerminalTests.cs
@@ -44,9 +44,11 @@ namespace System.CommandLine.Rendering.Tests
         }
 
         [Fact]
-        public void When_ANSI_sequences_are_used_to_set_cursor_positions_then_CursorPositionChanged_events_are_recorded()
+        public void When_in_ANSI_mode_and_ANSI_sequences_are_used_to_set_cursor_positions_then_a_CursorPositionChanged_events_is_recorded()
         {
             var terminal = (TestTerminal)GetTerminal();
+
+            terminal.VirtualTerminalMode = true;
 
             terminal.Out.Write($"before move{Ansi.Cursor.Move.ToLocation(3, 5).EscapeSequence}after move");
 
@@ -56,6 +58,22 @@ namespace System.CommandLine.Rendering.Tests
                         new TestTerminal.ContentWritten("before move"),
                         new TestTerminal.CursorPositionChanged(new Point(2, 4)),
                         new TestTerminal.ContentWritten("after move"));
+        }
+
+        [Fact]
+        public void When_not_in_ANSI_mode_and_ANSI_sequences_are_used_to_set_cursor_positions_then_a_CursorPositionChanged_events_is_recorded()
+        {
+            var terminal = (TestTerminal)GetTerminal();
+            
+            terminal.VirtualTerminalMode = false;
+
+            var stringWithEscapeSequence = $"before move{Ansi.Cursor.Move.ToLocation(3, 5).EscapeSequence}after move";
+
+            terminal.Out.Write(stringWithEscapeSequence);
+
+            terminal.Events
+                    .Should()
+                    .BeEquivalentSequenceTo(new TestTerminal.ContentWritten(stringWithEscapeSequence));
         }
 
         [Theory]
@@ -71,13 +89,13 @@ namespace System.CommandLine.Rendering.Tests
             OutputMode outputMode,
             string threeLinesOfText)
         {
-            var console = (TestTerminal)GetTerminal();
+            var terminal = (TestTerminal)GetTerminal();
 
-            var renderer = new ConsoleRenderer(console, outputMode);
+            var renderer = new ConsoleRenderer(terminal, outputMode);
 
             renderer.RenderToRegion(threeLinesOfText, new Region(2, 5, 13, 3));
 
-            console.Events
+            terminal.Events
                    .OfType<TestTerminal.CursorPositionChanged>()
                    .Select(e => e.Position)
                    .Should()
@@ -111,7 +129,7 @@ namespace System.CommandLine.Rendering.Tests
         }
 
         [Fact]
-        public void ContentWritten_events_do_not_include_escape_sequences()
+        public void When_in_ANSI_mode_then_ContentWritten_events_do_not_include_escape_sequences()
         {
             var terminal = (TestTerminal)GetTerminal();
 

--- a/src/System.CommandLine.Rendering/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine.Rendering/CommandLineBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace System.CommandLine.Rendering
             return builder;
         }
 
-        private static ITerminal GetTerminal(
+        public static ITerminal GetTerminal(
             this IConsole console,
             bool preferVirtualTerminal = true,
             OutputMode outputMode = OutputMode.Auto)

--- a/src/System.CommandLine.Rendering/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine.Rendering/CommandLineBuilderExtensions.cs
@@ -11,50 +11,9 @@ namespace System.CommandLine.Rendering
         public static CommandLineBuilder UseAnsiTerminalWhenAvailable(
             this CommandLineBuilder builder)
         {
-            builder.ConfigureConsole(context =>
-            {
-                return GetTerminal(context.Console, true);
-            });
+            builder.ConfigureConsole(context => context.Console.GetTerminal());
 
             return builder;
-        }
-
-        public static ITerminal GetTerminal(
-            this IConsole console,
-            bool preferVirtualTerminal = true,
-            OutputMode outputMode = OutputMode.Auto)
-        {
-            if (console == null)
-            {
-                throw new ArgumentNullException(nameof(console));
-            }
-
-            if (console is ITerminal t)
-            {
-                return t;
-            }
-
-            ITerminal terminal;
-
-            if (preferVirtualTerminal &&
-                VirtualTerminalMode.TryEnable() is VirtualTerminalMode virtualTerminalMode &&
-                virtualTerminalMode.IsEnabled)
-            {
-                terminal = new VirtualTerminal(
-                    console,
-                    virtualTerminalMode);
-            }
-            else
-            {
-                terminal = new SystemConsoleTerminal(console);
-            }
-
-            if (terminal is TerminalBase terminalBase)
-            {
-                terminalBase.OutputMode = outputMode;
-            }
-
-            return terminal;
         }
     }
 }

--- a/src/System.CommandLine.Rendering/Terminal.cs
+++ b/src/System.CommandLine.Rendering/Terminal.cs
@@ -29,5 +29,43 @@
                 renderer.RenderToRegion(span, region ?? t.GetRegion());
             }
         }
+
+        public static ITerminal GetTerminal(
+            this IConsole console,
+            bool preferVirtualTerminal = true,
+            OutputMode outputMode = OutputMode.Auto)
+        {
+            if (console == null)
+            {
+                throw new ArgumentNullException(nameof(console));
+            }
+
+            if (console is ITerminal t)
+            {
+                return t;
+            }
+
+            ITerminal terminal;
+
+            if (preferVirtualTerminal &&
+                VirtualTerminalMode.TryEnable() is VirtualTerminalMode virtualTerminalMode &&
+                virtualTerminalMode.IsEnabled)
+            {
+                terminal = new VirtualTerminal(
+                    console,
+                    virtualTerminalMode);
+            }
+            else
+            {
+                terminal = new SystemConsoleTerminal(console);
+            }
+
+            if (terminal is TerminalBase terminalBase)
+            {
+                terminalBase.OutputMode = outputMode;
+            }
+
+            return terminal;
+        }
     }
 }

--- a/src/System.CommandLine.Rendering/Terminal.cs
+++ b/src/System.CommandLine.Rendering/Terminal.cs
@@ -14,5 +14,20 @@
                 renderer.RenderToRegion(span, region ?? t.GetRegion());
             }
         }
+
+        public static void Render(
+            this ITerminal terminal,
+            FormattableString value,
+            Region region = null)
+        {
+            if (terminal is IRenderable t)
+            {
+                var renderer = new ConsoleRenderer(terminal, t.OutputMode);
+
+                var span = renderer.Formatter.Format(value);
+
+                renderer.RenderToRegion(span, region ?? t.GetRegion());
+            }
+        }
     }
 }

--- a/src/System.CommandLine.Rendering/TerminalBase.cs
+++ b/src/System.CommandLine.Rendering/TerminalBase.cs
@@ -30,11 +30,6 @@ namespace System.CommandLine.Rendering
 
         public abstract void ResetColor();
 
-        public Region GetRegion() =>
-            IsOutputRedirected
-                ? new Region(0, 0, int.MaxValue, int.MaxValue, false)
-                : EntireConsoleRegion.Instance;
-
         public IStandardStreamWriter Out => Console.Out;
 
         public IStandardStreamWriter Error => Console.Error;

--- a/src/System.CommandLine.Rendering/TestTerminal.cs
+++ b/src/System.CommandLine.Rendering/TestTerminal.cs
@@ -36,7 +36,7 @@ namespace System.CommandLine.Rendering
 
         private void OnCharWrittenToOut(char c)
         {
-            if (VirtualTerminalMode)
+            if (IsVirtualTerminalModeEnabled)
             {
                 if (_ansiCodeBuffer.Length == 0 &&
                     c != Ansi.Esc[0])
@@ -207,7 +207,7 @@ namespace System.CommandLine.Rendering
             }
         }
 
-        public bool VirtualTerminalMode { get; set; } = true;
+        public bool IsVirtualTerminalModeEnabled { get; set; } = true;
 
         public IEnumerable<TextRendered> RenderOperations()
         {

--- a/src/System.CommandLine.Rendering/VirtualTerminal.cs
+++ b/src/System.CommandLine.Rendering/VirtualTerminal.cs
@@ -3,13 +3,13 @@
 
 namespace System.CommandLine.Rendering
 {
-    internal class VirtualTerminal : TerminalBase
+    public class VirtualTerminal : TerminalBase
     {
         private readonly VirtualTerminalMode _virtualTerminalMode;
 
         public VirtualTerminal(
             IConsole console,
-            VirtualTerminalMode virtualTerminalMode ) : base(console)
+            VirtualTerminalMode virtualTerminalMode) : base(console)
         {
             _virtualTerminalMode = virtualTerminalMode;
         }


### PR DESCRIPTION
This addresses #370.

I also added `TestTerminal.VirtualTerminalMode` in order to start being able to better test ANSI vs non-ANSI output across terminal types.