### PR TITLE
Support attribute of array of FileInfo or DirectoryInfo

### DIFF
--- a/src/System.CommandLine/Builder/ArgumentExtensions.cs
+++ b/src/System.CommandLine/Builder/ArgumentExtensions.cs
@@ -59,6 +59,26 @@ namespace System.CommandLine.Builder
             return argument;
         }
 
+        public static Argument<FileInfo[]> ExistingOnly(this Argument<FileInfo[]> argument)
+        {
+            argument.AddValidator(symbol =>
+                symbol.Arguments
+                    .Where(filePath => !File.Exists(filePath))
+                    .Select(symbol.ValidationMessages.FileDoesNotExist)
+                    .FirstOrDefault());
+            return argument;
+        }
+
+        public static Argument<DirectoryInfo[]> ExistingOnly(this Argument<DirectoryInfo[]> argument)
+        {
+            argument.AddValidator(symbol =>
+                symbol.Arguments
+                    .Where(filePath => !Directory.Exists(filePath))
+                    .Select(symbol.ValidationMessages.DirectoryDoesNotExist)
+                    .FirstOrDefault());
+            return argument;
+        }
+
         public static TArgument LegalFilePathsOnly<TArgument>(
             this TArgument argument)
             where TArgument : Argument


### PR DESCRIPTION
In this PR I would like to support validation of:
```C#
new Argument<FileInfo[]>
                {
                    Arity = ArgumentArity.ZeroOrMore
                }.ExistingOnly()
```
and
```C#
new Argument<DirectoryInfo[]>
                    {
                        Arity = ArgumentArity.ZeroOrMore
                    }.ExistingOnly()
```

I validate until I find the first error. If you want, I can always validate all values.

Thanks to this PR you can pass:
`--paths file1.txt file2.txt`

I want to use this feature in BenchmarkDotNet in https://github.com/dotnet/BenchmarkDotNet/issues/1016. Currently It has:
https://github.com/dotnet/BenchmarkDotNet/blob/adde64cbbcde01938d6b2772066852c4f6c0e88d/src/BenchmarkDotNet/ConsoleArguments/CommandLineOptions.cs#L80-L81