### PR TITLE
Default command arg value bug fix

### DIFF
--- a/src/System.CommandLine.Rendering/ConsoleRenderer.cs
+++ b/src/System.CommandLine.Rendering/ConsoleRenderer.cs
@@ -47,6 +47,11 @@ namespace System.CommandLine.Rendering
             Span span,
             Region region)
         {
+            if (region == null)
+            {
+                throw new ArgumentNullException(nameof(region));
+            }
+
             if (span == null)
             {
                 span = Span.Empty();

--- a/src/System.CommandLine.Tests/MethodBinderTests.cs
+++ b/src/System.CommandLine.Tests/MethodBinderTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1011,6 +1011,29 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void Command_default_argument_value_does_not_override_parsed_value()
+        {
+            DirectoryInfo receivedArg = null;
+
+            var command = new Command("inner")
+            {
+                Argument = new Argument<DirectoryInfo>(() => new DirectoryInfo(Directory.GetCurrentDirectory()))
+                {
+                    Name = "arg"
+                },
+                Handler = CommandHandler.Create<DirectoryInfo>(arg => receivedArg = arg)
+            };
+
+            var result = command.Parse("c:\\temp");
+
+            result.CommandResult
+                  .GetValueOrDefault<DirectoryInfo>()
+                  .FullName
+                  .Should()
+                  .Be("c:\\temp");
+        }
+
+        [Fact]
         public void Unmatched_options_are_not_split_into_smaller_tokens()
         {
             var outer = new Command("outer");

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
 using System.IO;
 using FluentAssertions;
 using FluentAssertions.Equivalency;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions.Common;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -72,7 +72,8 @@ namespace System.CommandLine
                         }
                     }
 
-                    if (command.Command.Argument.HasDefaultValue)
+                    if (!command.IsArgumentLimitReached &&
+                        command.Command.Argument.HasDefaultValue)
                     {
                         var defaultValue = command.Command.Argument.GetDefaultValue();
 


### PR DESCRIPTION
This fixes a bug where a default argument value on a command will overwrite the value specified on the command line (which is initially correctly parsed).