### PR TITLE
Integrate CancellationToken from InvocationContext into UseHost method

### DIFF
--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -36,15 +36,17 @@ namespace System.CommandLine.Hosting
                 hostBuilder.UseConsoleLifetime();
                 configureHost?.Invoke(hostBuilder);
 
+                var invokeCancel = invocation.GetCancellationToken();
+
                 using (var host = hostBuilder.Build())
                 {
                     invocation.BindingContext.AddService(typeof(IHost), () => host);
 
-                    await host.StartAsync();
+                    await host.StartAsync(invokeCancel);
 
                     await next(invocation);
 
-                    await host.StopAsync();
+                    await host.StopAsync(invokeCancel);
                 }
             });
 

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -13,6 +13,14 @@ namespace System.CommandLine.Invocation
 
         public BindingContext BindingContext { get; }
 
+        public CancellationToken GetCancellationToken()
+        {
+            var obj = BindingContext.ServiceProvider.GetService(typeof(CancellationToken));
+            if (obj is CancellationToken ct)
+                return ct;
+            return CancellationToken.None;
+        }
+
         public InvocationContext(
             ParseResult parseResult,
             IConsole console = null)


### PR DESCRIPTION
Implementation of variant 2 of the 2<sup>nd</sup> approach described in issue #549.

* Add new instance method `InvokeContext.GetCancellationToken()` which resolves the `CancellationToken` from the service provider of the `BindingContext`.
* Resolve `CancellationToken` in `HostingExtensions.UseHost` to pass it to `host.StartAsync` and `host.StopAsync` to be able to forcefully shut down the application if needed.