### PR TITLE
Merge GetCancellationToken and AddCancellationHandling

### DIFF
--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -33,20 +33,20 @@ namespace System.CommandLine.Hosting
                     services.AddTransient(_ => invocation.InvocationResult);
                     services.AddTransient(_ => invocation.ParseResult);
                 });
-                hostBuilder.UseConsoleLifetime();
                 configureHost?.Invoke(hostBuilder);
-
-                var invokeCancel = invocation.GetCancellationToken();
 
                 using (var host = hostBuilder.Build())
                 {
                     invocation.BindingContext.AddService(typeof(IHost), () => host);
 
-                    await host.StartAsync(invokeCancel);
+                    // Stop the host when the invocation gets cancelled.
+                    var cancellationToken = invocation.AddCancellationHandling();
+
+                    await host.StartAsync(cancellationToken);
 
                     await next(invocation);
 
-                    await host.StopAsync(invokeCancel);
+                    await host.StopAsync(cancellationToken);
                 }
             });
 

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -41,14 +41,11 @@ namespace System.CommandLine.Hosting
                 {
                     invocation.BindingContext.AddService(typeof(IHost), () => host);
 
-                    // Stop the host when the invocation gets cancelled.
-                    var cancellationToken = invocation.GetCancellationToken();
-
-                    await host.StartAsync(cancellationToken);
+                    await host.StartAsync();
 
                     await next(invocation);
 
-                    await host.StopAsync(cancellationToken);
+                    await host.StopAsync();
                 }
             });
 

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -40,7 +40,7 @@ namespace System.CommandLine.Hosting
                     invocation.BindingContext.AddService(typeof(IHost), () => host);
 
                     // Stop the host when the invocation gets cancelled.
-                    var cancellationToken = invocation.AddCancellationHandling();
+                    var cancellationToken = invocation.GetCancellationToken();
 
                     await host.StartAsync(cancellationToken);
 

--- a/src/System.CommandLine.Hosting/InvocationLifetime.cs
+++ b/src/System.CommandLine.Hosting/InvocationLifetime.cs
@@ -1,0 +1,98 @@
+﻿using System.CommandLine.Invocation;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace System.CommandLine.Hosting
+{
+    public class InvocationLifetime : IHostLifetime
+    {
+        private readonly CancellationToken invokeCancelToken;
+        private CancellationTokenRegistration invokeCancelReg;
+        private CancellationTokenRegistration appStartedReg;
+        private CancellationTokenRegistration appStoppingReg;
+
+        public InvocationLifetime(
+            IOptions<InvocationLifetimeOptions> options,
+            IHostingEnvironment environment,
+            IApplicationLifetime applicationLifetime,
+            InvocationContext context = null,
+            ILoggerFactory loggerFactory = null)
+        {
+            Options = options?.Value ?? throw new ArgumentNullException(nameof(options));
+            Environment = environment
+                ?? throw new ArgumentNullException(nameof(environment));
+            ApplicationLifetime = applicationLifetime
+                ?? throw new ArgumentNullException(nameof(applicationLifetime));
+
+            // if InvocationLifetime is added outside of a System.CommandLine
+            // invocation pipeline context will be null.
+            // Use default cancellation token instead, and become a noop lifetime.
+            invokeCancelToken = context?.GetCancellationToken() ?? default;
+
+            Logger = (loggerFactory ?? NullLoggerFactory.Instance)
+                .CreateLogger("Microsoft.Hosting.Lifetime");
+        }
+
+        public InvocationLifetimeOptions Options { get; }
+        private ILogger Logger { get; }
+        public IHostingEnvironment Environment { get; }
+        public IApplicationLifetime ApplicationLifetime { get; }
+
+        public Task WaitForStartAsync(CancellationToken cancellationToken)
+        {
+            if (!Options.SuppressStatusMessages)
+            {
+                appStartedReg = ApplicationLifetime.ApplicationStarted.Register(state =>
+                {
+                    ((InvocationLifetime)state).OnApplicationStarted();
+                }, this);
+                appStoppingReg = ApplicationLifetime.ApplicationStopping.Register(state =>
+                {
+                    ((InvocationLifetime)state).OnApplicationStopping();
+                }, this);
+            }
+
+            invokeCancelReg = invokeCancelToken.Register(state =>
+            {
+                ((InvocationLifetime)state).OnInvocationCancelled();
+            }, this);
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            // There's nothing to do here
+            return Task.CompletedTask;
+        }
+
+        private void OnInvocationCancelled()
+        {
+            ApplicationLifetime.StopApplication();
+        }
+
+        private void OnApplicationStarted()
+        {
+            Logger.LogInformation("Application started. Press Ctrl+C to shut down.");
+            Logger.LogInformation("Hosting environment: {envName}", Environment.EnvironmentName);
+            Logger.LogInformation("Content root path: {contentRoot}", Environment.ContentRootPath);
+        }
+
+        private void OnApplicationStopping()
+        {
+            Logger.LogInformation("Application is shutting down...");
+        }
+
+        public void Dispose()
+        {
+            invokeCancelReg.Dispose();
+            appStartedReg.Dispose();
+            appStoppingReg.Dispose();
+        }
+    }
+}

--- a/src/System.CommandLine.Hosting/InvocationLifetimeOptions.cs
+++ b/src/System.CommandLine.Hosting/InvocationLifetimeOptions.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace System.CommandLine.Hosting
+{
+    public class InvocationLifetimeOptions : ConsoleLifetimeOptions
+    {
+    }
+}

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -13,14 +13,6 @@ namespace System.CommandLine.Invocation
 
         public BindingContext BindingContext { get; }
 
-        public CancellationToken GetCancellationToken()
-        {
-            var obj = BindingContext.ServiceProvider.GetService(typeof(CancellationToken));
-            if (obj is CancellationToken ct)
-                return ct;
-            return CancellationToken.None;
-        }
-
         public InvocationContext(
             ParseResult parseResult,
             IConsole console = null)
@@ -62,7 +54,7 @@ namespace System.CommandLine.Invocation
         /// Indicates the invocation can be cancelled.
         /// </summary>
         /// <returns>Token used by the caller to implement cancellation handling.</returns>
-        internal CancellationToken AddCancellationHandling()
+        public CancellationToken AddCancellationHandling()
         {
             if (_cts != null)
             {

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine.Invocation
             IConsole console = null)
         {
             BindingContext = new BindingContext(parseResult, console);
-            BindingContext.ServiceProvider.AddService(AddCancellationHandling);
+            BindingContext.ServiceProvider.AddService(GetCancellationToken);
             BindingContext.ServiceProvider.AddService(() => this);
         }
 
@@ -51,18 +51,17 @@ namespace System.CommandLine.Invocation
         }
 
         /// <summary>
-        /// Indicates the invocation can be cancelled.
+        /// Gets token to implement cancellation handling.
         /// </summary>
         /// <returns>Token used by the caller to implement cancellation handling.</returns>
-        public CancellationToken AddCancellationHandling()
+        public CancellationToken GetCancellationToken()
         {
-            if (_cts != null)
+            if (_cts == null)
             {
-                throw new InvalidOperationException("Cancellation handling was already added.");
+                _cts = new CancellationTokenSource();
+                _cancellationHandlingAddedEvent?.Invoke(_cts);
             }
 
-            _cts = new CancellationTokenSource();
-            _cancellationHandlingAddedEvent?.Invoke(_cts);
             return _cts.Token;
         }
 


### PR DESCRIPTION
These functions do the same thing.

@couven92 @jonsequitur 

`AddCancellationHandling` is the point where the InvocationContext becomes cancellable, that is: the invocation can be canceled because it is using the cancellation token.

```
        /// <summary>
        /// Indicates the invocation can be cancelled.
        /// </summary>
        /// <returns>Token used by the caller to implement cancellation handling.</returns>
```