### PR TITLE
Fix #495

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
@@ -47,7 +47,7 @@ namespace System.CommandLine.DragonFruit.Tests
             var stdOut = _terminal.Out.ToString();
 
             stdOut.Should()
-                  .Contain("--name <NAME>    Specifies the name option")
+                  .Contain("--name <name>    Specifies the name option")
                   .And.Contain("Options:");
             stdOut.Should()
                   .Contain("Help for the test program");

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -661,7 +661,7 @@ namespace System.CommandLine.Tests.Help
         [Theory]
         [InlineData(typeof(bool))]
         [InlineData(typeof(bool?))]
-        public void Command_argument_descriptor_indicates_when_it_accepts_boolean_values(Type type)
+        public void Command_argument_descriptor_is_empty_for_boolean_values(Type type)
         {
             var description = "This is the argument description";
 
@@ -680,7 +680,7 @@ namespace System.CommandLine.Tests.Help
 
             var expected =
                 $"Arguments:{NewLine}" +
-                $"{_indentation}<False|True>{_columnPadding}{description}";
+                $"{_indentation}{_columnPadding}{description}";
 
             _console.Out.ToString().Should().Contain(expected);
         }
@@ -715,14 +715,14 @@ namespace System.CommandLine.Tests.Help
         [Theory]
         [InlineData(typeof(bool))]
         [InlineData(typeof(bool?))]
-        public void Option_argument_descriptor_indicates_when_it_accepts_boolean_values(Type type)
+        public void Option_argument_descriptor_is_empty_for_boolean_values(Type type)
         {
-            var description = "This is the argument description";
+            var description = "This is the option description";
 
             var command = new Command(
                 "outer", "Help text for the outer command")
                           {
-                              new Option("--opt")
+                              new Option("--opt", description)
                               {
                                   Argument = new Argument
                                              {
@@ -735,11 +735,9 @@ namespace System.CommandLine.Tests.Help
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
 
             helpBuilder.Write(command);
-
             
-            _console.Out.ToString().Should().Contain("--opt <False|True>");
+            _console.Out.ToString().Should().Contain($"--opt{_columnPadding}{description}");
         }
-
         
         [Theory]
         [InlineData(typeof(FileAccess))]
@@ -751,11 +749,10 @@ namespace System.CommandLine.Tests.Help
             var command = new Command(
                               "outer", "Help text for the outer command")
                           {
-                              new Option("--opt")
+                              new Option("--opt", description)
                               {
                                   Argument = new Argument
                                              {
-                                                 Description = description,
                                                  ArgumentType = type
                                              }
                               }
@@ -765,7 +762,7 @@ namespace System.CommandLine.Tests.Help
 
             helpBuilder.Write(command);
 
-            _console.Out.ToString().Should().Contain("--opt <Read|ReadWrite|Write>");
+            _console.Out.ToString().Should().Contain($"--opt <Read|ReadWrite|Write>{_columnPadding}{description}");
         }
 
         #endregion Arguments

--- a/src/System.CommandLine.Tests/SymbolTests.cs
+++ b/src/System.CommandLine.Tests/SymbolTests.cs
@@ -78,15 +78,27 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Symbol_defaults_argument_to_alias_name_when_it_is_not_provided()
         {
-            var symbol = new TestSymbol(new[] { "-alias" }, "", new Argument() { Arity = ArgumentArity.ZeroOrOne });
+            var symbol = new TestSymbol(new[]
+                                        {
+                                            "-alias"
+                                        }, "", new Argument
+                                               {
+                                                   Arity = ArgumentArity.ZeroOrOne
+                                               });
 
-            symbol.Argument.Name.Should().Be("ALIAS");
+            symbol.Argument.Name.Should().Be("alias");
         }
 
         [Fact]
         public void Symbol_retains_argument_name_when_it_is_provided()
         {
-            var symbol = new TestSymbol(new[] { "-alias" }, "", new Argument() { Name = "arg", Arity = ArgumentArity.ZeroOrOne });
+            var symbol = new TestSymbol(new[]
+                                        {
+                                            "-alias"
+                                        }, "", new Argument
+                                               {
+                                                   Name = "arg", Arity = ArgumentArity.ZeroOrOne
+                                               });
 
             symbol.Argument.Name.Should().Be("arg");
         }
@@ -94,7 +106,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Symbol_does_not_default_argument_name_when_arity_is_zero()
         {
-            var symbol = new TestSymbol(new[] { "-alias" }, "", new Argument());
+            var symbol = new TestSymbol(new[]
+                                        {
+                                            "-alias"
+                                        }, "", new Argument());
 
             symbol.Argument.Name.Should().BeNull();
         }

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -284,17 +284,24 @@ namespace System.CommandLine
         /// <returns>A new <see cref="HelpItem"/></returns>
         protected virtual HelpItem ArgumentFormatter(ISymbol symbol)
         {
-            var argumentName = ArgumentDescriptor(symbol.Argument);
+            var argumentDescriptor = ArgumentDescriptor(symbol.Argument);
 
             return new HelpItem
                    {
-                       Invocation = $"<{argumentName}>",
+                       Invocation = string.IsNullOrWhiteSpace(argumentDescriptor)
+                                        ? ""
+                                        : $"<{argumentDescriptor}>",
                        Description = symbol.Argument?.Description ?? ""
                    };
         }
 
         protected virtual string ArgumentDescriptor(IArgument argument)
         {
+            if (argument.Type == typeof(bool) || argument.Type == typeof(bool?) )
+            {
+                return "";
+            }
+
             var suggestions = argument.Suggest().ToArray();
             if (suggestions.Length > 0)
             {
@@ -319,7 +326,11 @@ namespace System.CommandLine
             if (symbol?.ShouldShowHelp() == true && 
                 !string.IsNullOrWhiteSpace(symbol.Argument?.Name))
             {
-                option = $"{option} <{ArgumentDescriptor(symbol.Argument)}>";
+                var argumentDescriptor = ArgumentDescriptor(symbol.Argument);
+                if (!string.IsNullOrWhiteSpace(argumentDescriptor))
+                {
+                    option = $"{option} <{argumentDescriptor}>";
+                }
             }
 
             return new HelpItem {

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -47,18 +47,20 @@ namespace System.CommandLine
 
         public IReadOnlyCollection<string> RawAliases => _rawAliases;
 
-        public Argument Argument 
-        { 
+        public Argument Argument
+        {
             get => _argument;
             set
             {
-                if (value?.Arity.MaximumNumberOfArguments > 0 && string.IsNullOrEmpty(value.Name))
+                if (value?.Arity.MaximumNumberOfArguments > 0 && 
+                    string.IsNullOrEmpty(value.Name))
                 {
-                    value.Name = _aliases.First().ToUpper();
+                    value.Name = _aliases.First().ToLower();
                 }
-                _argument = value ?? Argument.None; 
+
+                _argument = value ?? Argument.None;
                 _argument.Parent = this;
-            } 
+            }
         }
 
         public string Description { get; set; }


### PR DESCRIPTION
This changes the default argument names in help to lower-case and fixed #495.