### PR TITLE
change ParseResult.Tokens to return Tokens rather than strings

### DIFF
--- a/src/System.CommandLine.Tests/DirectiveTests.cs
+++ b/src/System.CommandLine.Tests/DirectiveTests.cs
@@ -26,7 +26,7 @@ namespace System.CommandLine.Tests
             var result = option.Parse("[parse] -y");
 
             result.Directives.Contains("parse").Should().BeTrue();
-            result.Tokens.Should().Contain("[parse]");
+            result.Tokens.Should().Contain(t => t.Value == "[parse]");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/InvocationPipelineTests.cs
+++ b/src/System.CommandLine.Tests/InvocationPipelineTests.cs
@@ -111,7 +111,12 @@ namespace System.CommandLine.Tests
             var parser = new CommandLineBuilder()
                          .UseMiddleware(async (context, next) =>
                          {
-                             var tokens = context.ParseResult.Tokens.Concat(new[] { "implicit-inner-command" }).ToArray();
+                             var tokens = context.ParseResult
+                                                 .Tokens
+                                                 .Select(t => t.Value)
+                                                 .Concat(new[] { "implicit-inner-command" })
+                                                 .ToArray();
+
                              context.ParseResult = context.Parser.Parse(tokens);
                              await next(context);
                          })

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1023,13 +1023,13 @@ namespace System.CommandLine.Tests
                 Handler = CommandHandler.Create<DirectoryInfo>(arg => receivedArg = arg)
             };
 
-            var result = command.Parse("c:\\temp");
+            var result = command.Parse("the-directory");
 
             result.CommandResult
                   .GetValueOrDefault<DirectoryInfo>()
-                  .FullName
+                  .Name
                   .Should()
-                  .Be("c:\\temp");
+                  .Be("the-directory");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -652,7 +652,6 @@ namespace System.CommandLine.Tests
         [InlineData("--one 1 --many 1 --many 2 arg1 arg2")]
         [InlineData("--many 1 --one 1 --many 2")]
         [InlineData("--many 2 --many 1 --one 1")]
-        [InlineData("--many:2 --many=1 --one 1")]
         [InlineData("[parse] --one 1 --many 1 --many 2")]
         [InlineData("--one \"stuff in quotes\" this-is-arg1 \"this is arg2\"")]
         [InlineData("not a valid command line --one 1")]
@@ -668,7 +667,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse(commandLine);
 
-            result.Tokens.Should().Equal(rawSplit);
+            result.Tokens.Select(t => t.Value).Should().Equal(rawSplit);
         }
 
         [Fact]

--- a/src/System.CommandLine/Invocation/InvocationExtensions.cs
+++ b/src/System.CommandLine/Invocation/InvocationExtensions.cs
@@ -361,7 +361,7 @@ namespace System.CommandLine.Invocation
         {
             var lastToken = context.ParseResult.Tokens.LastOrDefault();
 
-            if (helpOptionAliases.Contains(lastToken) &&
+            if (helpOptionAliases.Contains(lastToken?.Value) &&
                 !TokenIsDefinedInSyntax())
             {
                 context.InvocationResult = new HelpResult();

--- a/src/System.CommandLine/LexResult.cs
+++ b/src/System.CommandLine/LexResult.cs
@@ -1,10 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 
 namespace System.CommandLine
 {
     internal class LexResult
     {
-        public IEnumerable<Token> Tokens { get; set; }
-        public IEnumerable<ParseError> Errors { get; set; }
+        public LexResult(
+            IReadOnlyCollection<Token> tokens,
+            IReadOnlyCollection<ParseError> errors)
+        {
+            Tokens = tokens;
+            Errors = errors;
+        }
+
+        public IReadOnlyCollection<Token> Tokens { get; }
+        public IReadOnlyCollection<ParseError> Errors { get; }
     }
 }

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine
             CommandResult rootCommandResult,
             CommandResult commandResult,
             IDirectiveCollection directives,
-            IReadOnlyCollection<string> tokens,
+            IReadOnlyCollection<Token> tokens,
             IReadOnlyCollection<string> unparsedTokens,
             IReadOnlyCollection<string> unmatchedTokens,
             IReadOnlyCollection<ParseError> errors,
@@ -44,7 +44,7 @@ namespace System.CommandLine
 
         public IDirectiveCollection Directives { get; }
 
-        public IReadOnlyCollection<string> Tokens { get; }
+        public IReadOnlyCollection<Token> Tokens { get; }
 
         public IReadOnlyCollection<string> UnmatchedTokens { get; }
 

--- a/src/System.CommandLine/ParseResultExtensions.cs
+++ b/src/System.CommandLine/ParseResultExtensions.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine
                 // assume the cursor is at the end of the input
                 if (!source.RawInput.EndsWith(" "))
                 {
-                    return lastToken;
+                    return lastToken.Value;
                 }
                 else
                 {

--- a/src/System.CommandLine/Parser.cs
+++ b/src/System.CommandLine/Parser.cs
@@ -24,18 +24,18 @@ namespace System.CommandLine
 
         internal CommandLineConfiguration Configuration { get; }
 
-        public virtual ParseResult Parse(
-            IReadOnlyCollection<string> arguments, 
+        public ParseResult Parse(
+            IReadOnlyCollection<string> arguments,
             string rawInput = null)
         {
-            var rawTokens = arguments;  // allow a more user-friendly name for callers of Parse
-            var lexResult = NormalizeRootCommand(rawTokens).Lex(Configuration);
+            var normalizedArgs = NormalizeRootCommand(arguments);
+            var lexResult = normalizedArgs.Lex(Configuration);
             var directives = new DirectiveCollection();
             var unparsedTokens = new Queue<Token>(lexResult.Tokens);
             var allSymbolResults = new List<SymbolResult>();
             var errors = new List<ParseError>(lexResult.Errors);
             var unmatchedTokens = new List<Token>();
-            CommandResult rootCommand = null;   
+            CommandResult rootCommand = null;
             CommandResult innermostCommand = null;
 
             IList<IOption> optionQueue = GatherOptions(Configuration.Symbols);
@@ -65,7 +65,7 @@ namespace System.CommandLine
                         {
                             result = SymbolResult.Create(symbol, token.Value, validationMessages: Configuration.ValidationMessages);
 
-                            rootCommand = (CommandResult) result;
+                            rootCommand = (CommandResult)result;
                         }
 
                         allSymbolResults.Add(result);
@@ -143,7 +143,9 @@ namespace System.CommandLine
                 rootCommand,
                 innermostCommand ?? rootCommand,
                 directives,
-                rawTokens,
+                normalizedArgs.Count == arguments?.Count
+                 ? lexResult.Tokens
+                 : lexResult.Tokens.Skip(1).ToArray(),
                 unparsedTokens.Select(t => t.Value).ToArray(),
                 unmatchedTokens.Select(t => t.Value).ToArray(),
                 errors,
@@ -249,9 +251,4 @@ namespace System.CommandLine
             return args;
         }
     }
-
-
-    //
-    // Summary:
-    //     A collection of headers and their values as defined in RFC 2616.
 }

--- a/src/System.CommandLine/StringExtensions.cs
+++ b/src/System.CommandLine/StringExtensions.cs
@@ -192,10 +192,7 @@ namespace System.CommandLine
                 }
             }
 
-            return new LexResult {
-                Tokens = tokenList,
-                Errors = errorList
-            };
+            return new LexResult(tokenList, errorList);
         }
 
         internal static string[] SplitTokenByArgumentDelimiter(string arg, char[] argumentDelimiters) => arg.Split(argumentDelimiters, 2);

--- a/src/System.CommandLine/Token.cs
+++ b/src/System.CommandLine/Token.cs
@@ -3,9 +3,9 @@
 
 namespace System.CommandLine
 {
-    internal class Token
+    public class Token
     {
-        public Token(string value, TokenType type)
+        internal Token(string value, TokenType type)
         {
             Value = value ?? "";
             Type = type;

--- a/src/System.CommandLine/TokenType.cs
+++ b/src/System.CommandLine/TokenType.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace System.CommandLine


### PR DESCRIPTION
This is a refactor on the path to making some improvements in suggestions.