### PR TITLE
CommandHandler.Create() to handle more than 7 parameters.

### DIFF
--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// WARINING: Generated code.
 
 using System.CommandLine.Binding;
 using System.Reflection;
@@ -15,8 +17,8 @@ namespace System.CommandLine.Invocation
         public static ICommandHandler Create(Action action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
-        public static ICommandHandler Create<T>(
-            Action<T> action) =>
+        public static ICommandHandler Create<T1>(
+            Action<T1> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2>(
@@ -43,11 +45,48 @@ namespace System.CommandLine.Invocation
             Action<T1, T2, T3, T4, T5, T6, T7> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+
         public static ICommandHandler Create(Func<int> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
-        public static ICommandHandler Create<T>(
-            Func<T, int> action) =>
+        public static ICommandHandler Create<T1>(
+            Func<T1, int> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2>(
@@ -74,11 +113,48 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, int> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+
         public static ICommandHandler Create(Func<Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
-        public static ICommandHandler Create<T>(
-            Func<T, Task> action) =>
+        public static ICommandHandler Create<T1>(
+            Func<T1, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2>(
@@ -105,11 +181,49 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+
+
         public static ICommandHandler Create(Func<Task<int>> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
-        public static ICommandHandler Create<T>(
-            Func<T, Task<int>> action) =>
+        public static ICommandHandler Create<T1>(
+            Func<T1, Task<int>> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2>(
@@ -135,6 +249,43 @@ namespace System.CommandLine.Invocation
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
             Func<T1, T2, T3, T4, T5, T6, T7, Task<int>> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
 
         internal static async Task<int> GetResultCodeAsync(object value, InvocationContext context)
         {

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -16,209 +16,25 @@ namespace System.CommandLine.Invocation
         public static ICommandHandler Create(Action action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
+        public static ICommandHandler Create(Func<int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create(Func<Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create(Func<Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
         public static ICommandHandler Create<T1>(
             Action<T1> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2>(
-            Action<T1, T2> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3>(
-            Action<T1, T2, T3> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4>(
-            Action<T1, T2, T3, T4> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
-            Action<T1, T2, T3, T4, T5> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
-            Action<T1, T2, T3, T4, T5, T6> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
-            Action<T1, T2, T3, T4, T5, T6, T7> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-
-        public static ICommandHandler Create(Func<int> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1>(
             Func<T1, int> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
-        public static ICommandHandler Create<T1, T2>(
-            Func<T1, T2, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3>(
-            Func<T1, T2, T3, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4>(
-            Func<T1, T2, T3, T4, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
-            Func<T1, T2, T3, T4, T5, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
-            Func<T1, T2, T3, T4, T5, T6, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
-            Func<T1, T2, T3, T4, T5, T6, T7, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-
-        public static ICommandHandler Create(Func<Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
         public static ICommandHandler Create<T1>(
             Func<T1, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2>(
-            Func<T1, T2, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3>(
-            Func<T1, T2, T3, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4>(
-            Func<T1, T2, T3, T4, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
-            Func<T1, T2, T3, T4, T5, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
-            Func<T1, T2, T3, T4, T5, T6, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
-            Func<T1, T2, T3, T4, T5, T6, T7, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-
-
-        public static ICommandHandler Create(Func<Task<int>> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1>(
@@ -226,7 +42,31 @@ namespace System.CommandLine.Invocation
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2>(
+            Action<T1, T2> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2>(
+            Func<T1, T2, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2>(
+            Func<T1, T2, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2>(
             Func<T1, T2, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3>(
+            Action<T1, T2, T3> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3>(
+            Func<T1, T2, T3, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3>(
+            Func<T1, T2, T3, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3>(
@@ -234,7 +74,31 @@ namespace System.CommandLine.Invocation
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4>(
+            Action<T1, T2, T3, T4> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4>(
+            Func<T1, T2, T3, T4, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4>(
+            Func<T1, T2, T3, T4, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4>(
             Func<T1, T2, T3, T4, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
+            Action<T1, T2, T3, T4, T5> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
+            Func<T1, T2, T3, T4, T5, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
+            Func<T1, T2, T3, T4, T5, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5>(
@@ -242,7 +106,31 @@ namespace System.CommandLine.Invocation
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
+            Action<T1, T2, T3, T4, T5, T6> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
+            Func<T1, T2, T3, T4, T5, T6, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
+            Func<T1, T2, T3, T4, T5, T6, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
             Func<T1, T2, T3, T4, T5, T6, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
+            Action<T1, T2, T3, T4, T5, T6, T7> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
+            Func<T1, T2, T3, T4, T5, T6, T7, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
+            Func<T1, T2, T3, T4, T5, T6, T7, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
@@ -250,7 +138,31 @@ namespace System.CommandLine.Invocation
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
@@ -258,7 +170,31 @@ namespace System.CommandLine.Invocation
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
@@ -266,7 +202,31 @@ namespace System.CommandLine.Invocation
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
@@ -274,7 +234,31 @@ namespace System.CommandLine.Invocation
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
@@ -282,9 +266,20 @@ namespace System.CommandLine.Invocation
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task<int>> action) =>
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
         internal static async Task<int> GetResultCodeAsync(object value, InvocationContext context)
         {

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -1,5 +1,4 @@
-﻿
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // WARINING: Generated code.
 

--- a/src/System.CommandLine/Invocation/CommandHandler.tt
+++ b/src/System.CommandLine/Invocation/CommandHandler.tt
@@ -4,7 +4,6 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
-
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // WARINING: Generated code.

--- a/src/System.CommandLine/Invocation/CommandHandler.tt
+++ b/src/System.CommandLine/Invocation/CommandHandler.tt
@@ -1,8 +1,4 @@
 ﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ import namespace="System.Linq" #>
-<#@ import namespace="System.Text" #>
-<#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -22,63 +18,11 @@ namespace System.CommandLine.Invocation
         public static ICommandHandler Create(Action action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
-<#
-       for (var i = 1; i < 17; i++)
-       {
-          var ts = "T1";
-          for (var j = 2; j <= i; j++)
-          {
-            ts = $"{ts}, T{j}";
-          }
-#>
-        public static ICommandHandler Create<<#= ts #>>(
-            Action<<#= ts #>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-<#
-       }
-#>
-
         public static ICommandHandler Create(Func<int> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
-<#
-       for (var i = 1; i < 17; i++)
-       {
-          var ts = "T1";
-          for (var j = 2; j <= i; j++)
-          {
-            ts = $"{ts}, T{j}";
-          }
-#>
-        public static ICommandHandler Create<<#= ts #>>(
-            Func<<#= ts #>, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-<#
-       }
-#>
-
         public static ICommandHandler Create(Func<Task> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-<#
-       for (var i = 1; i < 17; i++)
-       {
-          var ts = "T1";
-          for (var j = 2; j <= i; j++)
-          {
-            ts = $"{ts}, T{j}";
-          }
-#>
-        public static ICommandHandler Create<<#= ts #>>(
-            Func<<#= ts #>, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-<#
-       }
-#>
-
 
         public static ICommandHandler Create(Func<Task<int>> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
@@ -93,13 +37,24 @@ namespace System.CommandLine.Invocation
           }
 #>
         public static ICommandHandler Create<<#= ts #>>(
+            Action<<#= ts #>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<<#= ts #>>(
+            Func<<#= ts #>, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<<#= ts #>>(
+            Func<<#= ts #>, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<<#= ts #>>(
             Func<<#= ts #>, Task<int>> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
 <#
        }
 #>
-
         internal static async Task<int> GetResultCodeAsync(object value, InvocationContext context)
         {
             switch (value)

--- a/src/System.CommandLine/Invocation/CommandHandler.tt
+++ b/src/System.CommandLine/Invocation/CommandHandler.tt
@@ -1,0 +1,122 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// WARINING: Generated code.
+
+using System.CommandLine.Binding;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace System.CommandLine.Invocation
+{
+    public static class CommandHandler
+    {
+        public static ICommandHandler Create(MethodInfo method) =>
+            HandlerDescriptor.FromMethodInfo(method).GetCommandHandler();
+
+        public static ICommandHandler Create(Action action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+<#
+       for (var i = 1; i < 17; i++)
+       {
+          var ts = "T1";
+          for (var j = 2; j <= i; j++)
+          {
+            ts = $"{ts}, T{j}";
+          }
+#>
+        public static ICommandHandler Create<<#= ts #>>(
+            Action<<#= ts #>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+<#
+       }
+#>
+
+        public static ICommandHandler Create(Func<int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+<#
+       for (var i = 1; i < 17; i++)
+       {
+          var ts = "T1";
+          for (var j = 2; j <= i; j++)
+          {
+            ts = $"{ts}, T{j}";
+          }
+#>
+        public static ICommandHandler Create<<#= ts #>>(
+            Func<<#= ts #>, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+<#
+       }
+#>
+
+        public static ICommandHandler Create(Func<Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+<#
+       for (var i = 1; i < 17; i++)
+       {
+          var ts = "T1";
+          for (var j = 2; j <= i; j++)
+          {
+            ts = $"{ts}, T{j}";
+          }
+#>
+        public static ICommandHandler Create<<#= ts #>>(
+            Func<<#= ts #>, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+<#
+       }
+#>
+
+
+        public static ICommandHandler Create(Func<Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+<#
+       for (var i = 1; i < 17; i++)
+       {
+          var ts = "T1";
+          for (var j = 2; j <= i; j++)
+          {
+            ts = $"{ts}, T{j}";
+          }
+#>
+        public static ICommandHandler Create<<#= ts #>>(
+            Func<<#= ts #>, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+<#
+       }
+#>
+
+        internal static async Task<int> GetResultCodeAsync(object value, InvocationContext context)
+        {
+            switch (value)
+            {
+                case Task<int> resultCodeTask:
+                    return await resultCodeTask;
+                case Task task:
+                    await task;
+                    return context.ResultCode;
+                case int resultCode:
+                    return resultCode;
+                case null:
+                    return context.ResultCode;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -15,4 +15,23 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Invocation\CommandHandler.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>CommandHandler.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Invocation\CommandHandler.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CommandHandler.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
CommandHandler.Create() to handle more than 7 parameters.

Issue #458