### PR TITLE
Add alias attribute to XML doc comment params for DragonFruit

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "2.2.203",
+    "dotnet": "2.2.204",
     "vs": {
       "version": "16.0"
     }

--- a/samples/DragonFruit/Program.cs
+++ b/samples/DragonFruit/Program.cs
@@ -10,9 +10,9 @@ namespace DragonFruit
         /// <summary>
         /// DragonFruit simple example program
         /// </summary>
-        /// <param name="verbose">Show verbose output</param>
-        /// <param name="flavor">Which flavor to use</param>
-        /// <param name="count">How many smoothies?</param>
+        /// <param name="verbose" alias="v">Show verbose output</param>
+        /// <param name="flavor" alias="f">Which flavor to use</param>
+        /// <param name="count" alias="c">How many smoothies?</param>
         static int Main(
             bool verbose,
             string flavor = "chocolate",

--- a/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
@@ -50,7 +50,7 @@ namespace System.CommandLine.DragonFruit.Tests
                   .Contain("<args>    These are arguments")
                   .And.Contain("Arguments:");
             stdOut.Should()
-                  .Contain("--name <name>    Specifies the name option")
+                  .Contain("-n, --name <name>    Specifies the name option")
                   .And.Contain("Options:");
             stdOut.Should()
                   .Contain("Help for the test program");

--- a/src/System.CommandLine.DragonFruit.Tests/TestProgram.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/TestProgram.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine.DragonFruit.Tests
         /// <summary>
         /// Help for the test program
         /// </summary>
-        /// <param name="name">Specifies the name option</param>
+        /// <param name="name" alias="n">Specifies the name option</param>
         /// <param name="console"></param>
         /// <param name="args">These are arguments</param>
         public void TestMain(string name, IConsole console, string[] args = null)

--- a/src/System.CommandLine.DragonFruit.Tests/XmlDocReaderTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/XmlDocReaderTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
@@ -30,7 +30,7 @@ namespace System.CommandLine.DragonFruit.Tests
             <summary>
             Hello
             </summary>
-            <param name=""verbose"">Show verbose output</param>
+            <param name=""verbose"" alias=""v"">Show verbose output</param>
             <param name=""flavor"">Which flavor to use</param>
             <param name=""count"">How many smoothies?</param>
         </member>
@@ -46,6 +46,7 @@ namespace System.CommandLine.DragonFruit.Tests
             helpMetadata.ParameterDescriptions["verbose"].Should().Be("Show verbose output");
             helpMetadata.ParameterDescriptions["flavor"].Should().Be("Which flavor to use");
             helpMetadata.ParameterDescriptions["count"].Should().Be("How many smoothies?");
+            helpMetadata.ParameterAliases["verbose"].Should().Be("v");
         }
     }
 }

--- a/src/System.CommandLine.DragonFruit/CommandHelpMetadata.cs
+++ b/src/System.CommandLine.DragonFruit/CommandHelpMetadata.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -12,5 +12,6 @@ namespace System.CommandLine.DragonFruit
         public string Name { get; set; }
 
         public Dictionary<string, string> ParameterDescriptions { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> ParameterAliases { get; } = new Dictionary<string, string>();
     }
 }

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -176,6 +176,10 @@ namespace System.CommandLine.DragonFruit
                         if (option != null)
                         {
                             option.Description = parameterDescription.Value;
+                            if (metadata.ParameterAliases.TryGetValue(parameterDescription.Key, out var alias))
+                            {
+                                option.AddAlias(BuildAlias(alias));
+                            }
                         }
                         else
                         {

--- a/src/System.CommandLine.DragonFruit/XmlDocReader.cs
+++ b/src/System.CommandLine.DragonFruit/XmlDocReader.cs
@@ -94,7 +94,14 @@ namespace System.CommandLine.DragonFruit
                         commandHelpMetadata.Description = element.Value?.Trim();
                         break;
                     case "param":
-                        commandHelpMetadata.ParameterDescriptions.Add(element.Attribute("name")?.Value, element.Value?.Trim());
+                        if (element.Attribute("name")?.Value is string paramName)
+                        {
+                            commandHelpMetadata.ParameterDescriptions.Add(paramName, element.Value?.Trim());
+                            if (element.Attribute("alias")?.Value is string alias)
+                            {
+                                commandHelpMetadata.ParameterAliases.Add(paramName, alias);
+                            }
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
There is currently no way (at least that I can see) to add aliases when using the DragonFruit API.

This change lets you add an `alias` attribute to the `param` tags in your XML doc comments to set an alias for the parameter. It seemed like a non-invasive way of introducing the functionality, as opposed to, say, creating an `AliasAttribute` for parameters.

Example usage:
```csharp
    class Program
    {
        /// <summary>
        /// DragonFruit simple example program
        /// </summary>
        /// <param name="verbose" alias="v">Show verbose output</param>
        /// <param name="flavor" alias="f">Which flavor to use</param>
        /// <param name="count" alias="c">How many smoothies?</param>
        static int Main(
            bool verbose,
            string flavor = "chocolate",
            int count = 1)
        {
            if (verbose)
            {
                Console.WriteLine("Running in verbose mode");
            }
            Console.WriteLine($"Creating {count} banana {(count == 1 ? "smoothie" : "smoothies")} with {flavor}");
            return 0;
        }
    }
```

Help output:

```
$ dotnet run -- --help
DragonFruit:
  DragonFruit simple example program

Usage:
  DragonFruit [options]

Options:
  -v, --verbose            Show verbose output
  -f, --flavor <flavor>    Which flavor to use
  -c, --count <count>      How many smoothies?
  --version                Display version information
```

Oh, and I updated the SDK version in global.json because `2.2.204` just came out and I've uninstalled `2.2.203`.