### PR TITLE
Fix package icon for System.CommandLine.DragonFruit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <NoWarn>$(NoWarn);NU5125</NoWarn>
+    <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/dotnet/command-line-api/master/LICENSE.md</PackageLicenseUrl>
   </PropertyGroup>
 

--- a/samples/DragonFruit/DragonFruit.csproj
+++ b/samples/DragonFruit/DragonFruit.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.CommandLine.Rendering/System.CommandLine.Rendering.csproj
+++ b/src/System.CommandLine.Rendering/System.CommandLine.Rendering.csproj
@@ -4,7 +4,6 @@
     <IsPackable>true</IsPackable>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
-    <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.CommandLine.Suggest/dotnet-suggest.csproj
+++ b/src/System.CommandLine.Suggest/dotnet-suggest.csproj
@@ -14,7 +14,6 @@
     <ToolCommandName>dotnet-suggest</ToolCommandName>
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
-    <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -5,7 +5,6 @@
     <PackageId>System.CommandLine.Experimental</PackageId>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
-    <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
   </PropertyGroup>
    
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
The System.CommandLine.DragonFruit package does not have a package icon: https://www.nuget.org/packages/System.CommandLine.DragonFruit

I made the `PackageIconUrl` property global on all projects by applying this property to the `Directory.Build.props` file. Please let me know if you'd like me to revert this.