### PR TITLE
intercept and track the platform not supported exceptions

### DIFF
--- a/src/System.CommandLine/ConsoleExtensions.cs
+++ b/src/System.CommandLine/ConsoleExtensions.cs
@@ -14,13 +14,12 @@ namespace System.CommandLine
                 ((dynamic)console).ForegroundColor = ConsoleColor.Red;
             }
 
-            var supported = Platform.SupportsOperation(() => Console.IsOutputRedirected,
-                    out var isOutputRedirected);
-            if (!supported)
+
+            if (!Platform.IsWasm && !Console.IsOutputRedirected)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
             }
-            else if (!isOutputRedirected)
+            else if (Platform.IsWasm)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
             }
@@ -33,13 +32,11 @@ namespace System.CommandLine
                 ((dynamic)console).ForegroundColor = ConsoleColor.Red;
             }
 
-            var supported = Platform.SupportsOperation(() => Console.IsOutputRedirected,
-                out var isOutputRedirected);
-            if (!supported)
+            if (!Platform.IsWasm && !Console.IsOutputRedirected)
             {
                 Console.ResetColor();
             }
-            else if (!isOutputRedirected)
+            else if (Platform.IsWasm)
             {
                 Console.ResetColor();
             }

--- a/src/System.CommandLine/ConsoleExtensions.cs
+++ b/src/System.CommandLine/ConsoleExtensions.cs
@@ -14,11 +14,11 @@ namespace System.CommandLine
                 ((dynamic)console).ForegroundColor = ConsoleColor.Red;
             }
 
-            if (!Platform.IsWasm && !Console.IsOutputRedirected)
+            if (!Platform.IsConsoleRedirectionCheckSupported && !Console.IsOutputRedirected)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
             }
-            else if (Platform.IsWasm)
+            else if (Platform.IsConsoleRedirectionCheckSupported)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
             }
@@ -31,11 +31,11 @@ namespace System.CommandLine
                 ((dynamic)console).ForegroundColor = ConsoleColor.Red;
             }
 
-            if (!Platform.IsWasm && !Console.IsOutputRedirected)
+            if (!Platform.IsConsoleRedirectionCheckSupported && !Console.IsOutputRedirected)
             {
                 Console.ResetColor();
             }
-            else if (Platform.IsWasm)
+            else if (Platform.IsConsoleRedirectionCheckSupported)
             {
                 Console.ResetColor();
             }

--- a/src/System.CommandLine/ConsoleExtensions.cs
+++ b/src/System.CommandLine/ConsoleExtensions.cs
@@ -13,7 +13,14 @@ namespace System.CommandLine
             {
                 ((dynamic)console).ForegroundColor = ConsoleColor.Red;
             }
-            else if (!Console.IsOutputRedirected)
+
+            var supported = Platform.SupportsOperation(() => Console.IsOutputRedirected,
+                    out var isOutputRedirected);
+            if (!supported)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+            }
+            else if (!isOutputRedirected)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
             }
@@ -25,7 +32,14 @@ namespace System.CommandLine
             {
                 ((dynamic)console).ForegroundColor = ConsoleColor.Red;
             }
-            else if (!Console.IsOutputRedirected)
+
+            var supported = Platform.SupportsOperation(() => Console.IsOutputRedirected,
+                out var isOutputRedirected);
+            if (!supported)
+            {
+                Console.ResetColor();
+            }
+            else if (!isOutputRedirected)
             {
                 Console.ResetColor();
             }

--- a/src/System.CommandLine/ConsoleExtensions.cs
+++ b/src/System.CommandLine/ConsoleExtensions.cs
@@ -14,7 +14,6 @@ namespace System.CommandLine
                 ((dynamic)console).ForegroundColor = ConsoleColor.Red;
             }
 
-
             if (!Platform.IsWasm && !Console.IsOutputRedirected)
             {
                 Console.ForegroundColor = ConsoleColor.Red;

--- a/src/System.CommandLine/Platform.cs
+++ b/src/System.CommandLine/Platform.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections.Concurrent;
+using System.Linq.Expressions;
+
+namespace System.CommandLine
+{
+    internal static class Platform
+    {
+        private static readonly ConcurrentDictionary<string, bool> _unsupportedOperations =
+            new ConcurrentDictionary<string, bool>();
+        public static bool SupportsOperation<T>(Expression<Func<T>> apiCall, out T result)
+        {
+            if (apiCall == null)
+            {
+                throw new ArgumentNullException(nameof(apiCall));
+            }
+
+            if (!Unsupported(apiCall,  out var name))
+            {
+                result = default;
+                return false;
+            }
+
+            try
+            {
+                var executor = apiCall.Compile();
+                result = executor();
+                return true;
+            }
+
+            catch (PlatformNotSupportedException)
+            {
+                _unsupportedOperations.TryAdd(name, false);
+                result = default;
+                return false;
+            }
+        }
+
+        private static bool Unsupported<T>(Expression<T> apiCall, out string name) where T : Delegate
+        {
+            name = GetMemberName(apiCall.Body);
+            return !_unsupportedOperations.TryGetValue(name, out _);
+        }
+     
+        public static bool SupportsOperation(Expression<Action> apiCall)
+        {
+            if (apiCall == null)
+            {
+                throw new ArgumentNullException(nameof(apiCall));
+            }
+            if (!Unsupported(apiCall,  out var name))
+            {
+                return false;
+            }
+            try
+            {
+                var executor = apiCall.Compile();
+                executor();
+                return true;
+            }
+
+            catch (PlatformNotSupportedException)
+            {
+                _unsupportedOperations.TryAdd(name, false);
+
+                return false;
+            }
+        }
+
+        private static string GetMemberName(MemberExpression memberExpression)
+        {
+            return $"{memberExpression.Member.DeclaringType?.FullName ?? "_"}.{memberExpression.Member.Name}";
+        }
+
+        private static string GetMemberName(MethodCallExpression methodCallExpression)
+        {
+            return $"{methodCallExpression.Method.DeclaringType?.FullName ?? "_"}.{methodCallExpression.Method.Name}";
+        }
+
+        private static string GetMemberName(Expression expression)
+        {
+            switch (expression)
+            {
+                case MemberExpression memberExpression:
+                    // Reference type property or field
+                    return GetMemberName(memberExpression);
+                case MethodCallExpression methodCallExpression:
+                    // Reference type method
+                    return GetMemberName(methodCallExpression);
+                case UnaryExpression unaryExpression:
+                    // Property, field of method returning value type
+                    return GetMemberName(unaryExpression);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(expression));
+            }
+        }
+
+        private static string GetMemberName(UnaryExpression unaryExpression)
+        {
+            switch (unaryExpression.Operand)
+            {
+                case MethodCallExpression methodExpression:
+                    return GetMemberName(methodExpression);
+                case MemberExpression memberExpression:
+                    return GetMemberName(memberExpression);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(unaryExpression));
+            }
+        }
+    }
+}

--- a/src/System.CommandLine/Platform.cs
+++ b/src/System.CommandLine/Platform.cs
@@ -1,109 +1,27 @@
-﻿using System.Collections.Concurrent;
-using System.Linq.Expressions;
-
-namespace System.CommandLine
+﻿namespace System.CommandLine
 {
     internal static class Platform
     {
-        private static readonly ConcurrentDictionary<string, bool> _unsupportedOperations =
-            new ConcurrentDictionary<string, bool>();
-        public static bool SupportsOperation<T>(Expression<Func<T>> apiCall, out T result)
+        private static bool? _isWasm;
+        public static bool IsWasm
         {
-            if (apiCall == null)
+            get
             {
-                throw new ArgumentNullException(nameof(apiCall));
-            }
+                if (_isWasm == null)
+                {
+                    try
+                    {
+                        var check = Console.IsOutputRedirected;
+                        _isWasm = false;
+                    }
 
-            if (!Unsupported(apiCall,  out var name))
-            {
-                result = default;
-                return false;
-            }
+                    catch (PlatformNotSupportedException)
+                    {
+                        _isWasm = true;
+                    }
+                }
 
-            try
-            {
-                var executor = apiCall.Compile();
-                result = executor();
-                return true;
-            }
-
-            catch (PlatformNotSupportedException)
-            {
-                _unsupportedOperations.TryAdd(name, false);
-                result = default;
-                return false;
-            }
-        }
-
-        private static bool Unsupported<T>(Expression<T> apiCall, out string name) where T : Delegate
-        {
-            name = GetMemberName(apiCall.Body);
-            return !_unsupportedOperations.TryGetValue(name, out _);
-        }
-     
-        public static bool SupportsOperation(Expression<Action> apiCall)
-        {
-            if (apiCall == null)
-            {
-                throw new ArgumentNullException(nameof(apiCall));
-            }
-            if (!Unsupported(apiCall,  out var name))
-            {
-                return false;
-            }
-            try
-            {
-                var executor = apiCall.Compile();
-                executor();
-                return true;
-            }
-
-            catch (PlatformNotSupportedException)
-            {
-                _unsupportedOperations.TryAdd(name, false);
-
-                return false;
-            }
-        }
-
-        private static string GetMemberName(MemberExpression memberExpression)
-        {
-            return $"{memberExpression.Member.DeclaringType?.FullName ?? "_"}.{memberExpression.Member.Name}";
-        }
-
-        private static string GetMemberName(MethodCallExpression methodCallExpression)
-        {
-            return $"{methodCallExpression.Method.DeclaringType?.FullName ?? "_"}.{methodCallExpression.Method.Name}";
-        }
-
-        private static string GetMemberName(Expression expression)
-        {
-            switch (expression)
-            {
-                case MemberExpression memberExpression:
-                    // Reference type property or field
-                    return GetMemberName(memberExpression);
-                case MethodCallExpression methodCallExpression:
-                    // Reference type method
-                    return GetMemberName(methodCallExpression);
-                case UnaryExpression unaryExpression:
-                    // Property, field of method returning value type
-                    return GetMemberName(unaryExpression);
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(expression));
-            }
-        }
-
-        private static string GetMemberName(UnaryExpression unaryExpression)
-        {
-            switch (unaryExpression.Operand)
-            {
-                case MethodCallExpression methodExpression:
-                    return GetMemberName(methodExpression);
-                case MemberExpression memberExpression:
-                    return GetMemberName(memberExpression);
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(unaryExpression));
+                return _isWasm.Value;
             }
         }
     }

--- a/src/System.CommandLine/Platform.cs
+++ b/src/System.CommandLine/Platform.cs
@@ -2,26 +2,26 @@
 {
     internal static class Platform
     {
-        private static bool? _isWasm;
-        public static bool IsWasm
+        private static bool? _isConsoleRedirectionCheckSupported;
+        public static bool IsConsoleRedirectionCheckSupported
         {
             get
             {
-                if (_isWasm == null)
+                if (_isConsoleRedirectionCheckSupported == null)
                 {
                     try
                     {
                         var check = Console.IsOutputRedirected;
-                        _isWasm = false;
+                        _isConsoleRedirectionCheckSupported = false;
                     }
 
                     catch (PlatformNotSupportedException)
                     {
-                        _isWasm = true;
+                        _isConsoleRedirectionCheckSupported = true;
                     }
                 }
 
-                return _isWasm.Value;
+                return _isConsoleRedirectionCheckSupported.Value;
             }
         }
     }


### PR DESCRIPTION
trying to address #497 
The issue so far manifests only on mono when compiled with following symbols

-  MONOTOUCH
- MONODROID 
- XAMMAC 
- WASM 
[see](https://github.com/mono/mono/blob/af6d863e5248a9e67292f94daf6ff0e0cbb38454/mcs/class/corlib/System/Environment.cs#L960) for more details