### PR TITLE
include suggestions from parent of current symbol; smarter TextToMatch

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -7,7 +7,6 @@ using System.IO;
 using FluentAssertions;
 using FluentAssertions.Equivalency;
 using System.Linq;
-using System.Threading.Tasks;
 using FluentAssertions.Common;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
@@ -207,17 +207,9 @@ namespace System.CommandLine.Tests
                           };
             command.Argument = new Argument<string>();
 
-            command.Parse("opt")
-                   .Suggestions()
-                   .Should()
-                   .BeEquivalentTo("--option1", "--option2");
-
             var console = new TestConsole();
 
-            await new CommandLineBuilder(command)
-                  .UseDefaults()
-                  .Build()
-                  .InvokeAsync("[suggest] opt", console);
+            await command.InvokeAsync("[suggest] opt", console);
 
             console.Out
                    .ToString()

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -4,7 +4,6 @@
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.IO;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -130,10 +129,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_one_option_has_been_specified_then_it_and_its_siblings_will_still_be_suggested()
         {
-            var parser = new Parser(
-                new Option("--apple"),
-                new Option("--banana"),
-                new Option("--cherry"));
+            var parser = new Command("command")
+                         {
+                             new Option("--apple"),
+                             new Option("--banana"),
+                             new Option("--cherry")
+                         };
 
             var result = parser.Parse("--apple grannysmith ");
 
@@ -144,7 +145,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void When_a_subcommand_has_been_specified_then_its_siblings_will_not_be_suggested()
+        public void When_a_subcommand_has_been_specified_then_its_sibling_commands_will_not_be_suggested()
         {
             var rootCommand = new RootCommand
             {
@@ -166,7 +167,64 @@ namespace System.CommandLine.Tests
 
             result.Suggestions()
                   .Should()
-                  .BeEquivalentTo("--rainier");
+                  .NotContain(new[]{"apple", "banana", "cherry"});
+        }
+
+        [Fact]
+        public void When_a_subcommand_has_been_specified_then_its_sibling_options_will_be_suggested()
+        {
+            var command = new RootCommand("parent")
+                          {
+                              new Command("child"),
+                              new Option("--parent-option")
+                          };
+            command.Argument = new Argument<string>();
+
+            var parseResult = command.Parse("child ");
+
+            parseResult
+                .Suggestions()
+                .Should()
+                .Contain("--parent-option");
+        }
+
+        [Fact]
+        public void When_a_subcommand_has_been_specified_then_its_sibling_options_with_argument_limit_reached_will_be_not_be_suggested()
+        {
+            var command = new RootCommand("parent")
+                          {
+                              new Command("child"),
+                              new Option("--parent-option", argument: new Argument<string>())
+                          };
+            command.Argument = new Argument<string>();
+
+            var parseResult = command.Parse("--parent-option 123 child ");
+
+            parseResult
+                .Suggestions()
+                .Should()
+                .NotContain("--parent-option");
+        }
+
+        [Fact]
+        public void When_a_subcommand_has_been_specified_then_its_child_options_will_be_suggested()
+        {
+            var command = new RootCommand("parent")
+                          {
+                              new Command("child")
+                              {
+                                  new Option("--child-option",
+                                             argument: new Argument<string>())
+                              }
+                          };
+            command.Argument = new Argument<string>();
+
+            var parseResult = command.Parse("child ");
+
+            parseResult
+                .Suggestions()
+                .Should()
+                .Contain("--child-option");
         }
 
         [Fact]
@@ -523,56 +581,6 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void When_position_is_unspecified_then_TextToMatch_matches_partial_argument_at_end_of_command_line()
-        {
-            Command command = new Command("the-command", "", new[] {
-                new Option("--option1", ""),
-                new Option("--option2", "")
-            });
-
-            string textToMatch = command.Parse("the-command t")
-                                        .TextToMatch();
-
-            textToMatch.Should().Be("t");
-        }
-
-        [Fact]
-        public void When_position_is_unspecified_and_command_line_ends_with_a_space_then_TextToMatch_returns_empty()
-        {
-            Command command = new Command("the-command", "", new[] {
-                new Option("--option1", ""),
-                new Option("--option2", "")
-            });
-
-            string textToMatch = command.Parse("the-command t ")
-                                        .TextToMatch();
-
-            textToMatch.Should().Be("");
-        }
-
-        [Theory]
-        [InlineData("the-command $one --two")]
-        [InlineData("the-command one$ --two")]
-        [InlineData("the-command on$e --two ")]
-        [InlineData(" the-command  $one --two ")]
-        [InlineData(" the-command  one$ --two ")]
-        [InlineData(" the-command  on$e --two ")]
-        public void When_position_is_specified_then_TextToMatch_matches_argument_at_cursor_position(string input)
-        {
-            Command command =
-                new Command("the-command", "",
-                            argument: new Argument
-                            {
-                                Arity = ArgumentArity.ZeroOrMore
-                            });
-
-            string textToMatch = command.Parse(input.Replace("$", ""))
-                                        .TextToMatch(input.IndexOf("$", StringComparison.Ordinal));
-
-            textToMatch.Should().Be("one");
-        }
-
-        [Fact]
         public void Arguments_of_type_enum_provide_enum_values_as_suggestions()
         {
             var command = new Command("the-command",
@@ -628,6 +636,128 @@ namespace System.CommandLine.Tests
             var suggestions = command.Parse("m").Suggestions();
 
             suggestions.Should().BeEquivalentTo("--implicit");
+        }
+
+        public class TextToMatch
+        {
+            [Fact]
+            public void When_position_is_unspecified_in_string_command_line_not_ending_with_a_space_then_it_returns_final_token()
+            {
+                var command = new Command("the-command", "",
+                                          new[]
+                                          {
+                                              new Option("--option1", ""),
+                                              new Option("--option2", "")
+                                          });
+
+                string textToMatch = command.Parse("the-command t")
+                                            .TextToMatch();
+
+                textToMatch.Should().Be("t");
+            }
+
+            [Fact]
+            public void When_position_is_unspecified_in_string_command_line_ending_with_a_space_then_it_returns_empty()
+            {
+                Command command = new Command("the-command", "",
+                                              new[]
+                                              {
+                                                  new Option("--option1", ""),
+                                                  new Option("--option2", "")
+                                              });
+
+                string textToMatch = command.Parse("the-command t ")
+                                            .TextToMatch();
+
+                textToMatch.Should().Be("");
+            }
+
+            [Fact]
+            public void When_position_is_unspecified_in_array_command_line_and_final_token_is_unmatched_then_it_returns_final_token()
+            {
+                var command = new Command("the-command", "",
+                                          new[]
+                                          {
+                                              new Option("--option1", ""),
+                                              new Option("--option2", "")
+                                          });
+
+                string textToMatch = command.Parse("the-command", "opt")
+                                            .TextToMatch();
+
+                textToMatch.Should().Be("opt");
+            }
+
+            [Fact]
+            public void When_position_is_unspecified_in_array_command_line_and_final_token_is_matches_an_command_then_it_returns_empty()
+            {
+                Command command = new Command("the-command", "",
+                                              new[]
+                                              {
+                                                  new Option("--option1", ""),
+                                                  new Option("--option2", "")
+                                              });
+
+                string textToMatch = command.Parse(new[] { "the-command" })
+                                            .TextToMatch();
+
+                textToMatch.Should().Be("");
+            }
+
+            [Fact]
+            public void When_position_is_unspecified_in_array_command_line_and_final_token_is_matches_an_option_then_it_returns_empty()
+            {
+                Command command = new Command("the-command", "",
+                                              new[]
+                                              {
+                                                  new Option("--option1", ""),
+                                                  new Option("--option2", "")
+                                              });
+
+                string textToMatch = command.Parse("the-command", "--option1")
+                                            .TextToMatch();
+
+                textToMatch.Should().Be("");
+            }
+
+            [Fact]
+            public void When_position_is_unspecified_in_array_command_line_and_final_token_is_matches_an_argument_then_it_returns_empty()
+            {
+                Command command = new Command("the-command", "",
+                                              new[]
+                                              {
+                                                  new Option("--option1", "", new Argument<string>().FromAmong("apple", "banana", "cherry", "durian")),
+                                                  new Option("--option2", "", new Argument<string>())
+                                              });
+                command.Argument = new Argument<string>();
+
+                string textToMatch = command.Parse("the-command", "--option1", "a")
+                                            .TextToMatch();
+
+                textToMatch.Should().Be("a");
+            }
+
+            [Theory]
+            [InlineData("the-command $one --two")]
+            [InlineData("the-command one$ --two")]
+            [InlineData("the-command on$e --two ")]
+            [InlineData(" the-command  $one --two ")]
+            [InlineData(" the-command  one$ --two ")]
+            [InlineData(" the-command  on$e --two ")]
+            public void When_position_is_specified_in_string_command_line_then_it_returns_argument_at_cursor_position(string input)
+            {
+                Command command =
+                    new Command("the-command", "",
+                                argument: new Argument
+                                          {
+                                              Arity = ArgumentArity.ZeroOrMore
+                                          });
+
+                string textToMatch = command.Parse(input.Replace("$", ""))
+                                            .TextToMatch(input.IndexOf("$", StringComparison.Ordinal));
+
+                textToMatch.Should().Be("one");
+            }
         }
     }
 }

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -15,6 +15,7 @@ namespace System.CommandLine
         private IArgumentArity _arity;
         private HashSet<string> _validValues;
         private ConvertArgument _convertArguments;
+        private Symbol _parent;
 
         public string Name { get; set; }
 
@@ -86,7 +87,24 @@ namespace System.CommandLine
 
         internal List<ValidateSymbol> SymbolValidators { get; } = new List<ValidateSymbol>();
 
-        public Symbol Parent { get; internal set; }
+        public Symbol Parent
+        {
+            get => _parent;
+            internal set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                if (_parent != null)
+                {
+                    throw new InvalidOperationException($"{nameof(Parent)} is already set.");
+                }
+
+                _parent = value;
+            }
+        }
 
         public void AddValidator(ValidateSymbol validator) => SymbolValidators.Add(validator);
 

--- a/src/System.CommandLine/Builder/ArgumentExtensions.cs
+++ b/src/System.CommandLine/Builder/ArgumentExtensions.cs
@@ -62,20 +62,20 @@ namespace System.CommandLine.Builder
         public static Argument<FileInfo[]> ExistingOnly(this Argument<FileInfo[]> argument)
         {
             argument.AddValidator(symbol =>
-                symbol.Arguments
-                    .Where(filePath => !File.Exists(filePath))
-                    .Select(symbol.ValidationMessages.FileDoesNotExist)
-                    .FirstOrDefault());
+                                      symbol.Arguments
+                                            .Where(filePath => !File.Exists(filePath))
+                                            .Select(symbol.ValidationMessages.FileDoesNotExist)
+                                            .FirstOrDefault());
             return argument;
         }
 
         public static Argument<DirectoryInfo[]> ExistingOnly(this Argument<DirectoryInfo[]> argument)
         {
             argument.AddValidator(symbol =>
-                symbol.Arguments
-                    .Where(filePath => !Directory.Exists(filePath))
-                    .Select(symbol.ValidationMessages.DirectoryDoesNotExist)
-                    .FirstOrDefault());
+                                      symbol.Arguments
+                                            .Where(filePath => !Directory.Exists(filePath))
+                                            .Select(symbol.ValidationMessages.DirectoryDoesNotExist)
+                                            .FirstOrDefault());
             return argument;
         }
 

--- a/src/System.CommandLine/ISymbol.cs
+++ b/src/System.CommandLine/ISymbol.cs
@@ -6,7 +6,7 @@ using System.CommandLine.Binding;
 
 namespace System.CommandLine
 {
-    public interface ISymbol : IValueDescriptor
+    public interface ISymbol : IValueDescriptor, ISuggestionSource
     {
         string Description { get; }
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -128,18 +128,21 @@ namespace System.CommandLine
 
         public bool IsHidden { get; set; }
 
-        public virtual IEnumerable<string> Suggest(
+        public IEnumerable<string> Suggest(
             ParseResult parseResult,
             int? position = null)
         {
             var argumentSuggestions =
-                Argument.Suggest(parseResult, position);
+                Argument.Suggest(parseResult, position)
+                        .ToArray();
+
+            var textToMatch = parseResult.TextToMatch(position);
 
             return this.ChildSymbolAliases()
                        .Concat(argumentSuggestions)
                        .Distinct()
                        .OrderBy(symbol => symbol)
-                       .Containing(parseResult.TextToMatch(position));
+                       .Containing(textToMatch);
         }
 
         public override string ToString() => $"{GetType().Name}: {Name}";


### PR DESCRIPTION
This fixes a couple of additional cases related to #424.