### PR TITLE
add support for reusing options and arguments in multiple positions

### DIFF
--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -334,7 +334,7 @@ namespace System.CommandLine.Tests.Binding
                     .Which
                     .Message
                     .Should()
-                    .Be(ValidationMessages.Instance.RequiredArgumentMissing(new OptionResult(option, new Token("-x", TokenType.Option))));
+                    .Be("Required argument missing for option: -x");
         }
 
         [Fact]
@@ -416,7 +416,7 @@ namespace System.CommandLine.Tests.Binding
                     .Which
                     .Message
                     .Should()
-                    .Be(ValidationMessages.Instance.RequiredArgumentMissing(new OptionResult(option, new Token("-x", TokenType.Option))));
+                    .Be("Required argument missing for option: -x");
         }
 
         [Fact]
@@ -458,9 +458,9 @@ namespace System.CommandLine.Tests.Binding
         }
 
         [Fact]
-        public void The_default_value_of_a_command_with_no_arguments_is_an_empty_collection()
+        public void The_default_value_of_a_command_with_no_arguments_is_null()
         {
-            var result = new CommandResult(new Command("-x"), new Token("-x", TokenType.Command));
+            var result = new Command("x").Parse("").CommandResult;
 
             var valueOrDefault = result.GetValueOrDefault();
 
@@ -497,11 +497,22 @@ namespace System.CommandLine.Tests.Binding
         }
 
         [Fact]
-        public void The_default_value_of_an_option_with_no_arguments_is_true()
+        public void The_default_value_of_an_option_with_no_arguments_is_null()
         {
-            var command = new OptionResult(new Option("-x"), new Token("-x", TokenType.Option));
+            var option = new Option("-x");
 
-            command.GetValueOrDefault().Should().Be(null);
+            var command =
+                new Command("the-command")
+                {
+                    option
+                };
+
+            var result = command.Parse("-x");
+
+            result.FindResultFor(option)
+                  .GetValueOrDefault()
+                  .Should()
+                  .BeNull();
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ParserTests.MultiplePositions.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultiplePositions.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Invocation;
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public partial class ParserTests
+    {
+        public class MultiplePositions
+        {
+            [Theory]
+            [InlineData("outer xyz")]
+            [InlineData("outer inner xyz")]
+            public void An_argument_can_be_specified_in_more_than_one_position(string commandLine)
+            {
+                var argument = new Argument<string>
+                {
+                    Name = "the-argument"
+                };
+
+                var command = new Command("outer")
+                {
+                    new Command("inner")
+                    {
+                        argument
+                    },
+                    argument
+                };
+
+                var parseResult = command.Parse(commandLine);
+
+                var argumentResult = parseResult.FindResultFor(argument);
+
+                argumentResult.Should().NotBeNull();
+
+                argumentResult
+                    .GetValueOrDefault<string>()
+                    .Should()
+                    .Be("xyz");
+            }
+
+            [Theory]
+            [InlineData("outer xyz inner")]
+            [InlineData("outer inner xyz")]
+            public void When_an_argument_is_shared_between_an_outer_and_inner_command_then_specifying_in_one_does_not_result_in_error_on_other(string commandLine)
+            {
+                var argument = new Argument<string>
+                {
+                    Name = "the-argument"
+                };
+
+                var command = new Command("outer")
+                {
+                    new Command("inner")
+                    {
+                        argument
+                    },
+                    argument
+                };
+
+                var parseResult = command.Parse(commandLine);
+
+                parseResult.Errors.Should().BeEmpty();
+            }
+
+            [Theory]
+            [InlineData("outer --the-option xyz")]
+            [InlineData("outer inner --the-option xyz")]
+            public void An_option_can_be_specified_in_more_than_one_position(string commandLine)
+            {
+                var option = new Option("--the-option")
+                {
+                    Argument = new Argument<string>()
+                };
+
+                var command = new Command("outer")
+                {
+                    new Command("inner")
+                    {
+                        option
+                    },
+                    option
+                };
+
+                var parseResult = command.Parse(commandLine);
+
+                var optionResult = parseResult.FindResultFor(option);
+
+                optionResult.Should().NotBeNull();
+
+                optionResult
+                    .GetValueOrDefault<string>()
+                    .Should()
+                    .Be("xyz");
+            }
+
+            [Theory]
+            [InlineData("outer --the-option xyz inner")]
+            [InlineData("outer inner --the-option xyz")]
+            public void When_an_option_is_shared_between_an_outer_and_inner_command_then_specifying_in_one_does_not_result_in_error_on_other(string commandLine)
+            {
+                var option = new Option("--the-option")
+                {
+                    Argument = new Argument<string>()
+                };
+
+                var command = new Command("outer")
+                {
+                    new Command("inner")
+                    {
+                        option
+                    },
+                    option
+                };
+
+                var parseResult = command.Parse(commandLine);
+
+                parseResult.Errors.Should().BeEmpty();
+            }
+
+            [Theory]
+            [InlineData("outer inner1 reused --the-option 123", "inner1")]
+            [InlineData("outer inner2 reused --the-option 456", "inner2")]
+            public void A_command_can_be_specified_in_more_than_one_position(
+                string commandLine,
+                string expectedParent)
+            {
+                var reusedCommand = new Command("reused")
+                {
+                    Handler = CommandHandler.Create(() =>
+                    {
+                    })
+                };
+                reusedCommand.Add(new Option("--the-option")
+                {
+                    Argument = new Argument<string>()
+                });
+
+                var outer = new Command("outer")
+                {
+                    new Command("inner1")
+                    {
+                        reusedCommand
+                    },
+                    new Command("inner2")
+                    {
+                        reusedCommand
+                    }
+                };
+
+                var result = outer.Parse(commandLine);
+
+                result.Errors.Should().BeEmpty();
+                result.CommandResult.Parent.Name.Should().Be(expectedParent);
+            }
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/SymbolResultTests.cs
+++ b/src/System.CommandLine.Tests/SymbolResultTests.cs
@@ -16,7 +16,11 @@ namespace System.CommandLine.Tests
                 "",
                 new Argument<string>("default"));
 
-            var result = new OptionResult(option, new Token(option.Name, TokenType.Option));
+            var result = new RootCommand
+            {
+                option
+            }.Parse("-x")
+             .FindResultFor(option);
 
             result.Arguments.Should().BeEmpty();
         }
@@ -103,11 +107,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void ValueForOption_throws_with_empty_alias()
         {
-            var command = new Command("one", "");
+            var command = new Command("one");
 
-            var result = new CommandResult(command, new Token("one", TokenType.Command));
+            var result = command.Parse("");
 
-            Action action = () => {
+            Action action = () =>
+            {
                 result.ValueForOption<string>(string.Empty);
             };
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine
                 {
                     if (ArgumentType != null)
                     {
-                        return ArgumentArity.Default(ArgumentType, this, Parent);
+                        return ArgumentArity.Default(ArgumentType, this, Parents.FirstOrDefault());
                     }
                     else
                     {

--- a/src/System.CommandLine/ArgumentConverter.cs
+++ b/src/System.CommandLine/ArgumentConverter.cs
@@ -240,13 +240,13 @@ namespace System.CommandLine
             switch (conversionResult)
             {
                 case SuccessfulArgumentConversionResult successful when !type.IsInstanceOfType(successful.Value):
-                    return ArgumentConverter.ConvertObject(
+                    return ConvertObject(
                         conversionResult.Argument,
                         type,
                         successful.Value);
 
                 case NoArgumentConversionResult _ when type == typeof(bool):
-                    return ArgumentConversionResult.Success(conversionResult.Argument, true);
+                    return Success(conversionResult.Argument, true);
 
                 case NoArgumentConversionResult _ when conversionResult.Argument.Arity.MinimumNumberOfValues > 0:
                     return new MissingArgumentConversionResult(
@@ -254,7 +254,7 @@ namespace System.CommandLine
                         ValidationMessages.Instance.RequiredArgumentMissing(symbolResult));
 
                 case NoArgumentConversionResult _ when type.IsEnumerable():
-                    return ArgumentConverter.ConvertObject(
+                    return ConvertObject(
                         conversionResult.Argument,
                         type,
                         Array.Empty<string>());

--- a/src/System.CommandLine/ArgumentResult.cs
+++ b/src/System.CommandLine/ArgumentResult.cs
@@ -7,6 +7,8 @@ namespace System.CommandLine
 {
     public class ArgumentResult : SymbolResult
     {
+        private ArgumentConversionResult _conversionResult;
+
         internal ArgumentResult(
             IArgument argument,
             Token token,
@@ -16,6 +18,9 @@ namespace System.CommandLine
         }
 
         public IArgument Argument { get; }
+
+        internal override ArgumentConversionResult ArgumentConversionResult =>
+            _conversionResult ??= Convert(this, Argument);
 
         public override string ToString() => $"{GetType().Name} {Argument.Name}: {string.Join(" ", Tokens.Select(t => $"<{t.Value}>"))}";
     }

--- a/src/System.CommandLine/ArgumentResultExtensions.cs
+++ b/src/System.CommandLine/ArgumentResultExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine
+{
+    public static class ArgumentResultExtensions
+    {
+        public static object GetValueOrDefault(this ArgumentResult argumentResult) => 
+            argumentResult.GetValueOrDefault<object>();
+
+        public static T GetValueOrDefault<T>(this ArgumentResult argumentResult) =>
+            argumentResult
+                .ArgumentConversionResult
+                .ConvertIfNeeded(argumentResult, typeof(T))
+                .GetValueOrDefault<T>();
+    }
+}

--- a/src/System.CommandLine/CommandResult.cs
+++ b/src/System.CommandLine/CommandResult.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine
 {
     public class CommandResult : SymbolResult
     {
-        public CommandResult(
+        internal CommandResult(
             ICommand command,
             Token token,
             CommandResult parent = null) :
@@ -28,6 +28,8 @@ namespace System.CommandLine
         {
             return Children[alias] as OptionResult;
         }
+
+        internal virtual RootCommandResult Root => ParentCommandResult.Root;
 
         internal bool TryGetValueForArgument(
             IValueDescriptor valueDescriptor,

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -375,9 +375,25 @@ namespace System.CommandLine
         {
             var usage = new List<string>();
 
-            var subcommands = command
-                .RecurseWhileNotNull(c => c.Parent as ICommand)
-                .Reverse();
+            IEnumerable<ICommand> subcommands;
+
+            if (command is Command cmd)
+            {
+                subcommands = cmd
+                              .RecurseWhileNotNull(c =>
+                              {
+                                  var firstOrDefault = c.Parents
+                                                        .OfType<Command>()
+                                                        .FirstOrDefault();
+
+                                  return firstOrDefault ;
+                              })
+                              .Reverse();
+            }
+            else
+            {
+                subcommands = Enumerable.Empty<ICommand>();
+            }
 
             foreach (var subcommand in subcommands)
             {
@@ -437,7 +453,8 @@ namespace System.CommandLine
         {
             var commands = new List<ICommand>();
 
-            if (command.Parent is ICommand parent &&
+            if (command is Command cmd &&
+                cmd.Parents.FirstOrDefault() is ICommand parent &&
                 ShouldDisplayArgumentHelp(parent))
             {
                 commands.Add(parent);

--- a/src/System.CommandLine/ISymbol.cs
+++ b/src/System.CommandLine/ISymbol.cs
@@ -15,8 +15,6 @@ namespace System.CommandLine
 
         IReadOnlyCollection<string> RawAliases { get; }
 
-        ISymbol Parent { get; }
-
         bool HasAlias(string alias);
 
         bool HasRawAlias(string alias);

--- a/src/System.CommandLine/OptionResult.cs
+++ b/src/System.CommandLine/OptionResult.cs
@@ -7,7 +7,7 @@ namespace System.CommandLine
 {
     public class OptionResult : SymbolResult
     {
-        public OptionResult(
+        internal OptionResult(
             IOption option,
             Token token,
             CommandResult parent = null) :

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -9,10 +9,11 @@ namespace System.CommandLine
     public class ParseResult
     {
         private readonly List<ParseError> _errors;
+        private readonly RootCommandResult _rootCommandResult;
 
         internal ParseResult(
             Parser parser,
-            CommandResult rootCommandResult,
+            RootCommandResult rootCommandResult,
             CommandResult commandResult,
             IDirectiveCollection directives,
             TokenizeResult tokenizeResult,
@@ -22,7 +23,7 @@ namespace System.CommandLine
             string rawInput = null)
         {
             Parser = parser;
-            RootCommandResult = rootCommandResult;
+            _rootCommandResult = rootCommandResult;
             CommandResult = commandResult;
             Directives = directives;
 
@@ -48,7 +49,7 @@ namespace System.CommandLine
 
         public Parser Parser { get; }
 
-        public CommandResult RootCommandResult { get; }
+        public CommandResult RootCommandResult => _rootCommandResult;
 
         public IReadOnlyCollection<ParseError> Errors => _errors;
 
@@ -88,10 +89,13 @@ namespace System.CommandLine
 
         public override string ToString() => $"{nameof(ParseResult)}: {this.Diagram()}";
 
+        public ArgumentResult FindResultFor(IArgument argument) =>
+            _rootCommandResult.FindResultFor(argument);
+            
+        public CommandResult FindResultFor(ICommand command) =>
+            _rootCommandResult.FindResultFor(command);
+
         public OptionResult FindResultFor(IOption option) =>
-            RootCommandResult
-                .AllSymbolResults()
-                .OfType<OptionResult>()
-                .FirstOrDefault(s => s.Symbol == option);
+            _rootCommandResult.FindResultFor(option);
     }
 }

--- a/src/System.CommandLine/ParseResultExtensions.cs
+++ b/src/System.CommandLine/ParseResultExtensions.cs
@@ -187,20 +187,21 @@ namespace System.CommandLine
                     : Array.Empty<string>();
 
             IEnumerable<string> siblingSuggestions;
+            var parentSymbol = currentSymbolResult.Parent?.Symbol;
 
-            if (currentSymbol.Parent == null ||
+            if (parentSymbol == null ||
                 !currentSymbolResult.IsArgumentLimitReached)
             {
                 siblingSuggestions = Array.Empty<string>();
             }
             else
             {
-                siblingSuggestions = currentSymbol.Parent
-                                                  .Suggest(textToMatch)
-                                                  .Except(currentSymbol.Parent
-                                                                       .Children
-                                                                       .OfType<ICommand>()
-                                                                       .Select(c => c.Name));
+                siblingSuggestions = parentSymbol
+                                     .Suggest(textToMatch)
+                                     .Except(parentSymbol
+                                             .Children
+                                             .OfType<ICommand>()
+                                             .Select(c => c.Name));
             }
 
             if (currentSymbolResult is CommandResult commandResult)

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -17,7 +17,7 @@ namespace System.CommandLine.Parsing
         private readonly List<string> _unmatchedTokens;
         private readonly List<ParseError> _errors;
 
-        private CommandResult _rootCommandResult;
+        private RootCommandResult _rootCommandResult;
         private CommandResult _innermostCommandResult;
 
         public ParseResultVisitor(
@@ -51,7 +51,7 @@ namespace System.CommandLine.Parsing
 
         protected override void VisitRootCommandNode(RootCommandNode rootCommandNode)
         {
-            _rootCommandResult = new CommandResult(
+            _rootCommandResult = new RootCommandResult(
                 rootCommandNode.Command,
                 rootCommandNode.Token);
             _rootCommandResult.ValidationMessages = _parser.Configuration.ValidationMessages;
@@ -272,11 +272,11 @@ namespace System.CommandLine.Parsing
                 }
             }
 
-            if (SymbolResult.Parse(argumentResult, argumentResult.Argument) is FailedArgumentConversionResult failed)
+            if (argumentResult.ArgumentConversionResult is FailedArgumentConversionResult failed)
             {
                 _errors.Add(
                     new ParseError(
-                        failed.ErrorMessage, 
+                        failed.ErrorMessage,
                         argumentResult));
             }
         }

--- a/src/System.CommandLine/RootCommandResult.cs
+++ b/src/System.CommandLine/RootCommandResult.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace System.CommandLine
+{
+    internal class RootCommandResult : CommandResult
+    {
+        private Dictionary<IArgument, ArgumentResult> _allArgumentResults;
+        private Dictionary<ICommand, CommandResult> _allCommandResults;
+        private Dictionary<IOption, OptionResult> _allOptionResults;
+
+        public RootCommandResult(
+            ICommand command,
+            Token token) : base(command, token)
+        {
+        }
+
+        internal override RootCommandResult Root => this;
+
+        private void EnsureResultMapsAreInitialized()
+        {
+            if (_allArgumentResults != null)
+            {
+                return;
+            }
+
+            _allArgumentResults = new Dictionary<IArgument, ArgumentResult>();
+            _allCommandResults = new Dictionary<ICommand, CommandResult>();
+            _allOptionResults = new Dictionary<IOption, OptionResult>();
+
+            foreach (var symbolResult in this.AllSymbolResults())
+            {
+                switch (symbolResult)
+                {
+                    case ArgumentResult argumentResult:
+                        _allArgumentResults.Add(argumentResult.Argument, argumentResult);
+                        break;
+                    case CommandResult commandResult:
+                        _allCommandResults.Add(commandResult.Command, commandResult);
+                        break;
+                    case OptionResult optionResult:
+                        _allOptionResults.Add(optionResult.Option, optionResult);
+                        break;
+                }
+            }
+        }
+
+        public ArgumentResult FindResultFor(IArgument argument)
+        {
+            EnsureResultMapsAreInitialized();
+
+            _allArgumentResults.TryGetValue(argument, out var result);
+
+            return result;
+        }
+
+        public CommandResult FindResultFor(ICommand command)
+        {
+            EnsureResultMapsAreInitialized();
+
+            _allCommandResults.TryGetValue(command, out var result);
+
+            return result;
+        }
+
+        public OptionResult FindResultFor(IOption option)
+        {
+            EnsureResultMapsAreInitialized();
+
+            _allOptionResults.TryGetValue(option, out var result);
+
+            return result;
+        }
+    }
+}

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine
         private string _longestAlias = "";
         private string _specifiedName;
         private protected readonly ArgumentSet _arguments = new ArgumentSet();
-        private List<Symbol> _parents = new List<Symbol>();
+        private readonly List<Symbol> _parents = new List<Symbol>();
 
         private protected Symbol()
         {

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine
         private string _longestAlias = "";
         private string _specifiedName;
         private protected readonly ArgumentSet _arguments = new ArgumentSet();
-        private Symbol _parent;
+        private List<Symbol> _parents = new List<Symbol>();
 
         private protected Symbol()
         {
@@ -75,17 +75,18 @@ namespace System.CommandLine
             }
         }
 
-        public Symbol Parent
+        internal IReadOnlyList<Symbol> Parents => _parents; 
+
+        private protected void AddParent(Symbol symbol)
         {
-            get => _parent;
-            internal set => _parent = value ?? throw new ArgumentNullException(nameof(value));
+            _parents.Add(symbol);
         }
 
         private protected void AddSymbol(Symbol symbol)
         {
             if (this is Command command)
             {
-                symbol.Parent = command;
+                symbol.AddParent(command);
             }
 
             Children.Add(symbol);
@@ -98,7 +99,7 @@ namespace System.CommandLine
                 throw new ArgumentNullException(nameof(argument));
             }
 
-            argument.Parent = this;
+            argument.AddParent(this);
 
             if (string.IsNullOrEmpty(argument.Name))
             {
@@ -167,8 +168,6 @@ namespace System.CommandLine
         }
 
         public override string ToString() => $"{GetType().Name}: {Name}";
-
-        ISymbol ISymbol.Parent => Parent;
 
         ISymbolSet ISymbol.Children => Children;
     }

--- a/src/System.CommandLine/SymbolExtensions.cs
+++ b/src/System.CommandLine/SymbolExtensions.cs
@@ -14,18 +14,6 @@ namespace System.CommandLine
                 .Where(s => !s.IsHidden)
                 .SelectMany(s => s.RawAliases);
 
-        internal static bool ShouldShowHelp(this ISymbol symbol) =>
-            !symbol.IsHidden &&
-            (!String.IsNullOrWhiteSpace(symbol.Name) ||
-             !String.IsNullOrWhiteSpace(symbol.Description) ||
-             symbol.Arguments().Any(a => a.ShouldShowHelp()));
-
-        internal static bool ShouldShowHelp(
-            this IArgument argument) =>
-            argument != null &&
-            !String.IsNullOrWhiteSpace(argument.Name) &&
-            argument.Arity.MaximumNumberOfValues > 0;
-
         internal static IReadOnlyCollection<IArgument> Arguments(this ISymbol symbol)
         {
             switch (symbol)

--- a/src/System.CommandLine/SymbolResultExtensions.cs
+++ b/src/System.CommandLine/SymbolResultExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.CommandLine

--- a/src/System.CommandLine/SymbolResultSet.cs
+++ b/src/System.CommandLine/SymbolResultSet.cs
@@ -8,7 +8,7 @@ namespace System.CommandLine
 {
     public class SymbolResultSet : AliasedSet<SymbolResult>
     {
-        public SymbolResult ResultFor(ISymbol symbol) =>
+        internal SymbolResult ResultFor(ISymbol symbol) =>
             Items.SingleOrDefault(i => i.Symbol == symbol);
 
         protected override bool ContainsItemWithAlias(SymbolResult item, string alias) =>


### PR DESCRIPTION
This provides a possible solution to #530. It allows the same symbol to be added at multiple positions within the tree, e.g.

```cs
var argument = new Argument<string>
{
    Name = "the-argument"
};

var command = new Command("outer")
{
    new Command("inner")
    {
        argument
    },
    argument
};
```

This means that in all of these examples, `xyz` is parsed as argument `the-argument`:

```console
> outer xyz
> outer inner xyz
> outer xyz inner
```

For the purpose of retrieving the value (and model binding), the result is looked up using a reference to the symbol without having to know which command it was parsed under:

```cs
var argumentResult = parseResult.FindResultFor(argument);
```

This PR also includes some help improvements (addressing #543) to indicate optionality and arity in help output, e.g.:

```
<arg1> <arg2>         # two required args (arity a,a) and (arity b,b)
[<arg1> [<arg2>]]     # two non-required args (arity 0,1) and (arity 0,1)
[<arg1> [<arg2>...]]  # two non-required args (arity a,a) and (arity b,c)
```


There are a few potential issues to be sorted out here. 

* The following is also allowed but seems strange:

```cs
var argument = new Argument<string>
{
    Name = "the-argument"
};

var command = new Command("outer")
{
    new Command("inner")
    {
        new Option("-x")
        {
            Argument = argument
        }
    },
    argument
};
```

* The arity of an argument, when not specified or inferred from its type, is sometimes based on the parent, so that it will be (0,1) for command arguments and (1,1) for option arguments. This behavior should potentially be removed.










