### PR TITLE
Fix dotnet-suggest verison

### DIFF
--- a/src/System.CommandLine.Suggest/dotnet-suggest.csproj
+++ b/src/System.CommandLine.Suggest/dotnet-suggest.csproj
@@ -2,8 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <VersionPrefix>1.0.3</VersionPrefix>
+
+    <VersionPrefix>1.0.3$(DotnetSuggestBuildNumber)</VersionPrefix>
+    <DotnetSuggestBuildNumber Condition="'$(OfficialBuild)' == 'true'">
+      .$(VersionSuffixDateStamp).$(VersionSuffixBuildOfTheDay)
+    </DotnetSuggestBuildNumber>
     <VersionSuffix />
+
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
A previous change removed the version suffix from `dotnet-suggest` in order to make installation easier, but the package version now needs to be made build-specific.