### PR TITLE
fix type-based arity assumption for command arguments with max arity > 1

### DIFF
--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -409,6 +409,33 @@ namespace System.CommandLine.Tests.Binding
                   .BeNull();
         }
 
+        [Theory]
+        [InlineData("c -a o c c")]
+        [InlineData("c c -a o c")]
+        [InlineData("c c c")]
+        public void When_command_has_arity_greater_than_one_it_captures_arguments_before_and_after_option(string commandLine)
+        {
+            var command = new Command("the-command")
+                          {
+                              new Option("-a")
+                              {
+                                  Argument = new Argument<string>()
+                              }
+                          };
+
+            command.Argument = new Argument<string>
+                               {
+                                   Arity = ArgumentArity.ZeroOrMore
+                               };
+
+            var result = command.Parse(commandLine);
+
+            result.CommandResult
+                  .GetValueOrDefault()
+                  .Should()
+                  .BeEquivalentTo(new[] { "c", "c", "c" });
+        }
+
         [Fact]
         public void The_default_value_of_an_option_with_no_arguments_is_true()
         {

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -103,7 +103,7 @@ namespace System.CommandLine.Tests.Binding
         [InlineData(typeof(int[]))]
         [InlineData(typeof(IEnumerable<int>))]
         [InlineData(typeof(List<int>))]
-        public void ParseArgumentsAs_infers_arity_of_IEnumerable_types_as_OneOrMore(Type type)
+        public void Argument_infers_arity_of_IEnumerable_types_as_OneOrMore(Type type)
         {
             var argument = new Argument { ArgumentType = type };
 

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -410,7 +410,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void ParseArgumentsAs_with_arity_of_One_validates_against_extra_arguments()
+        public void When_arity_is_ExactlyOne_it_validates_against_extra_arguments()
         {
             var parser = new Parser(
                 new Option(

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -57,12 +57,27 @@ namespace System.CommandLine
                         }
                         else
                         {
-                            _convertArguments = ArgumentConverter.DefaultConvertArgument(ArgumentType);
+                            _convertArguments = DefaultConvert;
                         }
                     }
                 }
 
                 return _convertArguments;
+
+                ArgumentResult DefaultConvert(SymbolResult symbol)
+                {
+                    switch (Arity.MaximumNumberOfArguments)
+                    {
+                        case 1:
+                            return ArgumentConverter.Parse(
+                                ArgumentType,
+                                symbol.Arguments.SingleOrDefault());
+                        default:
+                            return ArgumentConverter.ParseMany(
+                                ArgumentType, 
+                                symbol.Arguments);
+                    }
+                }
             }
             set => _convertArguments = value;
         }


### PR DESCRIPTION
The added test under `TypeConversionTests` was the repro for a bug by which the default arity for the type rather than the specified arity for the command argument was being used, resulting in an exception. This fixes it and tests the expected behavior.