### PR TITLE
Proposed .editorconfig change for var usage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,7 +63,7 @@ dotnet_naming_symbols.constant_fields.required_modifiers          = const
 # var preferences 
 csharp_style_var_for_built_in_types = true:silent 
 csharp_style_var_when_type_is_apparent = true:silent 
-csharp_style_var_elsewhere = true:silent 
+csharp_style_var_elsewhere = false:silent 
 # Expression-bodied members 
 csharp_style_expression_bodied_methods = false:silent 
 csharp_style_expression_bodied_constructors = false:silent 


### PR DESCRIPTION
@jonsequitur and @KathleenDollard are there any opinions about `var` usage. 
The default editor config that we put it suggests using var everywhere, even when the type is not apparent. I would suggest that we reverse that and only use `var` when the type is apparent. 

Thoughts?