### PR TITLE
Add support for making an argument optional in DragonFruit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,12 +52,3 @@ macOS/Linux:
 
     $ ./build.sh --test
 
-To run tests without compiling,
-
-Windows:
-
-    > .\test.cmd
-
-macOS/Linux
-
-    $ ./test.sh

--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -68,8 +68,12 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Theory]
+        [InlineData(nameof(Method_having_string_argument), 1, 1)]
+        [InlineData(nameof(Method_having_string_argument_with_default_value), 0, 1)]
         [InlineData(nameof(Method_having_string_array_arguments), 0, byte.MaxValue)]
+        [InlineData(nameof(Method_having_string_array_arguments_with_default_value), 0, byte.MaxValue)]
         [InlineData(nameof(Method_having_FileInfo_argument), 1, 1)]
+        [InlineData(nameof(Method_having_FileInfo_argument_with_default_value), 0, 1)]
         [InlineData(nameof(Method_having_FileInfo_array_args), 0, byte.MaxValue)]
         public void Parameters_named_arguments_generate_command_arguments_having_the_correct_arity(
             string methodName,
@@ -88,8 +92,12 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Theory]
+        [InlineData(nameof(Method_having_string_argument), "argument")]
+        [InlineData(nameof(Method_having_string_argument_with_default_value), "argument")]
         [InlineData(nameof(Method_having_string_array_arguments), "arguments")]
+        [InlineData(nameof(Method_having_string_array_arguments_with_default_value), "arguments")]
         [InlineData(nameof(Method_having_FileInfo_argument), "argument")]
+        [InlineData(nameof(Method_having_FileInfo_argument_with_default_value), "argument")]
         [InlineData(nameof(Method_having_FileInfo_array_args), "args")]
         public void Parameters_named_arguments_generate_command_arguments_having_the_correct_name(string methodName, string expectedArgName)
         {
@@ -105,8 +113,12 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Theory]
+        [InlineData(nameof(Method_having_string_argument))]
+        [InlineData(nameof(Method_having_string_argument_with_default_value))]
         [InlineData(nameof(Method_having_string_array_arguments))]
+        [InlineData(nameof(Method_having_string_array_arguments_with_default_value))]
         [InlineData(nameof(Method_having_FileInfo_argument))]
+        [InlineData(nameof(Method_having_FileInfo_argument_with_default_value))]
         [InlineData(nameof(Method_having_FileInfo_array_args))]
         public void Options_are_not_generated_for_command_argument_parameters(string methodName)
         {
@@ -129,8 +141,12 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Theory]
+        [InlineData(nameof(Method_having_string_argument), typeof(string))]
+        [InlineData(nameof(Method_having_string_argument_with_default_value), typeof(string))]
         [InlineData(nameof(Method_having_string_array_arguments), typeof(string[]))]
+        [InlineData(nameof(Method_having_string_array_arguments_with_default_value), typeof(string[]))]
         [InlineData(nameof(Method_having_FileInfo_argument), typeof(FileInfo))]
+        [InlineData(nameof(Method_having_FileInfo_argument_with_default_value), typeof(FileInfo))]
         [InlineData(nameof(Method_having_FileInfo_array_args), typeof(FileInfo[]))]
         public void Parameters_named_arguments_generate_command_arguments_having_the_correct_type(
             string methodName,
@@ -231,13 +247,30 @@ namespace System.CommandLine.DragonFruit.Tests
             return i;
         }
 
+        internal void Method_having_string_argument(string stringOption, int intOption, string argument)
+        {
+        }
+
+        internal void Method_having_string_argument_with_default_value(string stringOption, int intOption, string argument = null)
+        {
+        }
+
         internal void Method_having_string_array_arguments(string stringOption, int intOption, string[] arguments)
+        {
+        }
+
+        internal void Method_having_string_array_arguments_with_default_value(string stringOption, int intOption, string[] arguments = null)
         {
         }
 
         internal void Method_having_FileInfo_argument(string stringOption, int intOption, FileInfo argument)
         {
         }
+
+        internal void Method_having_FileInfo_argument_with_default_value(string stringOption, int intOption, FileInfo argument = null)
+        {
+        }
+
         internal void Method_having_FileInfo_array_args(string stringOption, int intOption, FileInfo[] args)
         {
         }

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -133,11 +133,18 @@ namespace System.CommandLine.DragonFruit
             if (method.GetParameters()
                       .FirstOrDefault(p => _argumentParameterNames.Contains(p.Name)) is ParameterInfo argsParam)
             {
-                command.AddArgument(new Argument
+                var argument = new Argument
                 {
                     ArgumentType = argsParam.ParameterType,
                     Name = argsParam.Name
-                });
+                };
+
+                if (argsParam.HasDefaultValue)
+                {
+                    argument.SetDefaultValue(argsParam.DefaultValue);
+                }
+
+                command.AddArgument(argument);
             }
 
             command.Handler = CommandHandler.Create(method);

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine
                 {
                     if (ArgumentType != null)
                     {
-                        return ArgumentArity.Default(ArgumentType, Parent);
+                        return ArgumentArity.Default(ArgumentType, this, Parent);
                     }
                     else
                     {

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -78,7 +78,7 @@ namespace System.CommandLine
 
         public static IArgumentArity OneOrMore => new ArgumentArity(1, byte.MaxValue);
 
-        internal static IArgumentArity Default(Type type, ISymbol symbol)
+        internal static IArgumentArity Default(Type type, Argument argument, ISymbol symbol)
         {
             if (typeof(IEnumerable).IsAssignableFrom(type) &&
                 type != typeof(string))
@@ -95,6 +95,12 @@ namespace System.CommandLine
 
             if (symbol is ICommand &&
                 type.IsNullable())
+            {
+                return ZeroOrOne;
+            }
+
+            if (symbol is ICommand &&
+                argument.HasDefaultValue)
             {
                 return ZeroOrOne;
             }


### PR DESCRIPTION
Change the argument aritys from:

    static void Main(string argument = null) // ExactlyOne

To:

    static void Main(string argument = null) // ZeroOrOne

Fixes #524