### PR TITLE
Response file and tokenization refactor

### DIFF
--- a/src/System.CommandLine.Suggest.Tests/SuggestionDispatcherTests.cs
+++ b/src/System.CommandLine.Suggest.Tests/SuggestionDispatcherTests.cs
@@ -24,7 +24,7 @@ namespace System.CommandLine.Suggest.Tests
         [Fact]
         public async Task InvokeAsync_executes_suggestion_command_for_executable()
         {
-            string[] args = $@"get -p 12 -e ""{CurrentExeFullPath()}"" -- {_currentExeName} add".Tokenize().ToArray();
+            string[] args = $@"get -p 12 -e ""{CurrentExeFullPath()}"" -- {_currentExeName} add".SplitCommandLine().ToArray();
 
             var suggestions = await InvokeAsync(args, new TestSuggestionRegistration(CurrentExeRegistrationPair()));
 
@@ -36,7 +36,7 @@ namespace System.CommandLine.Suggest.Tests
         [Fact]
         public async Task InvokeAsync_with_unknown_suggestion_provider_returns_empty_string()
         {
-            string[] args = @"get -p 10 -e ""testcli.exe"" -- command op".Tokenize().ToArray();
+            string[] args = @"get -p 10 -e ""testcli.exe"" -- command op".SplitCommandLine().ToArray();
             (await InvokeAsync(args, new TestSuggestionRegistration()))
                 .Should()
                 .BeEmpty();
@@ -50,7 +50,7 @@ namespace System.CommandLine.Suggest.Tests
             dispatcher.Timeout = TimeSpan.FromMilliseconds(1);
             var testConsole = new TestConsole();
 
-            var args = $@"get -p 0 -e ""{_currentExeName}"" -- {_currentExeName} add".Tokenize().ToArray();
+            var args = $@"get -p 0 -e ""{_currentExeName}"" -- {_currentExeName} add".SplitCommandLine().ToArray();
 
             await dispatcher.InvokeAsync(args, testConsole);
 
@@ -93,7 +93,7 @@ namespace System.CommandLine.Suggest.Tests
             var provider = new TestSuggestionRegistration();
             var dispatcher = new SuggestionDispatcher(provider);
 
-            var args = $"register --command-path \"{_netExeFullPath}\" --suggestion-command \"net-suggestions complete\"".Tokenize().ToArray();
+            var args = $"register --command-path \"{_netExeFullPath}\" --suggestion-command \"net-suggestions complete\"".SplitCommandLine().ToArray();
 
             await dispatcher.InvokeAsync(args);
 
@@ -108,7 +108,7 @@ namespace System.CommandLine.Suggest.Tests
             var provider = new TestSuggestionRegistration();
             var dispatcher = new SuggestionDispatcher(provider);
 
-            var args = $"register --command-path \"{_netExeFullPath}\" --suggestion-command \"net-suggestions complete\"".Tokenize().ToArray();
+            var args = $"register --command-path \"{_netExeFullPath}\" --suggestion-command \"net-suggestions complete\"".SplitCommandLine().ToArray();
 
             await dispatcher.InvokeAsync(args);
             await dispatcher.InvokeAsync(args);

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -656,7 +656,7 @@ namespace System.CommandLine.Tests
         [InlineData("not a valid command line --one 1")]
         public void Original_order_of_tokens_is_preserved_in_ParseResult_Tokens(string commandLine)
         {
-            var rawSplit = commandLine.Tokenize();
+            var rawSplit = commandLine.SplitCommandLine();
 
             var command = new Command("the-command", argument: new Argument<string[]>())
                           {

--- a/src/System.CommandLine.Tests/ResponseFileTests.cs
+++ b/src/System.CommandLine.Tests/ResponseFileTests.cs
@@ -1,127 +1,250 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.CommandLine.Builder;
 using System.IO;
-using System.Linq;
 using FluentAssertions;
+using System.Linq;
 using Xunit;
 
 namespace System.CommandLine.Tests
 {
     public class ResponseFileTests : IDisposable
     {
-        private string FilePath { get; }
-
-        public ResponseFileTests()
-        {
-            FilePath = Path.GetTempFileName();
-        }
+        private readonly List<FileInfo> _responseFiles = new List<FileInfo>();
 
         public void Dispose()
         {
-            File.Delete(FilePath);
+            foreach (var responseFile in _responseFiles)
+            {
+                responseFile.Delete();
+            }
+        }
+
+        private string ResponseFile(params string[] lines)
+        {
+            var responseFile = new FileInfo(Path.GetTempFileName());
+
+            using (var writer = new StreamWriter(responseFile.FullName))
+            {
+                foreach (var line in lines)
+                {
+                    writer.WriteLine(line);
+                }
+            }
+
+            _responseFiles.Add(responseFile);
+
+            return responseFile.FullName;
         }
 
         [Fact]
-        public void When_response_file_specified_it_loads_arguments_from_response_file()
+        public void When_response_file_specified_it_loads_options_from_response_file()
         {
-            using (var s = new StreamWriter(FilePath))
-            {
-                s.Write("--flag");
-            }
-            var result = new Parser(new Option(
-                    "--flag",
-                    ""))
-                .Parse("@" + FilePath);
+            var result = new Option("--flag")
+                .Parse($"@{ResponseFile("--flag")}");
+
             result.HasOption("--flag").Should().BeTrue();
         }
 
         [Fact]
-        public void When_response_file_specified_it_loads_arguments_with_blank_line_from_response_file()
+        public void When_response_file_is_specified_it_loads_options_with_arguments_from_response_file()
         {
-            using (var s = new StreamWriter(FilePath))
-            {
-                s.WriteLine("--flag");
-                s.WriteLine("");
-                s.WriteLine("--flag2");
-                s.WriteLine("123");
-            }
-            var result = new CommandLineBuilder()
-                .AddOption(new Option("--flag"))
-                .AddOption(new Option("--flag2", argument: new Argument<int>()))
-                .Build()
-                .Parse("@" + FilePath);
+            var responseFile = ResponseFile(
+                "--flag",
+                "--flag2",
+                "123");
+
+            var result = new RootCommand
+                         {
+                             new Option("--flag"),
+                             new Option("--flag2", argument: new Argument<int>())
+                         }
+                .Parse($"@{responseFile}");
+
             result.HasOption("--flag").Should().BeTrue();
             result.ValueForOption("--flag2").Should().Be(123);
             result.Errors.Should().BeEmpty();
         }
 
         [Fact]
-        public void When_response_file_specified_it_loads_arguments_with_comment_lines_from_response_file()
+        public void When_response_file_is_specified_it_loads_command_arguments_from_response_file()
         {
-            using (var s = new StreamWriter(FilePath))
-            {
-                s.WriteLine("# comment one");
-                s.WriteLine("--flag");
-                s.WriteLine("# comment two");
-                s.WriteLine("#");
-                s.WriteLine(" # comment two");
-                s.WriteLine("--flag2");
-            }
+            var responseFile = ResponseFile(
+                "one",
+                "two",
+                "three");
+
+            var result = new RootCommand
+                         {
+                             Argument = new Argument<string[]>()
+                         }
+                .Parse($"@{responseFile}");
+
+            result.CommandResult
+                  .Arguments
+                  .Should()
+                  .BeEquivalentSequenceTo("one", "two", "three");
+        }
+
+        [Fact]
+        public void Response_file_can_provide_subcommand_arguments()
+        {
+            var responseFile = ResponseFile(
+                "one",
+                "two",
+                "three");
+
+            var result = new RootCommand
+                         {
+                             new Command("subcommand")
+                             {
+                                 Argument = new Argument<string[]>()
+                             }
+                         }
+                .Parse($"subcommand @{responseFile}");
+
+            result.CommandResult
+                  .Arguments
+                  .Should()
+                  .BeEquivalentSequenceTo("one", "two", "three");
+        }
+
+        [Fact]
+        public void Response_file_can_provide_subcommand()
+        {
+            var responseFile = ResponseFile("subcommand");
+
+            var result = new RootCommand
+                         {
+                             new Command("subcommand")
+                             {
+                                 Argument = new Argument<string[]>()
+                             }
+                         }
+                .Parse($"@{responseFile} one two three");
+
+            result.CommandResult
+                  .Arguments
+                  .Should()
+                  .BeEquivalentSequenceTo("one", "two", "three");
+        }
+
+        [Fact]
+        public void When_response_file_is_specified_it_loads_subcommand_arguments_from_response_file()
+        {
+            var responseFile = ResponseFile(
+                "one",
+                "two",
+                "three");
+
+            var result = new RootCommand
+                         {
+                             new Command("subcommand")
+                             {
+                                 Argument = new Argument<string[]>()
+                             }
+                         }
+                .Parse($"subcommand @{responseFile}");
+
+            result.CommandResult
+                  .Arguments
+                  .Should()
+                  .BeEquivalentSequenceTo("one", "two", "three");
+        }
+
+        [Fact]
+        public void Response_file_can_contain_blank_lines()
+        {
+            var responseFile = ResponseFile(
+                "--flag",
+                "",
+                "123");
+
             var result = new CommandLineBuilder()
-                .AddOption(new Option("--flag"))
-                .AddOption(new Option("--flag2"))
-                .Build()
-                .Parse("@" + FilePath);
+                         .AddOption(new Option("--flag", argument: new Argument<int>()))
+                         .Build()
+                         .Parse($"@{responseFile}");
+
+            result.ValueForOption("--flag").Should().Be(123);
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Response_file_can_contain_comments_which_are_ignored_when_loaded()
+        {
+            var responseFile = ResponseFile(
+                "# comment one",
+                "--flag",
+                "# comment two",
+                "#",
+                " # comment two",
+                "--flag2");
+
+            var result = new RootCommand
+                         {
+                             new Option("--flag"),
+                             new Option("--flag2")
+                         }.Parse($"@{responseFile}");
+
             result.HasOption("--flag").Should().BeTrue();
             result.HasOption("--flag2").Should().BeTrue();
             result.Errors.Should().BeEmpty();
         }
 
         [Fact]
-        public void When_response_file_does_not_exist_adds_to_errors()
+        public void When_response_file_does_not_exist_then_error_is_returned()
         {
-            File.Delete(FilePath);
-            var result = new CommandLineBuilder()
-                .AddOption(new Option("--flag"))
-                .AddOption(new Option("--flag2"))
-                .Build()
-                .Parse("@" + FilePath);
+            var result = new RootCommand
+                         {
+                             new Option("--flag"),
+                             new Option("--flag2")
+                         }.Parse("@nonexistent.rsp");
+
             result.HasOption("--flag").Should().BeFalse();
             result.HasOption("--flag2").Should().BeFalse();
             result.Errors.Should().HaveCount(1);
-            result.Errors.Single().Message.Should().Be($"Response file not found '{FilePath}'");
+            result.Errors.Single().Message.Should().Be("Response file not found 'nonexistent.rsp'");
         }
 
         [Fact]
-        public void When_response_filepath_is_not_specified_error_is_returned()
+        public void When_response_filepath_is_not_specified_then_error_is_returned()
         {
-            var result = new CommandLineBuilder()
-                .AddOption(new Option("--flag"))
-                .AddOption(new Option("--flag2"))
-                .Build()
+            var result = new RootCommand
+                         {
+                             new Option("--flag"),
+                             new Option("--flag2")
+                         }
                 .Parse("@");
+
             result.HasOption("--flag").Should().BeFalse();
             result.HasOption("--flag2").Should().BeFalse();
             result.Errors.Should().HaveCount(1);
-            result.Errors.Single().Message.Should().Be("Unrecognized command or argument '@'");
+            result.Errors
+                  .Single()
+                  .Message
+                  .Should()
+                  .Be("Invalid response file token: @");
         }
 
         [Fact]
-        public void When_response_file_cannot_be_read_specified_error_is_returned()
+        public void When_response_file_cannot_be_read_then_specified_error_is_returned()
         {
-            using (File.Open(FilePath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            var nonexistent = Path.GetTempFileName();
+
+            using (File.Open(nonexistent, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
             {
-                var result = new CommandLineBuilder()
-                    .AddOption(new Option("--flag"))
-                    .AddOption(new Option("--flag2"))
-                    .Build()
-                    .Parse("@" + FilePath);
+                var result = new RootCommand
+                             {
+                                 new Option("--flag"),
+                                 new Option("--flag2")
+                             }.Parse($"@{nonexistent}");
+
                 result.HasOption("--flag").Should().BeFalse();
                 result.HasOption("--flag2").Should().BeFalse();
                 result.Errors.Should().HaveCount(1);
-                result.Errors.Single().Message.Should().StartWith($"Error reading response file '{FilePath}'");
+                result.Errors.Single().Message.Should().StartWith($"Error reading response file '{nonexistent}'");
             }
         }
 
@@ -131,37 +254,63 @@ namespace System.CommandLine.Tests
         [InlineData("--flag=\"first value\" --flag2=123")]
         public void When_response_file_parse_as_space_separated_returns_expected_values(string input)
         {
-            using (var s = new StreamWriter(FilePath))
-            {
-                s.WriteLine(input);
-            }
+            var responseFile = ResponseFile(input);
 
-            var rootCommand = new RootCommand();
-            rootCommand.AddOption(new Option("--flag", "", new Argument<string>()));
-            rootCommand.AddOption(new Option("--flag2", "", new Argument<int>()));
+            var rootCommand = new RootCommand
+                              {
+                                  new Option("--flag", "", new Argument<string>()),
+                                  new Option("--flag2", "", new Argument<int>())
+                              };
             var parser = new CommandLineBuilder(rootCommand)
                          .ParseResponseFileAs(ResponseFileHandling.ParseArgsAsSpaceSeparated)
                          .Build();
 
-            var result = parser.Parse("@" + FilePath);
+            var result = parser.Parse($"@{responseFile}");
 
             result.ValueForOption("--flag").Should().Be("first value");
             result.ValueForOption("--flag2").Should().Be(123);
         }
 
         [Fact]
-        public void When_response_file_processing_is_disabled_returns_response_file_name_as_argument()
+        public void When_response_file_processing_is_disabled_then_it_returns_response_file_name_as_argument()
         {
             var result = new CommandLineBuilder()
-                .AddOption(new Option("--flag"))
-                .AddOption(new Option("--flag2"))
-                .ParseResponseFileAs(ResponseFileHandling.Disabled)
-                .Build()
-                .Parse($"--flag @{FilePath} --flag2");
+                         .AddOption(new Option("--flag"))
+                         .AddOption(new Option("--flag2"))
+                         .ParseResponseFileAs(ResponseFileHandling.Disabled)
+                         .Build()
+                         .Parse("--flag @file.rsp --flag2");
+
             result.HasOption("--flag").Should().BeTrue();
             result.HasOption("--flag2").Should().BeTrue();
             result.Errors.Should().HaveCount(1);
-            result.Errors.Single().Message.Should().Be($"Unrecognized command or argument '@{FilePath}'");
+            result.Errors.Single().Message.Should().Be("Unrecognized command or argument '@file.rsp'");
+        }
+
+        [Fact]
+        public void Response_files_can_refer_to_other_response_files()
+        {
+            var file3 = ResponseFile("--three", "3");
+            var file2 = ResponseFile($"@{file3}", "--two", "2");
+            var file1 = ResponseFile("--one", "1", $"@{file2}");
+
+            var option1 = new Option("--one") { Argument = new Argument<int>() };
+            var option2 = new Option("--two") { Argument = new Argument<int>() };
+            var option3 = new Option("--three") { Argument = new Argument<int>() };
+
+            var command = new RootCommand
+                          {
+                              option1,
+                              option2,
+                              option3
+                          };
+
+            var result = command.Parse($"@{file1}");
+
+            result.FindResultFor(option1).GetValueOrDefault().Should().Be(1);
+            result.FindResultFor(option2).GetValueOrDefault().Should().Be(2);
+            result.FindResultFor(option3).GetValueOrDefault().Should().Be(3);
+            result.Errors.Should().BeEmpty();
         }
     }
 }

--- a/src/System.CommandLine.Tests/ResponseFileTests.cs
+++ b/src/System.CommandLine.Tests/ResponseFileTests.cs
@@ -225,7 +225,7 @@ namespace System.CommandLine.Tests
                   .Single()
                   .Message
                   .Should()
-                  .Be("Invalid response file token: @");
+                  .Be("Unrecognized command or argument '@'");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/SplitCommandLineTests.cs
+++ b/src/System.CommandLine.Tests/SplitCommandLineTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -8,31 +8,31 @@ using Xunit.Abstractions;
 
 namespace System.CommandLine.Tests
 {
-    public class TokenizeTests
+    public class SplitCommandLineTests
     {
-        private ITestOutputHelper _output;
+        private readonly ITestOutputHelper _output;
 
-        public TokenizeTests(ITestOutputHelper output)
+        public SplitCommandLineTests(ITestOutputHelper output)
         {
             _output = output;
         }
 
         [Fact]
-        public void Tokenize_splits_strings_based_on_whitespace()
+        public void It_splits_strings_based_on_whitespace()
         {
             var commandLine = "one two\tthree   four ";
 
-            commandLine.Tokenize()
+            commandLine.SplitCommandLine()
                        .Should()
                        .BeEquivalentTo("one", "two", "three", "four");
         }
 
         [Fact]
-        public void Tokenize_does_not_break_up_double_quote_delimited_values()
+        public void It_does_not_break_up_double_quote_delimited_values()
         {
             var commandLine = @"rm -r ""c:\temp files\""";
 
-            commandLine.Tokenize()
+            commandLine.SplitCommandLine()
                        .Should()
                        .BeEquivalentTo("rm", "-r", @"c:\temp files\");
         }
@@ -44,7 +44,7 @@ namespace System.CommandLine.Tests
         [InlineData("--", ':')]
         [InlineData("/", '=')]
         [InlineData("/", ':')]
-        public void Tokenize_does_not_split_double_quote_delimited_values_when_a_non_whitespace_argument_delimiter_is_used(
+        public void It_does_not_split_double_quote_delimited_values_when_a_non_whitespace_argument_delimiter_is_used(
             string prefix,
             char delimiter)
         {
@@ -52,20 +52,20 @@ namespace System.CommandLine.Tests
 
             var commandLine = $"the-command {optionAndArgument}";
 
-            commandLine.Tokenize()
+            commandLine.SplitCommandLine()
                        .Should()
                        .BeEquivalentTo("the-command", optionAndArgument.Replace("\"", ""));
         }
 
         [Fact]
-        public void Tokenize_handles_multiple_options_with_quoted_arguments()
+        public void It_handles_multiple_options_with_quoted_arguments()
         {
             var source = Directory.GetCurrentDirectory();
             var destination = Path.Combine(Directory.GetCurrentDirectory(), ".trash");
 
             var commandLine = $"move --from \"{source}\" --to \"{destination}\"";
 
-            var tokenized = commandLine.Tokenize();
+            var tokenized = commandLine.SplitCommandLine();
 
             _output.WriteLine(commandLine);
 

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -10,12 +10,22 @@
     <EmbeddedResource Remove="TestResults\**" />
     <None Remove="TestResults\**" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\System.CommandLine\System.CommandLine.csproj" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
 	<PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(DisableArcade)' == '1'" >
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" >
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/System.CommandLine/Invocation/InvocationExtensions.cs
+++ b/src/System.CommandLine/Invocation/InvocationExtensions.cs
@@ -228,7 +228,7 @@ namespace System.CommandLine.Invocation
             this Parser parser,
             string commandLine,
             IConsole console = null) =>
-            parser.InvokeAsync(commandLine.Tokenize().ToArray(), console);
+            parser.InvokeAsync(commandLine.SplitCommandLine().ToArray(), console);
 
         public static async Task<int> InvokeAsync(
             this Parser parser,
@@ -240,7 +240,7 @@ namespace System.CommandLine.Invocation
             this Command command,
             string commandLine,
             IConsole console = null) =>
-            command.InvokeAsync(commandLine.Tokenize().ToArray(), console);
+            command.InvokeAsync(commandLine.SplitCommandLine().ToArray(), console);
 
         public static async Task<int> InvokeAsync(
             this Command command,

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine
             IReadOnlyCollection<Token> tokens,
             IReadOnlyCollection<string> unparsedTokens,
             IReadOnlyCollection<string> unmatchedTokens,
-            IReadOnlyCollection<ParseError> errors,
+            IReadOnlyCollection<TokenizeError> tokenizeErrors,
             string rawInput)
         {
             Parser = parser;
@@ -30,9 +30,10 @@ namespace System.CommandLine
             UnmatchedTokens = unmatchedTokens;
             RawInput = rawInput;
 
-            if (errors != null)
+            if (tokenizeErrors?.Count > 0)
             {
-                _errors.AddRange(errors);
+                _errors.AddRange(
+                    tokenizeErrors.Select(e => new ParseError(e.Message)));
             }
 
             AddImplicitOptionsAndCheckForErrors();

--- a/src/System.CommandLine/Parser.cs
+++ b/src/System.CommandLine/Parser.cs
@@ -29,7 +29,7 @@ namespace System.CommandLine
             string rawInput = null)
         {
             var normalizedArgs = NormalizeRootCommand(arguments);
-            var lexResult = normalizedArgs.Lex(Configuration);
+            var lexResult = normalizedArgs.Tokenize(Configuration);
             var directives = new DirectiveCollection();
             var unparsedTokens = new Queue<Token>(lexResult.Tokens);
             var allSymbolResults = new List<SymbolResult>();

--- a/src/System.CommandLine/ParserExtensions.cs
+++ b/src/System.CommandLine/ParserExtensions.cs
@@ -10,6 +10,6 @@ namespace System.CommandLine
         public static ParseResult Parse(
             this Parser parser,
             string input) =>
-            parser.Parse(input.Tokenize().ToArray(), input);
+            parser.Parse(input.SplitCommandLine().ToArray(), input);
     }
 }

--- a/src/System.CommandLine/StringExtensions.cs
+++ b/src/System.CommandLine/StringExtensions.cs
@@ -51,7 +51,7 @@ namespace System.CommandLine
             CommandLineConfiguration configuration)
         {
             var tokenList = new List<Token>();
-            var errorList = new List<ParseError>();
+            var errorList = new List<TokenizeError>();
 
             ISymbol currentSymbol = null;
             var foundEndOfArguments = false;
@@ -195,7 +195,9 @@ namespace System.CommandLine
             return new TokenizeResult(tokenList, errorList);
         }
 
-        internal static string[] SplitTokenByArgumentDelimiter(string arg, char[] argumentDelimiters) => arg.Split(argumentDelimiters, 2);
+        internal static string[] SplitByDelimiters(
+            this string arg, 
+            char[] argumentDelimiters) => arg.Split(argumentDelimiters, 2);
 
         public static string ToKebabCase(this string value)
         {

--- a/src/System.CommandLine/StringExtensions.cs
+++ b/src/System.CommandLine/StringExtensions.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine
     {
         private static readonly string[] _optionPrefixStrings = { "--", "-", "/" };
 
-        private static readonly Regex _tokenizer = new Regex(
+        private static readonly Regex _commandLineSplitter = new Regex(
             @"((?<opt>[^""\s]+)""(?<arg>[^""]+)"") # token + quoted argument with non-space argument delimiter, ex: --opt:""c:\path with\spaces""
               |                                
               (""(?<token>[^""]*)"")               # tokens surrounded by spaces, ex: ""c:\path with\spaces""
@@ -46,7 +46,7 @@ namespace System.CommandLine
             return option;
         }
 
-        internal static LexResult Lex(
+        internal static TokenizeResult Tokenize(
             this IEnumerable<string> args,
             CommandLineConfiguration configuration)
         {
@@ -192,7 +192,7 @@ namespace System.CommandLine
                 }
             }
 
-            return new LexResult(tokenList, errorList);
+            return new TokenizeResult(tokenList, errorList);
         }
 
         internal static string[] SplitTokenByArgumentDelimiter(string arg, char[] argumentDelimiters) => arg.Split(argumentDelimiters, 2);
@@ -279,9 +279,9 @@ namespace System.CommandLine
 
         private static bool HasPrefix(string arg) => _optionPrefixStrings.Any(arg.StartsWith);
 
-        public static IEnumerable<string> Tokenize(this string commandLine)
+        public static IEnumerable<string> SplitCommandLine(this string commandLine)
         {
-            var matches = _tokenizer.Matches(commandLine);
+            var matches = _commandLineSplitter.Matches(commandLine);
 
             foreach (Match match in matches)
             {
@@ -320,7 +320,7 @@ namespace System.CommandLine
                         yield return line;
                         break;
                     case ResponseFileHandling.ParseArgsAsSpaceSeparated:
-                        foreach (var word in Tokenize(arg))
+                        foreach (var word in SplitCommandLine(arg))
                         {
                             yield return word;
                         }

--- a/src/System.CommandLine/TokenizeError.cs
+++ b/src/System.CommandLine/TokenizeError.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine
+{
+    internal class TokenizeError
+    {
+        public TokenizeError(string message)
+        {
+            Message = message;
+        }
+
+        public string Message { get; }
+
+        public override string ToString() => Message;
+    }
+}

--- a/src/System.CommandLine/TokenizeError.cs
+++ b/src/System.CommandLine/TokenizeError.cs
@@ -7,7 +7,7 @@ namespace System.CommandLine
     {
         public TokenizeError(string message)
         {
-            Message = message;
+            Message = message ?? throw new ArgumentNullException(nameof(message));
         }
 
         public string Message { get; }

--- a/src/System.CommandLine/TokenizeResult.cs
+++ b/src/System.CommandLine/TokenizeResult.cs
@@ -8,15 +8,15 @@ namespace System.CommandLine
     internal class TokenizeResult
     {
         public TokenizeResult(
-            IReadOnlyCollection<Token> tokens,
-            IReadOnlyCollection<TokenizeError> errors)
+            IReadOnlyCollection<Token> tokens = null,
+            IReadOnlyCollection<TokenizeError> errors = null)
         {
-            Tokens = tokens;
-            Errors = errors;
+            Tokens = tokens ?? Array.Empty<Token>();
+            Errors = errors ?? Array.Empty<TokenizeError>();
         }
 
         public IReadOnlyCollection<Token> Tokens { get; }
-        
+
         public IReadOnlyCollection<TokenizeError> Errors { get; }
     }
 }

--- a/src/System.CommandLine/TokenizeResult.cs
+++ b/src/System.CommandLine/TokenizeResult.cs
@@ -9,13 +9,14 @@ namespace System.CommandLine
     {
         public TokenizeResult(
             IReadOnlyCollection<Token> tokens,
-            IReadOnlyCollection<ParseError> errors)
+            IReadOnlyCollection<TokenizeError> errors)
         {
             Tokens = tokens;
             Errors = errors;
         }
 
         public IReadOnlyCollection<Token> Tokens { get; }
-        public IReadOnlyCollection<ParseError> Errors { get; }
+        
+        public IReadOnlyCollection<TokenizeError> Errors { get; }
     }
 }

--- a/src/System.CommandLine/TokenizeResult.cs
+++ b/src/System.CommandLine/TokenizeResult.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 
 namespace System.CommandLine
 {
-    internal class LexResult
+    internal class TokenizeResult
     {
-        public LexResult(
+        public TokenizeResult(
             IReadOnlyCollection<Token> tokens,
             IReadOnlyCollection<ParseError> errors)
         {


### PR DESCRIPTION
Rather than reuse `ParseError` to track tokenization errors, this introduces a `TokenizationError` class.

I've also added support for referencing one response file from within another.