### PR TITLE
simplify Command and Option constructors

### DIFF
--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_CustomScenarios.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_CustomScenarios.cs
@@ -19,12 +19,11 @@ namespace System.CommandLine.Benchmarks.CommandLine
         {
             var rootCommand = new Command("root_command");
             var nestedCommand = new Command("nested_command");
-            nestedCommand.AddOption(new Option("-opt1",
-                                               "description...",
-                                               new Argument<int>(defaultValue: 123)
-                                               {
-                                                   Arity = ArgumentArity.ExactlyOne
-                                               }));
+            var option = new Option("-opt1")
+            {
+                Argument = new Argument<int>(() => 123)
+            };
+            nestedCommand.AddOption(option);
             rootCommand.AddCommand(nestedCommand);
 
             _testParser = new Parser(rootCommand);

--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Directives_Suggest.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Directives_Suggest.cs
@@ -23,13 +23,19 @@ namespace System.CommandLine.Benchmarks.CommandLine
         {
             _nullConsole = new NullConsole();
 
-            var eatCommand = new Command("eat") {
-                new Option("--fruit",
-                    argument: new Argument<string>()
-                        .WithSuggestions("apple", "banana", "cherry")),
-                new Option("--vegetable",
-                    argument: new Argument<string>()
-                        .WithSuggestions("asparagus", "broccoli", "carrot")) };
+            var eatCommand = new Command("eat")
+            {
+                new Option("--fruit")
+                {
+                    Argument = new Argument<string>()
+                        .WithSuggestions("apple", "banana", "cherry")
+                },
+                new Option("--vegetable")
+                {
+                    Argument = new Argument<string>()
+                        .WithSuggestions("asparagus", "broccoli", "carrot")
+                }
+            };
 
             _testParser = new CommandLineBuilder(eatCommand)
                 .UseSuggestDirective()

--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Options_Bare.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Options_Bare.cs
@@ -19,11 +19,16 @@ namespace System.CommandLine.Benchmarks.CommandLine
 
         private IEnumerable<Option> GenerateTestOptions(int count, IArgumentArity arity)
             => Enumerable.Range(0, count)
-                         .Select(i => new Option(
-                             $"-option{i}",
-                             $"Description for -option {i} ....",
-                             new Argument { Arity = arity }
-                         ));
+                         .Select(i =>
+                                     new Option($"-option{i}")
+                                     {
+                                         Description = $"Description for -option {i} ....",
+                                         Argument = new Argument
+                                         {
+                                             Arity = arity
+                                         }
+                                     }
+                         );
 
         /// <remarks>
         /// count=1  : cmd-root -option0

--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Options_With_Arguments.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Options_With_Arguments.cs
@@ -18,11 +18,15 @@ namespace System.CommandLine.Benchmarks.CommandLine
 
         private IEnumerable<Option> GenerateTestOptions(int count, IArgumentArity arity)
             => Enumerable.Range(0, count)
-                         .Select(i => new Option(
-                             $"-option{i}",
-                             $"Description for -option {i} ....",
-                             new Argument { Arity = arity }
-                         ));
+                         .Select(i => new Option($"-option{i}")
+                             {
+                                 Description = $"Description for -option {i} ....",
+                                 Argument = new Argument
+                                 {
+                                     Arity = arity
+                                 }
+                             }
+                         );
 
         /// <remarks>
         /// For optionsCount: 5, argumentsCount: 5 will return:

--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Suggestions.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Suggestions.cs
@@ -37,11 +37,14 @@ namespace System.CommandLine.Benchmarks.CommandLine
         [GlobalSetup(Target = nameof(SuggestionsFromSymbol))]
         public void Setup_FromSymbol()
         {
-            _testSymbol = new Option(
-                "--hello",
-                "",
-                new Argument { Arity = ArgumentArity.ExactlyOne }
-                    .WithSuggestions(GenerateSuggestionsArray(TestSuggestionsCount)));
+            _testSymbol = new Option("--hello")
+            {
+                Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                    .WithSuggestions(GenerateSuggestionsArray(TestSuggestionsCount))
+            };
         }
 
         [Benchmark]

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -263,8 +263,10 @@ namespace System.CommandLine.DragonFruit
 
             var option = new Option(
                 parameter.BuildAlias(),
-                parameter.ValueName,
-                argument);
+                parameter.ValueName)
+            {
+                Argument = argument
+            };
 
             return option;
         }

--- a/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/Program.cs
+++ b/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/Program.cs
@@ -12,10 +12,22 @@ namespace EndToEndTestApp
         {
             var rootCommand = new RootCommand
             {
-                new Option("--apple", argument: new Argument<string>()),
-                new Option("--banana", argument: new Argument<string>()),
-                new Option("--cherry", argument: new Argument<string>()),
-                new Option("--durian", argument: new Argument<string>())
+                new Option("--apple" )
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--banana")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--cherry")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--durian")
+                {
+                    Argument = new Argument<string>()
+                }
             };
 
             rootCommand.Handler = CommandHandler.Create(typeof(Program).GetMethod(nameof(Run)));

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -36,63 +36,77 @@ namespace System.CommandLine.Suggest
                    
                       .Build();
 
-            Command GetCommand() =>
-                new Command("get",
-                            "Gets suggestions from the specified executable",
-                            new[] { ExecutableOption(), PositionOption() })
+            Command GetCommand()
+            {
+                var command = new Command("get")
                 {
-                    Handler = CommandHandler.Create<ParseResult, IConsole>(Get)
+                    ExecutableOption(),
+                    PositionOption()
                 };
+                command.Description = "Gets suggestions from the specified executable";
+                command.Handler = CommandHandler.Create<ParseResult, IConsole>(Get);
+                return command;
+            }
 
             Option ExecutableOption() =>
-                new Option(new[] { "-e", "--executable" },
-                           "The executable to call for suggestions",
-                           new Argument<string>().LegalFilePathsOnly());
+                new Option(new[] { "-e", "--executable" })
+                {
+                    Argument = new Argument<string>().LegalFilePathsOnly(), Description = "The executable to call for suggestions"
+                };
 
             Option PositionOption() =>
-                new Option(new[] { "-p", "--position" },
-                           "The current character position on the command line",
-                           new Argument<int>());
+                new Option(new[] { "-p", "--position" })
+                {
+                    Argument = new Argument<int>(),
+                    Description = "The current character position on the command line"
+                };
 
             Command ListCommand() =>
-                new Command(
-                    "list",
-                    "Lists apps registered for suggestions")
+                new Command("list")
                 {
+                    Description = "Lists apps registered for suggestions",
                     Handler = CommandHandler.Create<IConsole>(
                         c => c.Out.WriteLine(ShellPrefixesToMatch(_suggestionRegistration)))
                 };
 
             Command CompleteScriptCommand() =>
-                new Command(
-                    "script",
-                    "Print complete script for specific shell")
-                   
+                new Command("script")
                 {
                     Argument = new Argument<ShellType>
-                               {
-                                   Name = nameof(ShellType)
-                               },
+                    {
+                        Name = nameof(ShellType)
+                    },
+                    Description = "Print complete script for specific shell",
                     Handler = CommandHandler.Create<IConsole, ShellType>(SuggestionShellScriptHandler.Handle)
                 };
 
-            Command RegisterCommand() =>
-                new Command("register",
-                            "Registers an app for suggestions",
-                            new[] { CommandPathOption(), SuggestionCommandOption() })
+            Command RegisterCommand()
+            {
+                var description = "Registers an app for suggestions";
+
+                var command = new Command("register")
                 {
+                    Description = description,
                     Handler = CommandHandler.Create<string, string, IConsole>(Register)
                 };
+                command.Add(CommandPathOption());
+                command.Add(SuggestionCommandOption());
+                return command;
+            }
 
             Option CommandPathOption() =>
-                new Option("--command-path",
-                           "The path to the command for which to register suggestions",
-                           new Argument<string>());
+                new Option("--command-path")
+                {
+                    Argument = new Argument<string>(),
+                    Description = "The path to the command for which to register suggestions"
+                };
 
             Option SuggestionCommandOption() =>
-                new Option("--suggestion-command",
-                           "The command to invoke to retrieve suggestions",
-                           new Argument<string>());
+                new Option("--suggestion-command")
+                {
+                    Argument = new Argument<string>(),
+                    Description = "The command to invoke to retrieve suggestions"
+                };
         }
 
         public Parser Parser { get; }

--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -78,10 +78,10 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Explicitly_configured_default_values_can_be_bound_by_name_to_constructor_parameters()
         {
-            var argument = new Argument<string>("the default");
-
-            var option = new Option("--string-option",
-                                    argument: argument);
+            var option = new Option("--string-option")
+            {
+                Argument = new Argument<string>(() => "the default")
+            };
 
             var command = new Command("the-command");
             command.AddOption(option);
@@ -166,10 +166,10 @@ namespace System.CommandLine.Tests.Binding
         {
             var tempPath = Path.GetTempPath();
 
-            var argument = new Argument<DirectoryInfo>();
-
-            var option = new Option("--value",
-                                    argument: argument);
+            var option = new Option("--value")
+            {
+                Argument = new Argument<DirectoryInfo>()
+            };
 
             var command = new Command("the-command");
             command.AddOption(option);
@@ -184,10 +184,12 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Explicitly_configured_default_values_can_be_bound_by_name_to_property_setters()
         {
-            var argument = new Argument<string>("the default");
+            var argument = new Argument<string>(() => "the default");
 
-            var option = new Option("--value",
-                                    argument: argument);
+            var option = new Option("--value")
+            {
+                Argument = argument
+            };
 
             var command = new Command("the-command");
             command.AddOption(option);
@@ -206,7 +208,10 @@ namespace System.CommandLine.Tests.Binding
         {
             var command = new Command("the-command")
                           {
-                              new Option("--string-option", argument: new Argument<string>())
+                              new Option("--string-option")
+                              {
+                                  Argument = new Argument<string>()
+                              }
                           };
 
             var binder = new ModelBinder(typeof(ClassWithSettersAndCtorParametersWithDifferentNames));
@@ -283,14 +288,14 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Values_from_parent_command_arguments_are_bound_by_name_by_default()
         {
-            var argument = new Argument<int>
-                           {
-                               Name = nameof(ClassWithMultiLetterSetters.IntOption)
-                           };
-            var parentCommand = new Command("parent-command", argument: argument)
-                                {
-                                    new Command("child-command")
-                                };
+            var parentCommand = new Command("parent-command")
+            {
+                new Argument<int>
+                {
+                    Name = nameof(ClassWithMultiLetterSetters.IntOption)
+                },
+                new Command("child-command")
+            };
 
             var binder = new ModelBinder<ClassWithMultiLetterSetters>();
 
@@ -352,9 +357,11 @@ namespace System.CommandLine.Tests.Binding
         public void PropertyInfo_can_be_bound_to_option()
         {
             var command = new Command("the-command");
-            var option = new Option("--fred",
-                                    argument: new Argument<int>());
-            command.AddOption(option);
+            var option = new Option("--fred")
+            {
+                Argument = new Argument<int>()
+            };
+            command.Add(option);
 
             var type = typeof(ClassWithMultiLetterSetters);
             var binder = new ModelBinder(type);

--- a/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.cs
@@ -177,15 +177,16 @@ namespace System.CommandLine.Tests.Binding
 
             var handler = CommandHandler.Create(captureMethod);
 
-            var command = new Command(
-                              "command")
+            var command = new Command("command")
                           {
-                              new Option("-x",
-                                         argument: new Argument
-                                                   {
-                                                       Name = "value",
-                                                       ArgumentType = parameterType
-                                                   })
+                              new Option("-x")
+                              {
+                                  Argument = new Argument
+                                  {
+                                      Name = "value",
+                                      ArgumentType = parameterType
+                                  }
+                              }
                           };
 
             command.Handler = handler;
@@ -211,10 +212,11 @@ namespace System.CommandLine.Tests.Binding
                 received = x;
             });
 
-            var root = new RootCommand(handler: handler)
+            var root = new RootCommand
             {
-                new Option("-x", "Explanation")
+                new Option("-x")
             };
+            root.Handler = handler;
 
             await root.InvokeAsync("-x");
 
@@ -231,15 +233,17 @@ namespace System.CommandLine.Tests.Binding
                 received = x;
             });
 
-            var root = new RootCommand(handler: handler)
+            var root = new RootCommand
             {
-                new Option("-x", "Explanation"
-                           , argument: new Argument
-                           {
-                               Arity = new ArgumentArity(1, 1)
-                           }
-                )
+                new Option("-x")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = new ArgumentArity(1, 1)
+                    }
+                }
             };
+            root.Handler = handler;
 
             await root.InvokeAsync("-x 123");
 
@@ -267,9 +271,7 @@ namespace System.CommandLine.Tests.Binding
 
             var handler = CommandHandler.Create(captureMethod);
 
-            var command = new Command(
-                "command",
-                handler: handler)
+            var command = new Command("command")
                           {
                               new Option("--value")
                               {
@@ -279,6 +281,7 @@ namespace System.CommandLine.Tests.Binding
                                              }
                               }
                           };
+            command.Handler = handler;
 
             var parseResult = command.Parse($"--value {testCase.CommandLine}");
 
@@ -316,13 +319,15 @@ namespace System.CommandLine.Tests.Binding
             var handler = CommandHandler.Create(captureMethod);
 
             var command = new Command(
-                "command",
-                argument: new Argument
-                          {
-                              Name = "value",
-                              ArgumentType = c.ParameterType
-                          },
-                handler: handler);
+                "command")
+            {
+                new Argument
+                {
+                    Name = "value",
+                    ArgumentType = c.ParameterType
+                }
+            };
+            command.Handler = handler;
 
             var parseResult = command.Parse(c.CommandLine);
 

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -18,11 +18,13 @@ namespace System.CommandLine.Tests
                 {
                     new Command("inner")
                     {
-                        new Option("--option",
-                                   argument: new Argument
-                                             {
-                                                 Arity = ArgumentArity.ExactlyOne
-                                             })
+                        new Option("--option")
+                        {
+                            Argument = new Argument
+                            {
+                                Arity = ArgumentArity.ExactlyOne
+                            }
+                        }
                     }
                 });
         }
@@ -92,17 +94,21 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Commands_at_multiple_levels_can_have_their_own_arguments()
         {
-            var outer = new Command("outer", 
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne
-                          });
+            var outer = new Command("outer")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            };
             outer.AddCommand(
-                new Command("inner",
-                            argument: new Argument
-                                      {
-                                          Arity = ArgumentArity.ZeroOrMore
-                                      }));
+                new Command("inner")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ZeroOrMore
+                    }
+                });
 
             var parser = new Parser(outer);
 
@@ -130,10 +136,17 @@ namespace System.CommandLine.Tests
         public void When_a_command_name_contains_a_delimiter_then_an_error_is_returned(
             string commandWithDelimiter)
         {
-            Action create = () => new Parser(
-                new Command(
-                    commandWithDelimiter, "",
-                    argument: new Argument { Arity = ArgumentArity.ExactlyOne }));
+            Action create = () =>
+            {
+                new Parser(
+                    new Command(commandWithDelimiter)
+                    {
+                        new Argument
+                        {
+                            Arity = ArgumentArity.ExactlyOne
+                        }
+                    });
+            };
 
             create.Should().Throw<SymbolCannotContainDelimiterArgumentException>();
         }
@@ -171,7 +184,7 @@ namespace System.CommandLine.Tests
         {
             var subject = new SymbolCannotContainDelimiterArgumentException('ツ');
             subject.Message.Should()
-                .Be(@"Symbol cannot contain delimiter: ""ツ""");
+                   .Be(@"Symbol cannot contain delimiter: ""ツ""");
         }
 
         [Theory]
@@ -188,13 +201,13 @@ namespace System.CommandLine.Tests
         public void ParseResult_Command_identifies_innermost_command(string input, string expectedCommand)
         {
             var outer = new Command("outer")
-                        {
-                            new Command("inner")
-                            {
-                                new Command("inner-er")
-                            },
-                            new Command("sibling")
-                        };
+            {
+                new Command("inner")
+                {
+                    new Command("inner-er")
+                },
+                new Command("sibling")
+            };
 
             var result = outer.Parse(input);
 
@@ -236,9 +249,9 @@ namespace System.CommandLine.Tests
             subcommand.AddAlias("that");
 
             var rootCommand = new RootCommand
-                              {
-                                  subcommand
-                              };
+            {
+                subcommand
+            };
 
             var result = rootCommand.Parse("that");
 
@@ -249,11 +262,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void It_defaults_argument_to_alias_name_when_it_is_not_provided()
         {
-            var command = new Command("-alias",
-                                      argument: new Argument
-                                      {
-                                          Arity = ArgumentArity.ZeroOrOne
-                                      });
+            var command = new Command("-alias")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ZeroOrOne
+                }
+            };
 
             command.Arguments.Single().Name.Should().Be("alias");
         }
@@ -261,16 +276,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void It_retains_argument_name_when_it_is_provided()
         {
-            var command = new Command("-alias", 
-                                     argument: new Argument
-                                     {
-                                         Name = "arg",
-                                         Arity = ArgumentArity.ZeroOrOne
-                                     });
+            var command = new Command("-alias")
+            {
+                new Argument
+                {
+                    Name = "arg", Arity = ArgumentArity.ZeroOrOne
+                }
+            };
 
             command.Arguments.Single().Name.Should().Be("arg");
         }
-
+  
         [Fact]
         public void When_multiple_arguments_are_configured_then_they_must_differ_by_name()
         {

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -139,11 +139,17 @@ namespace System.CommandLine.Tests.Help
                                Arity = new ArgumentArity(minArity, maxArity)
                            };
             var command = new Command("the-command", "command help")
-                          {
-                              Argument = argument
-                          };
-            command.AddOption(new Option(new[] { "-v", "--verbosity" },
-                                         "Sets the verbosity"));
+            {
+                argument,
+                new Option(new[]
+                {
+                    "-v",
+                    "--verbosity"
+                })
+                {
+                    Description = "Sets the verbosity"
+                }
+            };
             var rootCommand = new RootCommand();
             rootCommand.AddCommand(command);
 
@@ -182,12 +188,14 @@ namespace System.CommandLine.Tests.Help
                                    maxArityForArg2)
                            };
             var command = new Command("the-command", "command help")
-                          {
-                               arg1,
-                               arg2
-                          };
-            command.AddOption(new Option(new[] { "-v", "--verbosity" },
-                                         "Sets the verbosity"));
+            {
+                arg1,
+                arg2,
+                new Option(new[] { "-v", "--verbosity" })
+                {
+                    Description = "Sets the verbosity"
+                }
+            };
             var rootCommand = new RootCommand();
             rootCommand.AddCommand(command);
 
@@ -224,24 +232,23 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_for_subcommand_shows_arguments_for_subcommand_and_parent_command()
         {
-            var inner = new Command(
-                            "inner", "command help",
-                            argument: new Argument<string[]>
-                                      {
-                                          Name = "inner-args"
-                                      })
-                        {
-                            new Option("-v", "Sets the verbosity")
-                        };
+            var inner = new Command("inner", "command help")
+            {
+                new Option("-v", "Sets the verbosity"),
+                new Argument<string[]>
+                {
+                    Name = "inner-args"
+                }
+            };
 
-            var outer = new Command("outer", "command help",
-                                    argument: new Argument<string[]>
-                                              {
-                                                  Name = "outer-args"
-                                              })
-                        {
-                            inner
-                        };
+            var outer = new Command("outer", "command help")
+            {
+                inner,
+                new Argument<string[]>
+                {
+                    Name = "outer-args"
+                }
+            };
 
             _helpBuilder.Write(inner);
 
@@ -297,21 +304,21 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_removes_extra_whitespace()
         {
-            var outer = new Command("outer-command",
-                                    "command help",
-                                    argument: new Argument<string>
-                                              {
-                                                  Name = "outer  args \twith  whitespace"
-                                              })
-                        {
-                            new Command(
-                                "inner-command", "command help",
-                                argument: new Argument<string>
-                                          {
-                                              Name = "inner-args"
-                                          }
-                            )
-                        };
+            var outer = new Command("outer-command", "command help")
+            {
+                new Argument<string>
+                {
+                    Name = "outer  args \twith  whitespace"
+                },
+                new Command("inner-command", "command help")
+                {
+                    new Argument<string>
+                    {
+                        Name = "inner-args"
+                    }
+                }
+            };
+
             new RootCommand().Add(outer);
 
             _helpBuilder.Write(outer);
@@ -326,21 +333,20 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_removes_added_newlines()
         {
-            var outer = new Command(
-                            "outer-command", "command help",
-                            argument: new Argument<string[]>
-                                      {
-                                          Name = $"outer args {NewLine}with new{NewLine}lines"
-                                      })
-                        {
-                            new Command(
-                                "inner-command", "command help",
-                                argument: new Argument<string>
-                                          {
-                                              Name = "inner-args"
-                                          }
-                            )
-                        };
+            var outer = new Command("outer-command", "command help")
+            {
+                new Argument<string[]>
+                {
+                    Name = $"outer args {NewLine}with new{NewLine}lines"
+                },
+                new Command("inner-command", "command help")
+                {
+                    new Argument<string>
+                    {
+                        Name = "inner-args"
+                    }
+                }
+            };
 
             _helpBuilder.Write(outer);
 
@@ -356,23 +362,20 @@ namespace System.CommandLine.Tests.Help
         {
             var helpBuilder = GetHelpBuilder(SmallMaxWidth);
 
-            var outerCommand = new Command(
-                                   "outer-command",
-                                   "command help",
-                                   argument: new Argument<string[]>
-                                             {
-                                                 Name = "outer args long enough to wrap to a new line" 
-                                             }
-                               )
-                               {
-                                   new Command(
-                                       "inner-command",
-                                       "command help",
-                                       argument: new Argument<string[]>
-                                                 {
-                                                     Name = "inner-args" 
-                                                 })
-                               };
+            var outerCommand = new Command("outer-command", "command help")
+            {
+                new Argument<string[]>
+                {
+                    Name = "outer args long enough to wrap to a new line"
+                },
+                new Command("inner-command", "command help")
+                {
+                    new Argument<string[]>
+                    {
+                        Name = "inner-args"
+                    }
+                }
+            };
 
             var rootCommand = new RootCommand
                               {
@@ -443,14 +446,15 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_is_included_if_there_are_commands_with_arguments_configured()
         {
-            var command = new Command(name: "the-command",
-                                      description: "command help",
-                                      argument: new Argument
-                                                {
-                                                    Name = "arg command name",
-                                                    Description = "test",
-                                                    Arity = ArgumentArity.ExactlyOne
-                                                });
+            var command = new Command("the-command", "command help")
+            {
+                new Argument
+                {
+                    Name = "arg command name",
+                    Description = "test",
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            };
 
             _helpBuilder.Write(command);
 
@@ -476,16 +480,16 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_is_not_included_if_there_are_only_options_with_arguments_configured()
         {
-            var command = new Command("command");
-
-            command.AddOption(
-                new Option("-v",
-                           "Sets the verbosity.",
-                           new Argument
-                           {
-                               Name = "argument for options",
-                               Arity = ArgumentArity.ExactlyOne
-                           }));
+            var command = new Command("command")
+            {
+                new Option("-v", "Sets the verbosity.")
+                {
+                    Argument = new Argument
+                    {
+                        Name = "argument for options", Arity = ArgumentArity.ExactlyOne
+                    }
+                }
+            };
 
             _helpBuilder.Write(command);
 
@@ -495,15 +499,17 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_includes_configured_argument_aliases()
         {
-            var command = new Command("the-command", "command help");
-            var option = new Option(new[] { "-v", "--verbosity" },
-                                    "Sets the verbosity.",
-                                    new Argument
-                                    {
-                                        Name = "LEVEL",
-                                        Arity = ArgumentArity.ExactlyOne
-                                    });
-            command.AddOption(option);
+            var command = new Command("the-command", "command help")
+            {
+                new Option(new[] { "-v", "--verbosity" })
+                {
+                    Argument = new Argument
+                    {
+                        Name = "LEVEL", Arity = ArgumentArity.ExactlyOne
+                    },
+                    Description = "Sets the verbosity."
+                }
+            };
             var commandLineBuilder = new CommandLineBuilder()
                                      .AddCommand(command)
                                      .Command;
@@ -520,14 +526,15 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_uses_description_if_provided()
         {
-            var command = new Command(
-                "the-command", "Help text from description",
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne,
-                              Name = "the-arg",
-                              Description = "Help text from HelpDetail",
-                          });
+            var command = new Command("the-command", "Help text from description")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne,
+                    Name = "the-arg",
+                    Description = "Help text from HelpDetail"
+                }
+            };
 
             var expected =
                 $"Arguments:{NewLine}" +
@@ -548,7 +555,7 @@ namespace System.CommandLine.Tests.Help
                     Name = "test name",
                     Description = "test desc",
                     IsHidden = true
-                },
+                }
             };
 
             _helpBuilder.Write(command);
@@ -594,25 +601,22 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_aligns_arguments_on_new_lines()
         {
-            var inner = new Command(
-                "inner",
-                "HelpDetail text for the inner command",
-                argument: new Argument<string>
-                          {
-                              Name = "the-inner-command-arg",
-                              Description = "The argument for the inner command",
-                          }
-            );
-            var outer = new Command(
-                            "outer",
-                            "HelpDetail text for the outer command",
-                            argument: new Argument<string>
-                                      {
-                                          Name = "outer-command-arg",
-                                          Description = "The argument for the outer command"
-                                      }
-                        );
-            outer.Add(inner);
+            var inner = new Command("inner", "HelpDetail text for the inner command")
+            {
+                new Argument<string>
+                {
+                    Name = "the-inner-command-arg",
+                    Description = "The argument for the inner command",
+                }
+            };
+            var outer = new Command("outer", "HelpDetail text for the outer command")
+            {
+                new Argument<string>
+                {
+                    Name = "outer-command-arg", Description = "The argument for the outer command"
+                },
+                inner
+            };
 
             var expected =
                 $"Arguments:{NewLine}" +
@@ -627,14 +631,15 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_removes_extra_whitespace()
         {
-            var outer = new Command(
-                "outer", "Help text for the outer command",
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne,
-                              Name = "outer-command-arg",
-                              Description = "Argument\tfor the   inner command",
-                          });
+            var outer = new Command("outer", "Help text for the outer command")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne,
+                    Name = "outer-command-arg",
+                    Description = "Argument\tfor the   inner command",
+                }
+            };
 
             _helpBuilder.Write(outer);
 
@@ -648,14 +653,15 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_removes_added_newlines()
         {
-            var command = new Command(
-                "outer", "Help text for the outer command",
-                argument: new Argument
-                          {
-                              Name = "outer-command-arg",
-                              Description = $"The argument{NewLine}for the{NewLine}inner command",
-                              Arity = ArgumentArity.ExactlyOne
-                          });
+            var command = new Command("outer", "Help text for the outer command")
+            {
+                new Argument
+                {
+                    Name = "outer-command-arg",
+                    Description = $"The argument{NewLine}for the{NewLine}inner command",
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            };
 
             _helpBuilder.Write(command);
 
@@ -674,15 +680,15 @@ namespace System.CommandLine.Tests.Help
                 $"for inner command with line breaks that is long enough to wrap to a" +
                 $"{NewLine}new line";
 
-            var command = new Command(
-                "outer", "Help text for the outer command",
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne,
-                              Name = "outer-command-arg",
-                              Description = longCmdText,
-                          }
-            );
+            var command = new Command("outer", "Help text for the outer command")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne,
+                    Name = "outer-command-arg",
+                    Description = longCmdText
+                }
+            };
 
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
 
@@ -703,14 +709,14 @@ namespace System.CommandLine.Tests.Help
         {
             var description = "This is the argument description";
 
-            var command = new Command(
-                "outer", "Help text for the outer command",
-                argument: new Argument
-                          {
-                              Description = description,
-                              ArgumentType = type
-                          }
-            );
+            var command = new Command("outer", "Help text for the outer command")
+            {
+                new Argument
+                {
+                    Description = description,
+                    ArgumentType = type
+                }
+            };
 
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
 
@@ -730,14 +736,14 @@ namespace System.CommandLine.Tests.Help
         {
             var description = "This is the argument description";
 
-            var command = new Command(
-                "outer", "Help text for the outer command",
-                argument: new Argument
-                          {
-                              Description = description,
-                              ArgumentType = type
-                          }
-            );
+            var command = new Command("outer", "Help text for the outer command")
+            {
+                new Argument
+                {
+                    Description = description,
+                    ArgumentType = type
+                }
+            };
 
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
 
@@ -850,8 +856,14 @@ namespace System.CommandLine.Tests.Help
         public void Options_section_does_not_contain_option_with_HelpDefinition_that_IsHidden()
         {
             var command = new Command("the-command");
-            command.AddOption(new Option("-x", "Is Hidden", isHidden: true));
-            command.AddOption(new Option("-n", "Not Hidden", isHidden: false));
+            command.AddOption(new Option("-x", "Is Hidden")
+            {
+                IsHidden = true
+            });
+            command.AddOption(new Option("-n", "Not Hidden")
+            {
+                IsHidden = false
+            });
 
             var commandLineBuilder = new CommandLineBuilder()
                                      .AddCommand(command)
@@ -1031,22 +1043,20 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Subcommands_remove_extra_whitespace()
         {
-            var command = new Command(
-                              "outer",
-                              "outer command help",
-                              argument: new Argument<string[]>
-                                        {
-                                            Name = "outer-args"
-                                        })
-                          {
-                              new Command(
-                                  "inner",
-                                  "inner    command\t help  with whitespace",
-                                  argument: new Argument<string[]>
-                                            {
-                                                Name = "inner-args"
-                                            })
-                          };
+            var command = new Command("outer", "outer command help")
+            {
+                new Argument<string[]>
+                {
+                    Name = "outer-args"
+                },
+                new Command("inner", "inner    command\t help  with whitespace")
+                {
+                    new Argument<string[]>
+                    {
+                        Name = "inner-args"
+                    }
+                }
+            };
 
             _helpBuilder.Write(command);
 
@@ -1060,24 +1070,21 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Subcommands_remove_added_newlines()
         {
-            var command = new Command(
-                              "outer",
-                              "outer command help",
-                              argument: new Argument<string>
-                                        {
-                                            Name = "outer-args"
-                                        })
-                          {
-                              new Command(
-                                  "inner",
-                                  $"inner{NewLine}command help {NewLine} with {NewLine}newlines",
-                                  argument: new Argument<string>
+            var command = new Command("outer", "outer command help")
+                {
+                    new Argument<string>
+                    {
+                        Name = "outer-args"
+                    },
+                    new Command("inner", $"inner{NewLine}command help {NewLine} with {NewLine}newlines")
+                    {
+                        new Argument<string>
 
-                                            {
-                                                Name = "inner-args"
-                                            }
-                              )
-                          };
+                        {
+                            Name = "inner-args"
+                        }
+                    }
+                };
 
             _helpBuilder.Write(command);
 
@@ -1096,29 +1103,29 @@ namespace System.CommandLine.Tests.Help
                 $"subcommand with line breaks that is long enough to wrap to a{NewLine}" +
                 $"new line";
 
-            HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
+            var helpBuilder = GetHelpBuilder(SmallMaxWidth);
 
-            var command = new Command(
-                              "outer-command",
-                              "outer command help",
-                              argument: new Argument<string[]>
-                                        {
-                                            Name = "outer-args"
-                                        })
-                          {
-                              new Command(
-                                  "inner-command",
-                                  longSubcommandText,
-                                  argument: new Argument<string[]>
-                                            {
-                                                Name = "inner-args"
-                                            })
-                              {
-                                  new Option(new[] { "-v", "--verbosity" })
-                              }
-                          };
+            var command = new Command("outer-command", "outer command help")
+             {
+                 new Argument<string[]>
+                 {
+                     Name = "outer-args"
+                 },
+                 new Command("inner-command", longSubcommandText)
+                 {
+                     new Argument<string[]>
+                     {
+                         Name = "inner-args"
+                     },
+                     new Option(new[]
+                     {
+                         "-v",
+                         "--verbosity"
+                     })
+                 }
+             };
 
-            helpBuilder.Write(command);
+             helpBuilder.Write(command);
 
             var expected =
                 $"Commands:{NewLine}" +

--- a/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
@@ -43,11 +43,15 @@ namespace System.CommandLine.Tests.Invocation
 
             var command = new Command("command");
             command.AddOption(
-                new Option("--name",
-                           argument: new Argument<string>()));
+                new Option("--name")
+                {
+                    Argument = new Argument<string>()
+                });
             command.AddOption(
-                new Option("--age",
-                           argument: new Argument<int>()));
+                new Option("--age")
+                {
+                    Argument = new Argument<int>()
+                });
             command.Handler = CommandHandler.Create<string, int>(Execute);
 
             await command.InvokeAsync("command --age 425 --name Gandalf", _console);
@@ -66,9 +70,16 @@ namespace System.CommandLine.Tests.Invocation
                 boundFirstName = firstName;
             }
 
-            var command = new Command("command");
-            command.AddOption(new Option("--first-name",
-                                         argument: new Argument { Arity = ArgumentArity.ExactlyOne }));
+            var command = new Command("command")
+            {
+                new Option("--first-name")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                }
+            };
             command.Handler = CommandHandler.Create<string>(Execute);
 
             await command.InvokeAsync("command --first-name Gandalf", _console);
@@ -89,8 +100,14 @@ namespace System.CommandLine.Tests.Invocation
             }
 
             var command = new Command("command");
-            command.AddOption(new Option("--NAME", argument: new Argument { Arity = ArgumentArity.ExactlyOne }));
-            command.AddOption(new Option("--age", argument: new Argument<int>()));
+            command.AddOption(new Option("--NAME")
+            {
+                Argument = new Argument { Arity = ArgumentArity.ExactlyOne }
+            });
+            command.AddOption(new Option("--age")
+            {
+                Argument = new Argument<int>()
+            });
             command.Handler = CommandHandler.Create<string, int>(Execute);
 
             await command.InvokeAsync("command --age 425 --NAME Gandalf", _console);
@@ -111,9 +128,17 @@ namespace System.CommandLine.Tests.Invocation
                 boundAge = age;
             }
 
-            var command = new Command("command");
-            command.AddOption(new Option("--name", argument: new Argument<string>()));
-            command.AddOption(new Option("--age", argument: new Argument<int>()));
+            var command = new Command("command")
+            {
+                new Option("--name")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--age")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
             command.Handler = CommandHandler.Create<string, int>(Execute);
 
             await command.InvokeAsync("command", _console);
@@ -134,9 +159,17 @@ namespace System.CommandLine.Tests.Invocation
                 boundAge = age;
             }
 
-            var command = new Command("command");
-            command.AddOption(new Option(new[] { "-n", "--NAME" }, argument: new Argument { Arity = ArgumentArity.ExactlyOne }));
-            command.AddOption(new Option(new[] { "-a", "--age" }, argument: new Argument<int>()));
+            var command = new Command("command")
+            {
+                new Option(new[] { "-n", "--NAME" })
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option(new[] { "-a", "--age" })
+                {
+                    Argument = new Argument<int>()
+                }
+            };
             command.Handler = CommandHandler.Create<string, int>(Execute);
 
             await command.InvokeAsync("command -a 425 -n Gandalf", _console);
@@ -151,9 +184,17 @@ namespace System.CommandLine.Tests.Invocation
             string boundName = default;
             int boundAge = default;
 
-            var command = new Command("command");
-            command.AddOption(new Option("--name", "", new Argument<string>()));
-            command.AddOption(new Option("--age", "", new Argument<int>()));
+            var command = new Command("command")
+            {
+                new Option("--name")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--age")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
             command.Handler = CommandHandler.Create<string, int>((name, age) =>
             {
                 boundName = name;
@@ -171,8 +212,13 @@ namespace System.CommandLine.Tests.Invocation
         {
             int? boundAge = default;
 
-            var command = new Command("command");
-            command.AddOption(new Option("--age", "", new Argument<int?>()));
+            var command = new Command("command")
+            {
+                new Option("--age")
+                {
+                    Argument = new Argument<int?>()
+                }
+            };
             command.Handler = CommandHandler.Create<int?>(age =>
             {
                 boundAge = age;
@@ -189,8 +235,13 @@ namespace System.CommandLine.Tests.Invocation
             var wasCalled = false;
             int? boundAge = default;
 
-            var command = new Command("command");
-            command.AddOption(new Option("--age", "", new Argument<int?>()));
+            var command = new Command("command")
+            {
+                new Option("--age")
+                {
+                    Argument = new Argument<int?>()
+                }
+            };
             command.Handler = CommandHandler.Create<int?>(age =>
             {
                 wasCalled = true;
@@ -209,8 +260,13 @@ namespace System.CommandLine.Tests.Invocation
             DirectoryInfo boundDirectoryInfo = default;
             var tempPath = Path.GetTempPath();
 
-            var command = new Command("command");
-            command.AddOption(new Option("--dir", "", new Argument<DirectoryInfo>()));
+            var command = new Command("command")
+            {
+                new Option("--dir")
+                {
+                    Argument = new Argument<DirectoryInfo>()
+                }
+            };
             command.Handler = CommandHandler.Create<DirectoryInfo>(dir =>
             {
                 boundDirectoryInfo = dir;
@@ -226,8 +282,13 @@ namespace System.CommandLine.Tests.Invocation
         {
             ParseResult boundParseResult = default;
 
-            var command = new Command("command");
-            command.AddOption(new Option("-x", "", new Argument<int>()));
+            var command = new Command("command")
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
             command.Handler = CommandHandler.Create<ParseResult>(result => { boundParseResult = result; });
 
             await command.InvokeAsync("command -x 123", _console);
@@ -240,8 +301,13 @@ namespace System.CommandLine.Tests.Invocation
         {
             BindingContext boundContext = default;
 
-            var command = new Command("command");
-            command.AddOption(new Option("-x", "", new Argument<int>()));
+            var command = new Command("command")
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
             command.Handler = CommandHandler.Create<BindingContext>(context => { boundContext = context; });
 
             await command.InvokeAsync("command -x 123", _console);
@@ -252,8 +318,13 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Method_parameters_of_type_IConsole_receive_the_current_console_instance()
         {
-            var command = new Command("command");
-            command.AddOption(new Option("-x", "", new Argument<int>()));
+            var command = new Command("command")
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
             command.Handler = CommandHandler.Create<IConsole>(console => { console.Out.Write("Hello!"); });
 
             await command.InvokeAsync("command", _console);
@@ -266,8 +337,13 @@ namespace System.CommandLine.Tests.Invocation
         {
             InvocationContext boundContext = default;
 
-            var command = new Command("command");
-            command.AddOption(new Option("-x", "", new Argument<int>()));
+            var command = new Command("command")
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
             command.Handler = CommandHandler.Create<InvocationContext>(context => { boundContext = context; });
 
             await command.InvokeAsync("command -x 123", _console);

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_only_one_alias_then_that_alias_is_its_name()
         {
-            var option = new Option(new[] { "myname" }, "");
+            var option = new Option(new[] { "myname" });
 
             option.Name.Should().Be("myname");
         }
@@ -20,7 +20,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_several_aliases_then_the_longest_alias_is_its_name()
         {
-            var option = new Option(new[] { "myname", "m" }, "");
+            var option = new Option(new[] { "myname", "m" });
 
             option.Name.Should().Be("myname");
         }
@@ -28,7 +28,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_names_do_not_contain_prefix_characters()
         {
-            var option = new Option(new[] { "--myname", "m" }, "");
+            var option = new Option(new[] { "--myname", "m" });
 
             option.Name.Should().Be("myname");
         }
@@ -47,7 +47,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_aliases_are_case_sensitive()
         {
-            var option = new Option(new[] { "-o" }, "");
+            var option = new Option(new[] { "-o" });
 
             option.HasAlias("O").Should().BeFalse();
         }
@@ -55,8 +55,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void HasAlias_accepts_prefixed_short_value()
         {
-            var option = new Option(
-                new[] { "-o", "--option" }, "");
+            var option = new Option(new[] { "-o", "--option" });
 
             option.HasAlias("-o").Should().BeTrue();
         }
@@ -64,8 +63,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void HasAlias_accepts_unprefixed_short_value()
         {
-            var option = new Option(
-                new[] { "-o", "--option" }, "");
+            var option = new Option(new[] { "-o", "--option" });
 
             option.HasAlias("o").Should().BeTrue();
         }
@@ -73,8 +71,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void HasAlias_accepts_prefixed_long_value()
         {
-            var option = new Option(
-                new[] { "-o", "--option" }, "");
+            var option = new Option(new[] { "-o", "--option" });
 
             option.HasAlias("--option").Should().BeTrue();
         }
@@ -82,8 +79,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void HasAlias_accepts_unprefixed_long_value()
         {
-            var option = new Option(
-                new[] { "-o", "--option" }, "");
+            var option = new Option(new[] { "-o", "--option" });
 
             option.HasAlias("option").Should().BeTrue();
         }
@@ -91,8 +87,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void It_is_not_necessary_to_specify_a_prefix_when_adding_an_option()
         {
-            var option = new Option(
-                new[] { "o" }, "");
+            var option = new Option(new[] { "o" });
 
             option.HasAlias("o").Should().BeTrue();
             option.HasAlias("-o").Should().BeTrue();
@@ -101,7 +96,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_must_have_at_least_one_alias()
         {
-            Action create = () => new Option(Array.Empty<string>(), "");
+            Action create = () => new Option(Array.Empty<string>());
 
             create.Should()
                   .Throw<ArgumentException>()
@@ -114,7 +109,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_cannot_have_an_empty_alias()
         {
-            Action create = () => new Option(new[] { "" }, "");
+            Action create = () => new Option(new[] { "" });
 
             create.Should()
                   .Throw<ArgumentException>()
@@ -127,7 +122,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_cannot_have_an_alias_consisting_entirely_of_whitespace()
         {
-            Action create = () => new Option(new[] { "  \t" }, "");
+            Action create = () => new Option(new[] { "  \t" });
 
             create.Should()
                   .Throw<ArgumentException>()
@@ -140,9 +135,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Raw_aliases_are_exposed_by_an_option()
         {
-            var option = new Option(
-                new[] { "-h", "--help", "/?" },
-                "");
+            var option = new Option(new[] { "-h", "--help", "/?" });
 
             option.RawAliases
                   .Should()
@@ -162,7 +155,7 @@ namespace System.CommandLine.Tests
         {
             Action create = () => new Parser(
                 new Option(
-                    string.Format(template, delimiter), ""));
+                    string.Format(template, delimiter)));
 
             create.Should().Throw<ArgumentException>().Which.Message.Should()
                   .Be($"Symbol cannot contain delimiter: \"{delimiter}\"");
@@ -204,9 +197,15 @@ namespace System.CommandLine.Tests
         {
             var rootCommand = new RootCommand
                               {
-                                  new Option(prefix + "a", "", new Argument<string>()),
+                                  new Option(prefix + "a")
+                                  {
+                                      Argument = new Argument<string>()
+                                  },
                                   new Option(prefix + "b"),
-                                  new Option(prefix + "c", "", new Argument<string>())
+                                  new Option(prefix + "c")
+                                  {
+                                      Argument = new Argument<string>()
+                                  }
                               };
             var result = rootCommand.Parse(prefix + "c value-for-c " + prefix + "a value-for-a");
 
@@ -218,8 +217,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_option_not_explicitly_provides_help_will_use_default_help()
         {
-            var option = new Option(
-                new[] { "-o", "--option" }, "desc");
+            var option = new Option(new[] { "-o", "--option" }, "desc");
 
             option.Name.Should().Be("option");
             option.Description.Should().Be("desc");
@@ -227,28 +225,32 @@ namespace System.CommandLine.Tests
         }
         
         [Fact]
-        public void It_defaults_argument_to_alias_name_when_it_is_not_provided()
+        public void Argument_takes_option_alias_as_its_name_when_it_is_not_provided()
         {
-            var command = new Command("-alias",
-                                      argument: new Argument
-                                      {
-                                          Arity = ArgumentArity.ZeroOrOne
-                                      });
+            var command = new Option("--alias")
+            {
+                Argument = new Argument
+                {
+                    Arity = ArgumentArity.ZeroOrOne
+                }
+            };
 
-            command.Arguments.Single().Name.Should().Be("alias");
+            command.Argument.Name.Should().Be("alias");
         }
 
         [Fact]
-        public void It_retains_argument_name_when_it_is_provided()
+        public void Argument_retains_name_when_it_is_provided()
         {
-            var option = new Command("-alias", 
-                                     argument: new Argument
-                                     {
-                                         Name = "arg",
-                                         Arity = ArgumentArity.ZeroOrOne
-                                     });
+            var option = new Option("-alias")
+            {
+                Argument = new Argument
+                {
+                    Name = "arg",
+                    Arity = ArgumentArity.ZeroOrOne
+                }
+            };
 
-            option.Arguments.Single().Name.Should().Be("arg");
+            option.Argument.Name.Should().Be("arg");
         }
     }
 }

--- a/src/System.CommandLine.Tests/ParseDiagramTests.cs
+++ b/src/System.CommandLine.Tests/ParseDiagramTests.cs
@@ -14,23 +14,21 @@ namespace System.CommandLine.Tests
         {
             var parser = new Parser(
                 new Command(
-                    "the-command", "",
-                    new[] {
-                        new Option(
-                            "-x",
-                            "Specifies value x",
-                            new Argument
+                    "the-command")
+                  {
+                        new Option("-x")
+                        {
+                            Argument = new Argument
                             {
                                 Arity = ArgumentArity.ExactlyOne
-                            }),
-                        new Option(
-                            "-y",
-                            "Specifies value y")
-                    },
-                    new Argument
-                    {
-                        Arity = ArgumentArity.ZeroOrMore
-                    }));
+                            }
+                        },
+                        new Option("-y"),
+                        new Argument
+                        {
+                            Arity = ArgumentArity.ZeroOrMore
+                        }
+                    });
 
             var result = parser.Parse("the-command -x one -y two three");
 
@@ -42,19 +40,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_result_diagram_displays_unmatched_tokens()
         {
-            var command = new Command("command", "",
-                                      new[]
+            var command = new Command("command")
                                       {
-                                          new Option(
-                                              "-x",
-                                              "",
-                                              new Argument
+                                          new Option("-x")
+                                          {
+                                              Argument = new Argument
                                                   {
                                                       Arity = ArgumentArity.ExactlyOne
                                                   }
-                                                  .FromAmong("arg1", "arg2", "arg3"))
-                                      });
-            command.Argument.Arity = ArgumentArity.Zero;
+                                                  .FromAmong("arg1", "arg2", "arg3")
+                                          }
+                                      };
 
             var result = command.Parse("command -x ar");
 
@@ -66,9 +62,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_diagram_shows_type_conversion_errors()
         {
-            var command = new RootCommand();
-            command.AddOption(new Option("-f", "",
-                                         new Argument<int>()));
+            var command = new RootCommand
+            {
+                new Option("-f")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
 
             var result = command.Parse("-f not-an-int");
 
@@ -80,14 +80,22 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_diagram_identifies_options_where_default_values_have_been_applied()
         {
-            var rootCommand = new RootCommand();
+            var rootCommand = new RootCommand
+            {
+                new Option(new[] { "-h", "--height" })
+                {
+                    Argument = new Argument<int>(defaultValue: () => 10), Description = ""
+                },
+                new Option(new[] { "-w", "--width" })
+                {
+                    Argument = new Argument<int>(defaultValue: () => 15), Description = ""
+                },
+                new Option(new[] { "-c", "--color" })
+                {
+                    Argument = new Argument<ConsoleColor>(() => ConsoleColor.Cyan), Description = ""
+                }
+            };
 
-            rootCommand.AddOption(new Option(new[] { "-h", "--height" }, "",
-                                             new Argument<int>(defaultValue: 10)));
-            rootCommand.AddOption(new Option(new[] { "-w", "--width" }, "",
-                                             new Argument<int>(defaultValue: 15)));
-            rootCommand.AddOption(new Option(new[] { "-c", "--color" }, "",
-                                             new Argument<ConsoleColor>(() => ConsoleColor.Cyan)));
 
             var result = rootCommand.Parse("-w 9000");
 

--- a/src/System.CommandLine.Tests/ParseDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/ParseDirectiveTests.cs
@@ -25,8 +25,10 @@ namespace System.CommandLine.Tests
             var rootCommand = new RootCommand();
             var subcommand = new Command("subcommand");
             rootCommand.AddCommand(subcommand);
-            var option = new Option(new[] { "-c", "--count" }, "",
-                                    new Argument<int>());
+            var option = new Option(new[] { "-c", "--count" })
+            {
+                Argument = new Argument<int>(), Description = ""
+            };
             subcommand.AddOption(option);
 
             var parser = new CommandLineBuilder(rootCommand)
@@ -50,8 +52,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_there_are_no_errors_then_parse_directive_sets_exit_code_0()
         {
-            var command = new RootCommand();
-            command.AddOption(new Option("-x", argument: new Argument<int>()));
+            var command = new RootCommand
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
 
             var exitCode = await command.InvokeAsync("[parse] -x 123");
 
@@ -61,8 +68,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_there_are_errors_then_parse_directive_sets_exit_code_1()
         {
-            var command = new RootCommand();
-            command.AddOption(new Option("-x", argument: new Argument<int>()));
+            var command = new RootCommand
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
 
             var exitCode = await command.InvokeAsync("[parse] -x not-an-int");
 

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.IO;
@@ -115,10 +116,14 @@ namespace System.CommandLine.Tests
         public void Parse_result_contains_arguments_to_options()
         {
             var parser = new Parser(
-                new Option(new[] { "-o", "--one" },
-                           argument: new Argument { Arity = ArgumentArity.ExactlyOne }),
-                new Option(new[] { "-t", "--two" },
-                           argument: new Argument { Arity = ArgumentArity.ExactlyOne }));
+                new Option(new[] { "-o", "--one" })
+                {
+                    Argument = new Argument { Arity = ArgumentArity.ExactlyOne }
+                },
+                new Option(new[] { "-t", "--two" })
+                {
+                    Argument = new Argument { Arity = ArgumentArity.ExactlyOne }
+                });
 
             var result = parser.Parse("-o args_for_one -t args_for_two");
 
@@ -188,12 +193,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Short_form_options_can_be_specified_using_equals_delimiter()
         {
-            var parser = new Parser(new Option(
-                                        "-x",
-                                        argument: new Argument
-                                        {
-                                            Arity = ArgumentArity.ExactlyOne
-                                        }));
+            var parser = new Parser(new Option("-x")
+            {
+                Argument = new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            });
 
             var result = parser.Parse("-x=some-value");
 
@@ -206,12 +212,13 @@ namespace System.CommandLine.Tests
         public void Long_form_options_can_be_specified_using_equals_delimiter()
         {
             var parser = new Parser(
-                new Option(
-                    "--hello",
-                    argument: new Argument
-                              {
-                                  Arity = ArgumentArity.ExactlyOne
-                              }));
+                new Option("--hello")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                });
 
             var result = parser.Parse("--hello=there");
 
@@ -224,12 +231,13 @@ namespace System.CommandLine.Tests
         public void Short_form_options_can_be_specified_using_colon_delimiter()
         {
             var parser = new Parser(
-                new Option(
-                    "-x",
-                    argument: new Argument
-                              {
-                                  Arity = ArgumentArity.ExactlyOne
-                              }));
+                new Option("-x")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                });
 
             var result = parser.Parse("-x:some-value");
 
@@ -241,11 +249,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Long_form_options_can_be_specified_using_colon_delimiter()
         {
-            var option = new Option("--hello",
-                                    argument: new Argument
-                                              {
-                                                  Arity = ArgumentArity.ExactlyOne
-                                              });
+            var option = new Option("--hello")
+            {
+                Argument = new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            };
             
             var result = option.Parse("--hello:there");
 
@@ -297,10 +307,10 @@ namespace System.CommandLine.Tests
             var parser = new Parser(
                 new Command("the-command")
                 {
-                    new Option("--xyz", ""),
-                    new Option("-x", ""),
-                    new Option("-y", ""),
-                    new Option("-z", "")
+                    new Option("--xyz"),
+                    new Option("-x"),
+                    new Option("-y"),
+                    new Option("-z")
                 });
 
             var result = parser.Parse("the-command --xyz");
@@ -342,18 +352,20 @@ namespace System.CommandLine.Tests
         public void Parser_root_Options_can_be_specified_multiple_times_and_their_arguments_are_collated()
         {
             var parser = new Parser(
-                new Option(
-                    new[] { "-a", "--animals" }, "",
-                    new Argument
+                new Option(new[] { "-a", "--animals" })
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ZeroOrMore
-                    }),
-                new Option(
-                    new[] { "-v", "--vegetables" }, "",
-                    new Argument
+                    }, Description = ""
+                },
+                new Option(new[] { "-v", "--vegetables" })
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ZeroOrMore
-                    }));
+                    }, Description = ""
+                });
 
             var result = parser.Parse("-a cat -v carrot -a dog");
 
@@ -372,22 +384,22 @@ namespace System.CommandLine.Tests
         public void Options_can_be_specified_multiple_times_and_their_arguments_are_collated()
         {
             var parser = new Parser(
-                new Command("the-command", "", new[] {
-                    new Option(
-                        new[] { "-a", "--animals" },
-                        "",
-                        argument: new Argument
-                                  {
-                                      Arity = ArgumentArity.ZeroOrMore
-                                  }.FromAmong("dog", "cat", "sheep")),
-                    new Option(
-                        new[] { "-v", "--vegetables" },
-                        "",
-                        new Argument
+                new Command("the-command") {
+                    new Option(new[] { "-a", "--animals" })
+                    {
+                        Argument = new Argument
                         {
                             Arity = ArgumentArity.ZeroOrMore
-                        })
-                }));
+                        }.FromAmong("dog", "cat", "sheep"), Description = ""
+                    },
+                    new Option(new[] { "-v", "--vegetables" })
+                    {
+                        Argument = new Argument
+                        {
+                            Arity = ArgumentArity.ZeroOrMore
+                        }, Description = ""
+                    }
+                });
 
             var result = parser.Parse("the-command -a cat -v carrot -a dog");
 
@@ -408,20 +420,20 @@ namespace System.CommandLine.Tests
         public void When_a_Parser_root_option_is_not_respecified_but_limit_is_not_reached_then_the_following_token_is_used_as_value()
         {
             var parser = new Parser(
-                new Option(
-                    new[] { "-a", "--animals" },
-                    "",
-                    new Argument
+                new Option(new[] { "-a", "--animals" })
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ZeroOrMore
-                    }),
-                new Option(
-                    new[] { "-v", "--vegetables" },
-                    "",
-                    new Argument
+                    }, Description = ""
+                },
+                new Option(new[] { "-v", "--vegetables" })
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ZeroOrMore
-                    }));
+                    }, Description = ""
+                });
 
             ParseResult result = parser.Parse("-a cat dog -v carrot");
 
@@ -445,20 +457,20 @@ namespace System.CommandLine.Tests
         public void When_a_Parser_root_option_is_not_respecified_and_limit_is_reached_then_the_following_token_is_unmatched()
         {
             var parser = new Parser(
-                new Option(
-                    new[] { "-a", "--animals" },
-                    "",
-                    new Argument
+                new Option(new[] { "-a", "--animals" })
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ZeroOrOne
-                    }),
-                new Option(
-                    new[] { "-v", "--vegetables" },
-                    "",
-                    new Argument
+                    }, Description = ""
+                },
+                new Option(new[] { "-v", "--vegetables" })
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ZeroOrMore
-                    }));
+                    }, Description = ""
+                });
 
             ParseResult result = parser.Parse("-a cat some-arg -v carrot");
 
@@ -482,24 +494,27 @@ namespace System.CommandLine.Tests
         public void When_an_option_is_not_respecified_but_limit_is_not_reached_then_the_following_token_is_considered_as_value()
         {
             var parser = new Parser(
-                new Command("the-command", "", new[] {
-                                          new Option(
-                                              new[] { "-a", "--animals" }, "",
-                                              new Argument
-                                              {
-                                                Arity = ArgumentArity.ZeroOrMore
-                                              }),
-                                          new Option(
-                                              new[] { "-v", "--vegetables" }, "",
-                                              new Argument
-                                              {
-                                                Arity = ArgumentArity.ZeroOrMore
-                                              })
-                                      },
-                                      new Argument
-                                      {
-                                          Arity = ArgumentArity.ZeroOrMore
-                                      }));
+                new Command("the-command")
+                {
+                    new Option(new[] { "-a", "--animals" })
+                    {
+                        Argument = new Argument
+                        {
+                            Arity = ArgumentArity.ZeroOrMore
+                        }
+                    },
+                    new Option(new[] { "-v", "--vegetables" })
+                    {
+                        Argument = new Argument
+                        {
+                            Arity = ArgumentArity.ZeroOrMore
+                        }
+                    }
+                },
+                new Argument
+                {
+                    Arity = ArgumentArity.ZeroOrMore
+                });
 
             ParseResult result = parser.Parse("the-command -a cat dog -v carrot");
 
@@ -508,7 +523,7 @@ namespace System.CommandLine.Tests
             command["animals"]
                 .Arguments
                 .Should()
-                .BeEquivalentTo(new[]{"cat", "dog"});
+                .BeEquivalentTo("cat", "dog");
 
             command["vegetables"]
                 .Arguments
@@ -525,24 +540,26 @@ namespace System.CommandLine.Tests
         public void When_an_option_is_not_respecified_but_limit_is_reached_then_the_following_token_is_considered_an_argument_to_the_parent_command()
         {
             var parser = new Parser(
-                new Command("the-command", "", new[] {
-                        new Option(
-                            new[] { "-a", "--animals" }, "",
-                            new Argument
-                            {
-                                Arity = ArgumentArity.ZeroOrOne
-                            }),
-                        new Option(
-                            new[] { "-v", "--vegetables" }, "",
-                            new Argument
-                            {
-                                Arity = ArgumentArity.ZeroOrMore
-                            })
+                new Command("the-command")
+                {
+                    new Option(new[] { "-a", "--animals" })
+                    {
+                        Argument = new Argument
+                        {
+                            Arity = ArgumentArity.ZeroOrOne
+                        }
+                    },
+                    new Option(new[] { "-v", "--vegetables" })
+                    {
+                        Argument = new Argument
+                        {
+                            Arity = ArgumentArity.ZeroOrMore
+                        }
                     },
                     new Argument
                     {
                         Arity = ArgumentArity.ZeroOrMore
-                    }));
+                    }});
 
             ParseResult result = parser.Parse("the-command -a cat some-arg -v carrot");
 
@@ -567,21 +584,23 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_with_multiple_options_is_parsed_correctly()
         {
-            var option = new Command("outer", "",
-                                               new[] {
-                                                   new Option(
-                                                       "--inner1", "",
-                                                       new Argument
-                                                       {
-                                                           Arity = ArgumentArity.ExactlyOne
-                                                       }),
-                                                   new Option(
-                                                       "--inner2", "",
-                                                       new Argument
-                                                       {
-                                                           Arity = ArgumentArity.ExactlyOne
-                                                       })
-                                               });
+            var option = new Command("outer")
+            {
+                new Option("--inner1")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                },
+                new Option("--inner2")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                }
+            };
 
             var parser = new Parser(option);
 
@@ -604,10 +623,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Relative_order_of_arguments_and_options_within_a_command_does_not_matter()
         {
-            var command = new Command("move", argument: new Argument<string[]>())
-                         {
-                             new Option("-X", "", new Argument<string>())
-                         };
+            var command = new Command("move")
+            {
+                new Argument<string[]>(),
+                new Option("-X")
+                {
+                    Argument = new Argument<string>()
+                }
+            };
 
             // option before args
             ParseResult result1 = command.Parse(
@@ -646,10 +669,17 @@ namespace System.CommandLine.Tests
         {
             var rawSplit = commandLine.SplitCommandLine();
 
-            var command = new Command("the-command", argument: new Argument<string[]>())
+            var command = new Command("the-command")
                           {
-                              new Option("--one", "", new Argument<string>()),
-                              new Option("--many", "", new Argument<string[]>()),
+                              new Argument<string[]>(),
+                              new Option("--one")
+                              {
+                                  Argument = new Argument<string>()
+                              },
+                              new Option("--many")
+                              {
+                                  Argument = new Argument<string[]>()
+                              }
                           };
 
             var result = command.Parse(commandLine);
@@ -695,17 +725,22 @@ namespace System.CommandLine.Tests
         public void When_nested_commands_all_accept_arguments_then_the_nearest_captures_the_arguments()
         {
             var command = new Command(
-                              "outer",
-                              argument: new Argument
-                                        {
-                                            Arity = ArgumentArity.ZeroOrMore
-                                        })
-                          {
-                              new Command("inner",
-                                          argument: new Argument { Arity = ArgumentArity.ZeroOrMore })
-                          };
+                "outer")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ZeroOrMore
+                },
+                new Command("inner")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ZeroOrMore
+                    }
+                }
+            };
 
-            ParseResult result = command.Parse("outer arg1 inner arg2");
+            var result = command.Parse("outer arg1 inner arg2");
 
             result.CommandResult.Parent.Arguments.Should().BeEquivalentTo("arg1");
 
@@ -715,22 +750,22 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Nested_commands_with_colliding_names_cannot_both_be_applied()
         {
-            var command = new Command(
-                              "outer", "",
-                              argument: new Argument<string>())
-                          {
-                              new Command(
-                                  "non-unique",
-                                  argument: new Argument<string>()),
-                              new Command(
-                                  "inner", "",
-                                  argument: new Argument<string>())
-                              {
-                                  new Command(
-                                      "non-unique",
-                                      argument: new Argument<string>())
-                              }
-                          };
+            var command = new Command("outer")
+            {
+                new Argument<string>(),
+                new Command("non-unique")
+                {
+                    new Argument<string>()
+                },
+                new Command("inner")
+                {
+                    new Argument<string>(),
+                    new Command("non-unique")
+                    {
+                        new Argument<string>()
+                    }
+                }
+            };
 
             ParseResult result = command.Parse("outer arg1 inner arg2 non-unique arg3 ");
 
@@ -740,9 +775,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_child_option_will_not_accept_arg_then_parent_can()
         {
-            var command = new Command("the-command", argument: new Argument<string>())
+            var command = new Command("the-command")
                          {
-                             new Option("-x", "", Argument.None)
+                             new Option("-x"),
+                             new Argument<string>()
                          };
 
             var result = command.Parse("the-command -x the-argument");
@@ -756,11 +792,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_parent_option_will_not_accept_arg_then_child_can()
         {
-            var command = new Command("the-command",
-                                      argument: Argument.None)
-                          {
-                              new Option("-x", "", new Argument<string>())
-                          };
+            var command = new Command("the-command")
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument<string>()
+                }
+            };
 
             var result = command.Parse("the-command -x the-argument");
 
@@ -818,9 +856,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Arguments_only_apply_to_the_nearest_command()
         {
-            var outer = new Command("outer", argument: new Argument<string>())
+            var outer = new Command("outer")
             {
-                new Command("inner", argument: new Argument<string>())
+                new Argument<string>(),
+                new Command("inner")
+                {
+                    new Argument<string>()
+                }
             };
 
             ParseResult result = outer.Parse("outer inner arg1 arg2");
@@ -870,12 +912,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Subsequent_occurrences_of_tokens_matching_command_names_are_parsed_as_arguments()
         {
-            var command = new Command("the-command");
-            var complete = new Command("complete", argument: new Argument<string>());
-            command.AddCommand(complete);
-            var position = new Option("--position",
-                                      argument: new Argument<int>());
-            complete.AddOption(position);
+            var command = new Command("the-command")
+            {
+                new Command("complete")
+                {
+                    new Argument<string>(),
+                    new Option("--position")
+                    {
+                        Argument = new Argument<int>()
+                    }
+                }
+            };
 
             ParseResult result = command.Parse("the-command",
                                                "complete",
@@ -895,13 +942,13 @@ namespace System.CommandLine.Tests
                           {
                               new Command("inner")
                               {
-                                  new Option(
-                                      "-x",
-                                      "",
-                                      new Argument
+                                  new Option("-x")
+                                  {
+                                      Argument = new Argument
                                       {
                                           Arity = ArgumentArity.ExactlyOne
-                                      })
+                                      }
+                                  }
                               }
                           };
 
@@ -915,18 +962,18 @@ namespace System.CommandLine.Tests
         public void A_root_command_can_match_a_full_path_to_an_executable()
         {
             var command = new RootCommand
-                          {
-                              new Command("inner")
-                              {
-                                  new Option(
-                                      "-x",
-                                      "",
-                                      new Argument
-                                      {
-                                          Arity = ArgumentArity.ExactlyOne
-                                      })
-                              }
-                          };
+            {
+                new Command("inner")
+                {
+                    new Option("-x")
+                    {
+                        Argument = new Argument
+                        {
+                            Arity = ArgumentArity.ExactlyOne
+                        }
+                    }
+                }
+            };
 
             ParseResult result1 = command.Parse("inner -x hello");
 
@@ -942,13 +989,13 @@ namespace System.CommandLine.Tests
                               {
                                   new Command("inner")
                                   {
-                                      new Option(
-                                          "-x",
-                                          "",
-                                          new Argument
+                                      new Option("-x")
+                                      {
+                                          Argument = new Argument
                                           {
                                               Arity = ArgumentArity.ExactlyOne
-                                          })
+                                          }
+                                      }
                                   }
                               };
             rootCommand.Name = "outer";
@@ -967,11 +1014,13 @@ namespace System.CommandLine.Tests
             var command =
                 @"rm ""/temp/the file.txt""";
 
-            var parser = new Parser(new Command("rm", "",
-                                                argument: new Argument
-                                                {
-                                                    Arity = ArgumentArity.ZeroOrMore
-                                                }));
+            var parser = new Parser(new Command("rm")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ZeroOrMore
+                }
+            });
 
             var result = parser.Parse(command);
 
@@ -987,11 +1036,13 @@ namespace System.CommandLine.Tests
             var command =
                 @"rm ""c:\temp\the file.txt\""";
 
-            var parser = new Parser(new Command("rm", "",
-                                                argument: new Argument
-                                                {
-                                                    Arity = ArgumentArity.ZeroOrMore
-                                                }));
+            var parser = new Parser(new Command("rm")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ZeroOrMore
+                }
+            });
 
             ParseResult result = parser.Parse(command);
 
@@ -1004,8 +1055,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Commands_can_have_default_argument_values()
         {
-            var command = new Command("command",
-                                      argument: new Argument<string>("default"));
+            var command = new Command("command")
+            {
+                new Argument<string>(() => "default")
+            };
 
             ParseResult result = command.Parse("command");
 
@@ -1017,9 +1070,10 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("command");
             command.AddOption(
-                new Option(
-                    new[] { "-o", "--option" },
-                    argument: new Argument<string>("the-default")));
+                new Option(new[] { "-o", "--option" })
+                {
+                    Argument = new Argument<string>(() => "the-default")
+                });
 
             ParseResult result = command.Parse("command");
 
@@ -1032,13 +1086,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_with_a_default_value_is_not_matched_then_the_option_result_is_implicit()
         {
-            var command = new Command("command");
-            command.AddOption(
-                new Option(
-                    new[] { "-o", "--option" },
-                    argument: new Argument<string>("the-default")));
+            var command = new Command("command")
+            {
+                new Option(new[]{ "-o", "--option" })
+                {
+                    Argument = new Argument<string>(() => "the-default")
+                }
+            };
 
-            ParseResult result = command.Parse("command");
+            var result = command.Parse("command");
 
             result.CommandResult
                   .OptionResult("o")
@@ -1075,15 +1131,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Unmatched_options_are_not_split_into_smaller_tokens()
         {
-            var outer = new Command("outer");
-            outer.AddOption(
-                new Option("-p"));
-            outer.AddCommand(
-                new Command("inner",
-                            argument: new Argument
-                                      {
-                                          Arity = ArgumentArity.OneOrMore
-                                      }));
+            var outer = new Command("outer")
+            {
+                new Option("-p"),
+                new Command("inner")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.OneOrMore
+                    }
+                }
+            };
 
             ParseResult result = outer.Parse("outer inner -p:RandomThing=random");
 
@@ -1096,15 +1154,16 @@ namespace System.CommandLine.Tests
         [Fact]
         public void The_default_behavior_of_unmatched_tokens_resulting_in_errors_can_be_turned_off()
         {
-            var parser = new Command(
-                "the-command",
-                treatUnmatchedTokensAsErrors: false,
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne
-                          });
+            var command = new Command("the-command")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            };
+            command.TreatUnmatchedTokensAsErrors = false;
 
-            ParseResult result = parser.Parse("the-command arg1 arg2");
+            ParseResult result = command.Parse("the-command arg1 arg2");
 
             result.Errors.Should().BeEmpty();
 
@@ -1116,14 +1175,25 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Argument_names_can_collide_with_option_names()
         {
-            var command = new Command("the-command", "", new[] {
-                new Option(
-                    "--one",
-                    "",
-                    new Argument
+            IReadOnlyCollection<Symbol> symbols = new[] {
+                new Option("--one")
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ExactlyOne
-                    })});
+                    }
+                }};
+            var command1 = new Command(
+                "the-command",
+                ""
+            );
+
+            foreach (var symbol in symbols)
+            {
+                command1.Add(symbol);
+            }
+
+            var command = command1;
 
             ParseResult result = command.Parse("the-command --one one");
 
@@ -1136,26 +1206,25 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_and_Command_can_have_the_same_alias()
         {
-            var innerCommand = new Command(
-                "inner", "",
-                symbols: null,
+            var innerCommand = new Command("inner")
+            {
                 new Argument
                 {
                     Arity = ArgumentArity.ZeroOrMore
-                });
+                }
+            };
 
-            var option = new Option("--inner", "");
+            var option = new Option("--inner");
 
-            var outerCommand = new Command(
-                "outer", "",
-                new Symbol[] {
-                    innerCommand,
-                    option
-                },
+            var outerCommand = new Command("outer")
+            {
+                innerCommand,
+                option,
                 new Argument
                 {
                     Arity = ArgumentArity.ZeroOrMore
-                });
+                }
+            };
 
             var parser = new Parser(outerCommand);
 
@@ -1184,8 +1253,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_can_have_the_same_alias_differentiated_only_by_prefix()
         {
-            var option1 = new Option(new[] { "-a" }, "");
-            var option2 = new Option(new[] { "--a" }, "");
+            var option1 = new Option(new[] { "-a" });
+            var option2 = new Option(new[] { "--a" });
 
             var parser = new Parser(option1, option2);
 
@@ -1210,14 +1279,14 @@ namespace System.CommandLine.Tests
         [InlineData("-x:\"\"", "")]
         public void When_an_argument_is_enclosed_in_double_quotes_its_value_has_the_quotes_removed(string input, string expected)
         {
-            ParseResult parseResult = new Parser(
-                    new Option(
-                        "-x",
-                        "",
-                        new Argument
+            var parseResult = new Parser(
+                    new Option("-x")
+                    {
+                        Argument = new Argument
                         {
                             Arity = ArgumentArity.ZeroOrMore
-                        }))
+                        }
+                    })
                 .Parse(input);
 
             parseResult["x"].Arguments
@@ -1231,20 +1300,24 @@ namespace System.CommandLine.Tests
         [InlineData("-x:-y")]
         public void Arguments_can_start_with_prefixes_that_make_them_look_like_options(string input)
         {
-            var command = new Command("command");
+            var command = new Command("command")
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ZeroOrOne
+                    }
+                },
+                new Option("-z")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ZeroOrOne
+                    }
+                }
+            };
 
-            command.AddOption(
-                new Option("-x",
-                           argument: new Argument
-                                     {
-                                         Arity = ArgumentArity.ZeroOrOne
-                                     }));
-            command.AddOption(
-                new Option("-z",
-                           argument: new Argument
-                                     {
-                                         Arity = ArgumentArity.ZeroOrOne
-                                     }));
 
             var result = command.Parse(input);
 
@@ -1258,18 +1331,23 @@ namespace System.CommandLine.Tests
         [InlineData("-x:-y")]
         public void Arguments_can_match_the_aliases_of_sibling_options(string input)
         {
-            var command = new Command("command");
-            command.AddOption(
-                new Option("-x", argument: new Argument
-                                           {
-                                               Arity = ArgumentArity.ZeroOrOne
-                                           }));
-
-            command.AddOption(
-                new Option("-y", argument: new Argument
-                                           {
-                                               Arity = ArgumentArity.ZeroOrOne
-                                           }));
+            var command = new Command("command")
+            {
+                new Option("-x")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ZeroOrOne
+                    }
+                },
+                new Option("-y")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ZeroOrOne
+                    }
+                }
+            };
 
             var result = command.Parse(input);
 
@@ -1287,7 +1365,7 @@ namespace System.CommandLine.Tests
         [InlineData("--output")]
         public void Option_aliases_can_be_specified_and_are_prefixed_with_defaults(string input)
         {
-            var option = new Option(new[] { "output", "o" }, "");
+            var option = new Option(new[] { "output", "o" });
             var configuration = new CommandLineConfiguration(
                 new[] { option },
                 prefixes: new[] { "-", "--", "/" });
@@ -1317,7 +1395,7 @@ namespace System.CommandLine.Tests
         [InlineData("/out")]
         public void Option_aliases_can_be_specified_for_particular_prefixes(string input)
         {
-            var option = new Option(new[] { "--output", "-o", "/o", "out" }, "");
+            var option = new Option(new[] { "--output", "-o", "/o", "out" });
             var configuration = new CommandLineConfiguration(
                 new[] { option },
                 prefixes: new[] { "-", "--", "/" });
@@ -1332,10 +1410,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Boolean_options_with_no_argument_specified_do_not_match_subsequent_arguments()
         {
-            var command = new Command("command");
-            command.AddOption(
-                new Option("-v",
-                           argument: new Argument<bool>()));
+            var command = new Command("command")
+            {
+                new Option("-v")
+                {
+                    Argument = new Argument<bool>()
+                }
+            };
 
             var result = command.Parse("-v an-argument");
 
@@ -1347,19 +1428,26 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_command_line_has_unmatched_tokens_they_are_not_applied_to_subsequent_options()
         {
-            var command = new Command("command", treatUnmatchedTokensAsErrors: false);
+            var command = new Command("command")
+            {
+                TreatUnmatchedTokensAsErrors = false
+            };
             command.AddOption(
-                new Option("-x",
-                           argument: new Argument
-                                     {
-                                         Arity = ArgumentArity.ExactlyOne
-                                     }));
+                new Option("-x")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                });
             command.AddOption(
-                new Option("-y",
-                           argument: new Argument
-                                     {
-                                         Arity = ArgumentArity.ExactlyOne
-                                     }));
+                new Option("-y")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                });
 
             var result = command.Parse("-x 23 unmatched-token -y 42");
 
@@ -1460,7 +1548,9 @@ namespace System.CommandLine.Tests
                 }
             };
 
-            command.Parse("1 2 3 4")
+            ParseResult parseResult = command.Parse("1 2 3 4");
+
+            parseResult
                    .Errors
                    .Select(e => e.Message)
                    .Should()

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -25,14 +25,14 @@ namespace System.CommandLine.Tests
         public void When_an_option_accepts_only_specific_arguments_but_a_wrong_one_is_supplied_then_an_informative_error_is_returned()
         {
             var parser = new Parser(
-                new Option(
-                    "-x",
-                    "",
-                    new Argument
+                new Option("-x")
+                {
+                    Argument = new Argument
                         {
                             Arity = ArgumentArity.ExactlyOne 
                         }
-                        .FromAmong("this", "that", "the-other-thing")));
+                        .FromAmong("this", "that", "the-other-thing")
+                });
 
             var result = parser.Parse("-x none-of-those");
 
@@ -46,13 +46,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_en_error_then_the_error_has_a_reference_to_the_option()
         {
-            var option = new Option(
-                "-x",
-                "",
-                new Argument
+            var option = new Option("-x")
+            {
+                Argument = new Argument
                 {
                     Arity = ArgumentArity.ExactlyOne
-                }.FromAmong("this", "that"));
+                }.FromAmong("this", "that")
+            };
 
             var parser = new Parser(option);
 
@@ -67,13 +67,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_required_argument_is_not_supplied_then_an_error_is_returned()
         {
-            var parser = new Parser(new Option(
-                                        "-x",
-                                        "",
-                                        new Argument
-                                        {
-                                            Arity = ArgumentArity.ExactlyOne
-                                        }));
+            var parser = new Parser(new Option("-x")
+            {
+                Argument = new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            });
 
             var result = parser.Parse("-x");
 
@@ -86,11 +86,10 @@ namespace System.CommandLine.Tests
         public void When_no_option_accepts_arguments_but_one_is_supplied_then_an_error_is_returned()
         {
             var parser = new Parser(
-                new Command("the-command", "",
-                            new[]
-                            {
-                                new Option("-x", "")
-                            }, Argument.None));
+                new Command("the-command")
+                {
+                    new Option("-x")
+                });
 
             var result = parser.Parse("the-command -x some-arg");
 
@@ -116,10 +115,12 @@ namespace System.CommandLine.Tests
                 return null;
             });
 
-            var command = new Command("the-command", "", new[] {
-                new Option("--one", ""),
-                new Option("--two", "")
-            }, argument);
+            var command = new Command("the-command")
+            {
+                new Option("--one"),
+                new Option("--two"),
+                argument
+            };
 
             var result = command.Parse("the-command --one --two");
 
@@ -133,11 +134,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void LegalFilePathsOnly_rejects_arguments_containing_invalid_path_characters()
         {
-            var command = new Command("the-command", "",
-                                      argument: new Argument
-                                                {
-                                                    Arity = ArgumentArity.ZeroOrMore
-                                                }.LegalFilePathsOnly());
+            var command = new Command("the-command")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ZeroOrMore
+                }.LegalFilePathsOnly()
+            };
 
             var invalidCharacter = Path.GetInvalidPathChars().First(c => c!= '"');
 
@@ -152,11 +155,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void LegalFilePathsOnly_accepts_arguments_containing_valid_path_characters()
         {
-            var command = new Command("the-command", "",
-                                      argument: new Argument
-                                      {
-                                          Arity = ArgumentArity.ZeroOrMore
-                                      }.LegalFilePathsOnly());
+            var command = new Command("the-command")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ZeroOrMore
+                }.LegalFilePathsOnly()
+            };
 
             var validPathName = Directory.GetCurrentDirectory();
             var validNonExistingFileName = Path.Combine(validPathName, Guid.NewGuid().ToString());
@@ -169,19 +174,20 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_argument_can_be_invalid_based_on_file_existence()
         {
-            var command = new Command(
-                "move",
-                argument: new Argument<FileInfo>
-                          {
-                              Arity = ArgumentArity.ExactlyOne
-                          }.ExistingOnly());
-            command.AddOption(
-                new Option(
-                    "--to",
-                    argument: new Argument
-                              {
-                                  Arity = ArgumentArity.ExactlyOne
-                              }));
+            var command = new Command("move")
+            {
+                new Argument<FileInfo>
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }.ExistingOnly(),
+                new Option("--to")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                }
+            };
 
             Guid guid = Guid.NewGuid();
             var result =
@@ -197,19 +203,20 @@ namespace System.CommandLine.Tests
         [Fact] 
         public void An_argument_with_multiple_file_info_can_be_invalid_based_on_first_file_existence()
         {
-            var command = new Command(
-                "move",
-                argument: new Argument<FileInfo[]>
+            var command = new Command("move")
+            {
+                new Argument<FileInfo[]>
                 {
                     Arity = ArgumentArity.ZeroOrMore
-                }.ExistingOnly());
-            command.AddOption(
-                new Option(
-                    "--to",
-                    argument: new Argument
+                }.ExistingOnly(),
+                new Option("--to")
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ExactlyOne
-                    }));
+                    }
+                }
+            };
 
             Guid guid1 = Guid.NewGuid();
             Guid guid2 = Guid.NewGuid();
@@ -225,19 +232,20 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_argument_with_multiple_file_info_can_be_invalid_based_on_second_file_existence()
         {
-            var command = new Command(
-                "move",
-                argument: new Argument<FileInfo[]>
+            var command = new Command("move")
                 {
-                    Arity = ArgumentArity.ZeroOrMore
-                }.ExistingOnly());
-            command.AddOption(
-                new Option(
-                    "--to",
-                    argument: new Argument
+                    new Argument<FileInfo[]>
                     {
-                        Arity = ArgumentArity.ExactlyOne
-                    }));
+                        Arity = ArgumentArity.ZeroOrMore
+                    }.ExistingOnly(),
+                    new Option("--to")
+                    {
+                        Argument = new Argument
+                        {
+                            Arity = ArgumentArity.ExactlyOne
+                        }
+                    }
+                };
 
             var executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
             var guid = Guid.NewGuid();
@@ -253,18 +261,20 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_argument_can_be_invalid_based_on_directory_existence()
         {
-            var command = new Command(
-                "move",
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne
-                          });
-            command.AddOption(
-                new Option("--to",
-                           argument: new Argument<DirectoryInfo>
-                                     {
-                                         Arity = ArgumentArity.ExactlyOne
-                                     }.ExistingOnly()));
+            var command = new Command("move")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                },
+                new Option("--to")
+                {
+                    Argument = new Argument<DirectoryInfo>
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.ExistingOnly()
+                }
+            };
 
             var currentDirectory = Directory.GetCurrentDirectory();
             var trash = Path.Combine(currentDirectory, ".trash");
@@ -284,18 +294,20 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_argument_with_multiple_directory_info_can_be_invalid_based_on_first_directory_existence()
         {
-            var command = new Command(
-                "move",
-                argument: new Argument
+            var command = new Command("move")
+            {
+                new Argument
                 {
                     Arity = ArgumentArity.ExactlyOne
-                });
-            command.AddOption(
-                new Option("--to",
-                    argument: new Argument<DirectoryInfo[]>
+                },
+                new Option("--to")
+                {
+                    Argument = new Argument<DirectoryInfo[]>
                     {
                         Arity = ArgumentArity.ZeroOrMore
-                    }.ExistingOnly()));
+                    }.ExistingOnly()
+                }
+            };
 
             var currentDirectory = Directory.GetCurrentDirectory();
             var trash1 = Path.Combine(currentDirectory, ".trash1");
@@ -317,18 +329,20 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_argument_with_multiple_directory_info_can_be_invalid_based_on_second_directory_existence()
         {
-            var command = new Command(
-                "move",
-                argument: new Argument
+            var command = new Command("move")
+            {
+                new Argument
                 {
                     Arity = ArgumentArity.ExactlyOne
-                });
-            command.AddOption(
-                new Option("--to",
-                    argument: new Argument<DirectoryInfo[]>
+                },
+                new Option("--to")
+                {
+                    Argument = new Argument<DirectoryInfo[]>
                     {
                         Arity = ArgumentArity.ZeroOrMore
-                    }.ExistingOnly()));
+                    }.ExistingOnly()
+                }
+            };
 
             var currentDirectory = Directory.GetCurrentDirectory();
             var executionAssemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
@@ -389,13 +403,13 @@ namespace System.CommandLine.Tests
         public void When_an_option_is_specified_more_than_once_but_only_allowed_once_then_an_informative_error_is_returned()
         {
             var parser = new Parser(
-                new Option(
-                    "-x",
-                    "",
-                    new Argument
+                new Option("-x")
+                {
+                    Argument = new Argument
                     {
                         Arity = ArgumentArity.ExactlyOne
-                    }));
+                    }
+                });
 
             var result = parser.Parse("-x 1 -x 2");
 
@@ -409,10 +423,10 @@ namespace System.CommandLine.Tests
         public void When_arity_is_ExactlyOne_it_validates_against_extra_arguments()
         {
             var parser = new Parser(
-                new Option(
-                    "-x",
-                    "",
-                    new Argument<int>()));
+                new Option("-x")
+                {
+                    Argument = new Argument<int>()
+                });
 
             var result = parser.Parse("-x 1 -x 2");
 
@@ -426,9 +440,10 @@ namespace System.CommandLine.Tests
         public void When_an_option_has_a_default_value_it_is_not_valid_to_specify_the_option_without_an_argument()
         {
             var parser = new Parser(
-                new Option(
-                    "-x", "",
-                    new Argument<int>(123)));
+                new Option("-x")
+                {
+                    Argument = new Argument<int>(() => 123)
+                });
 
             var result = parser.Parse("-x");
 
@@ -442,14 +457,14 @@ namespace System.CommandLine.Tests
         public void When_an_option_has_a_default_value_then_the_default_should_apply_if_not_specified()
         {
             var parser = new Parser(
-                new Option(
-                    "-x",
-                    "",
-                    new Argument<int>(123)),
-                new Option(
-                    "-y",
-                    "",
-                    new Argument<int>(456)));
+                new Option("-x")
+                {
+                    Argument = (Argument) new Argument<int>(() => 123)
+                },
+                new Option("-y")
+                {
+                    Argument = (Argument) new Argument<int>(() => 456)
+                });
 
             var result = parser.Parse("");
 

--- a/src/System.CommandLine.Tests/PositionalOptionTests.cs
+++ b/src/System.CommandLine.Tests/PositionalOptionTests.cs
@@ -17,14 +17,14 @@ namespace System.CommandLine.Tests
             var configuration = new CommandLineConfiguration(
                 new[]
                 {
-                    new Option(
-                        "-x",
-                        "",
-                        new Argument<int>(123)),
-                    new Option(
-                        "-y",
-                        "",
-                        new Argument<int>(456))
+                    new Option("-x")
+                    {
+                        Argument = new Argument<int>(() => 123)
+                    },
+                    new Option("-y")
+                    {
+                        Argument = new Argument<int>(() => 456)
+                    }
                 },
                 enablePositionalOptions: true);
 
@@ -43,14 +43,14 @@ namespace System.CommandLine.Tests
             var configuration = new CommandLineConfiguration(
                 new[]
                 {
-                    new Option(
-                        "-x",
-                        "",
-                        new Argument<int>(123)),
-                    new Option(
-                        "-y",
-                        "",
-                        new Argument<int>(456))
+                    new Option("-x")
+                    {
+                        Argument = new Argument<int>(() => 123)
+                    },
+                    new Option("-y")
+                    {
+                        Argument = new Argument<int>(() => 456)
+                    }
                 },
                 enablePositionalOptions: true);
 
@@ -71,13 +71,19 @@ namespace System.CommandLine.Tests
                          .AddCommand(
                              new Command("command1")
                              {
-                                 new Option("-anon", "", new Argument<string>())
+                                 new Option("-anon")
+                                 {
+                                     Argument = new Argument<string>()
+                                 }
                              }
                          )
                          .AddCommand(
                              new Command("command2")
                              {
-                                 new Option("-anon", "", new Argument<string>())
+                                 new Option("-anon")
+                                 {
+                                     Argument = new Argument<string>()
+                                 }
                              }
                          )
                          .Build();
@@ -98,16 +104,22 @@ namespace System.CommandLine.Tests
             int subcommand2Options)
         {
             var subcommand1 = new Command("subcommand1");
-            foreach (int optionIndex in Enumerable.Range(1, subcommand1Options))
+            foreach (var optionIndex in Enumerable.Range(1, subcommand1Options))
             {
-                subcommand1.AddOption(new Option($"-anon{optionIndex}", "", new Argument<string>()));
+                subcommand1.AddOption(new Option($"-anon{optionIndex}")
+                {
+                    Argument = new Argument<string>()
+                });
             }
 
             var subcommand2 = new Command("subcommand2");
             subcommand1.AddCommand(subcommand2);
-            foreach (int optionIndex in Enumerable.Range(1, subcommand2Options))
+            foreach (var optionIndex in Enumerable.Range(1, subcommand2Options))
             {
-                subcommand2.AddOption(new Option($"-anon{optionIndex}", "", new Argument<string>()));
+                subcommand2.AddOption(new Option($"-anon{optionIndex}")
+                {
+                    Argument = new Argument<string>()
+                });
             }
 
             var parser = new CommandLineBuilder()
@@ -152,8 +164,14 @@ namespace System.CommandLine.Tests
                          .EnablePositionalOptions()
                          .AddCommand(new Command("subcommand")
                                      {
-                                         new Option("-anon1", "", new Argument<string>()),
-                                         new Option("-anon2", "", new Argument<string>())
+                                         new Option("-anon1")
+                                         {
+                                             Argument = new Argument<string>()
+                                         },
+                                         new Option("-anon2")
+                                         {
+                                             Argument = new Argument<string>()
+                                         }
                                      }
                          )
                          .Build();
@@ -170,7 +188,10 @@ namespace System.CommandLine.Tests
         {
             var result = new CommandLineBuilder()
                          .EnablePositionalOptions()
-                         .AddOption(new Option("-a", "", new Argument<string>()))
+                         .AddOption(new Option("-a")
+                         {
+                             Argument = new Argument<string>()
+                         })
                          .Build()
                          .Parse("value-for-a");
 
@@ -182,9 +203,15 @@ namespace System.CommandLine.Tests
         {
             var rootCommand = new RootCommand
                               {
-                                  new Option("-a", "", new Argument<string>()),
+                                  new Option("-a")
+                                  {
+                                      Argument = new Argument<string>()
+                                  },
                                   new Option("-b"),
-                                  new Option("-c", "", new Argument<string>())
+                                  new Option("-c")
+                                  {
+                                      Argument = new Argument<string>()
+                                  }
                               };
             var result = new CommandLineBuilder(rootCommand)
                          .EnablePositionalOptions()
@@ -201,9 +228,15 @@ namespace System.CommandLine.Tests
         {
             var rootCommand = new RootCommand
                               {
-                                  new Option("-a", "", new Argument<string>()),
+                                  new Option("-a")
+                                  {
+                                      Argument = new Argument<string>()
+                                  },
                                   new Option("-b"),
-                                  new Option("-c", "", new Argument<string>())
+                                  new Option("-c")
+                                  {
+                                      Argument = new Argument<string>()
+                                  }
                               };
             var result = new CommandLineBuilder(rootCommand)
                          .EnablePositionalOptions()
@@ -220,9 +253,15 @@ namespace System.CommandLine.Tests
         {
             var result = new CommandLineBuilder()
                          .EnablePositionalOptions()
-                         .AddOption(new Option("-a", "", new Argument<string>()))
+                         .AddOption(new Option("-a")
+                         {
+                             Argument = new Argument<string>()
+                         })
                          .AddOption(new Option("-b"))
-                         .AddOption(new Option("-c", "", new Argument<string>()))
+                         .AddOption(new Option("-c")
+                         {
+                             Argument = new Argument<string>()
+                         })
                          .Build()
                          .Parse("-c value-for-c value-for-a");
 

--- a/src/System.CommandLine.Tests/ResponseFileTests.cs
+++ b/src/System.CommandLine.Tests/ResponseFileTests.cs
@@ -59,7 +59,10 @@ namespace System.CommandLine.Tests
             var result = new RootCommand
                          {
                              new Option("--flag"),
-                             new Option("--flag2", argument: new Argument<int>())
+                             new Option("--flag2")
+                             {
+                                 Argument = new Argument<int>()
+                             }
                          }
                 .Parse($"@{responseFile}");
 
@@ -163,7 +166,10 @@ namespace System.CommandLine.Tests
                 "123");
 
             var result = new CommandLineBuilder()
-                         .AddOption(new Option("--flag", argument: new Argument<int>()))
+                         .AddOption(new Option("--flag")
+                         {
+                             Argument = new Argument<int>()
+                         })
                          .Build()
                          .Parse($"@{responseFile}");
 
@@ -257,10 +263,16 @@ namespace System.CommandLine.Tests
             var responseFile = ResponseFile(input);
 
             var rootCommand = new RootCommand
-                              {
-                                  new Option("--flag", "", new Argument<string>()),
-                                  new Option("--flag2", "", new Argument<int>())
-                              };
+            {
+                new Option("--flag")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--flag2")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
             var parser = new CommandLineBuilder(rootCommand)
                          .ParseResponseFileAs(ResponseFileHandling.ParseArgsAsSpaceSeparated)
                          .Build();

--- a/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
@@ -20,15 +20,22 @@ namespace System.CommandLine.Tests
 
         public SuggestDirectiveTests()
         {
-            _fruitOption = new Option("--fruit",
-                                      argument: new Argument<string>()
-                                          .WithSuggestions("apple", "banana", "cherry"));
+            _fruitOption = new Option("--fruit")
+            {
+                Argument = new Argument<string>()
+                    .WithSuggestions("apple", "banana", "cherry")
+            };
 
-            _vegetableOption = new Option("--vegetable",
-                                          argument: new Argument<string>()
-                                              .WithSuggestions("asparagus", "broccoli", "carrot"));
+            _vegetableOption = new Option("--vegetable")
+            {
+                Argument = new Argument<string>()
+                    .WithSuggestions("asparagus", "broccoli", "carrot")
+            };
 
-            _eatCommand = new Command("eat") { _fruitOption, _vegetableOption };
+            _eatCommand = new Command("eat")
+            {
+                _fruitOption, _vegetableOption
+            };
         }
 
         [Fact]
@@ -250,7 +257,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_does_not_repeat_suggestion_for_already_specified_bool_option()
         {
-            var command = new RootCommand { new Option("--bool-option", argument: new Argument<bool>()), };
+            var command = new RootCommand
+            {
+                new Option("--bool-option")
+                {
+                    Argument = new Argument<bool>()
+                }
+            };
 
             var console = new TestConsole();
 

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.IO;
@@ -22,14 +23,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_Suggest_returns_argument_suggestions_if_configured()
         {
-            var option = new Option(
-                "--hello",
-                "",
-                new Argument
+            var option = new Option("--hello")
+            {
+                Argument = new Argument
                     {
                         Arity = ArgumentArity.ExactlyOne
                     }
-                    .WithSuggestions("one", "two", "three"));
+                    .WithSuggestions("one", "two", "three")
+            };
 
             var suggestions = option.Suggest();
 
@@ -39,11 +40,22 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_Suggest_returns_available_option_aliases()
         {
-            var command = new Command("command", "a command", new[] {
+            IReadOnlyCollection<Symbol> symbols = new[] {
                 new Option("--one", "option one"),
                 new Option("--two", "option two"),
                 new Option("--three", "option three")
-            });
+            };
+            var command1 = new Command(
+                "command",
+                "a command"
+            );
+
+            foreach (var symbol in symbols)
+            {
+                command1.Add(symbol);
+            }
+
+            var command = command1;
 
             var suggestions = command.Suggest();
 
@@ -53,13 +65,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_Suggest_returns_available_subcommands()
         {
-            var command = new Command(
-                "command", "a command",
-                new[] {
-                    new Command("one", "subcommand one"),
-                    new Command("two", "subcommand two"),
-                    new Command("three", "subcommand three")
-                });
+            var command = new Command("command")
+            {
+                new Command("one"),
+                new Command("two"),
+                new Command("three")
+            };
 
             var suggestions = command.Suggest();
 
@@ -69,12 +80,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_Suggest_returns_available_subcommands_and_option_aliases()
         {
-            var command = new Command(
-                "command", "a command",
-                new Symbol[] {
-                    new Command("subcommand", "subcommand"),
-                    new Option("--option", "option")
-                });
+            var command = new Command("command")
+            {
+                new Command("subcommand"),
+                new Option("--option")
+            };
 
             var suggestions = command.Suggest();
 
@@ -84,17 +94,16 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_Suggest_returns_available_subcommands_and_option_aliases_and_configured_arguments()
         {
-            var command = new Command(
-                "command", "a command",
-                new Symbol[] {
-                    new Command("subcommand", "subcommand"),
-                    new Option("--option", "option")
-                },
+            var command = new Command("command")
+            {
+                new Command("subcommand", "subcommand"),
+                new Option("--option", "option"),
                 new Argument
                     {
                         Arity = ArgumentArity.OneOrMore
                     }
-                    .WithSuggestions("command-argument"));
+                    .WithSuggestions("command-argument")
+            };
 
             var suggestions = command.Suggest();
 
@@ -106,12 +115,18 @@ namespace System.CommandLine.Tests
         public void When_an_option_has_a_default_value_it_will_still_be_suggested()
         {
             var parser = new Parser(
-                new Option("--apple", "kinds of apples",
-                           new Argument<string[]>(new[] { "cortland" })),
-                new Option("--banana", "kinds of bananas",
-                           new Argument<string[]>()),
-                new Option("--cherry", "kinds of cherries",
-                           new Argument<string>()));
+                new Option("--apple", "kinds of apples")
+                {
+                    Argument = new Argument<string[]>("cortland")
+                },
+                new Option("--banana", "kinds of bananas")
+                {
+                    Argument = new Argument<string[]>()
+                },
+                new Option("--cherry", "kinds of cherries")
+                {
+                    Argument = new Argument<string>()
+                });
 
             var result = parser.Parse("");
 
@@ -192,11 +207,14 @@ namespace System.CommandLine.Tests
         public void When_a_subcommand_has_been_specified_then_its_sibling_options_with_argument_limit_reached_will_be_not_be_suggested()
         {
             var command = new RootCommand("parent")
-                          {
-                              new Command("child"),
-                              new Option("--parent-option", argument: new Argument<string>())
-                          };
-            command.Argument = new Argument<string>();
+            {
+                new Command("child"),
+                new Option("--parent-option")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Argument<string>()
+            };
 
             var commandLine = "--parent-option 123 child";
             var parseResult = command.Parse(commandLine);
@@ -211,14 +229,16 @@ namespace System.CommandLine.Tests
         public void When_a_subcommand_has_been_specified_then_its_child_options_will_be_suggested()
         {
             var command = new RootCommand("parent")
-                          {
-                              new Command("child")
-                              {
-                                  new Option("--child-option",
-                                             argument: new Argument<string>())
-                              }
-                          };
-            command.Argument = new Argument<string>();
+            {
+                new Argument<string>(),
+                new Command("child")
+                {
+                    new Option("--child-option")
+                    {
+                        Argument = new Argument<string>()
+                    }
+                }
+            };
 
             var commandLine = "child ";
             var parseResult = command.Parse(commandLine);
@@ -259,14 +279,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_one_option_has_been_partially_specified_then_nonmatching_siblings_will_not_be_suggested()
         {
-            var parser = new CommandLineBuilder()
-                         .AddOption(new Option("--apple"))
-                         .AddOption(new Option("--banana"))
-                         .AddOption(new Option("--cherry"))
-                         .Build();
+            var command = new Command("the-command")
+            {
+                new Option("--apple"),
+                new Option("--banana"),
+                new Option("--cherry")
+            };
 
             var input = "a";
-            var result = parser.Parse(input);
+            var result = command.Parse(input);
 
             result.Suggestions(input.Length)
                   .Should()
@@ -277,12 +298,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_can_be_hidden_from_suggestions_by_setting_IsHidden_to_true()
         {
-            var command = new Command(
-                "the-command", "Does things.",
-                new[] {
-                    new Option("--hide-me", isHidden: true),
-                    new Option("-n", "Not hidden")
-                });
+            var command = new Command("the-command")
+            {
+                new Option("--hide-me")
+                {
+                    IsHidden = true
+                },
+                new Option("-n", "Not hidden")
+            };
 
             var suggestions = command.Parse("the-command ").Suggestions();
 
@@ -293,14 +316,16 @@ namespace System.CommandLine.Tests
         public void Parser_options_can_supply_context_sensitive_matches()
         {
             var parser = new Parser(
-                new Option(
-                    "--bread", "",
-                    new Argument { Arity = ArgumentArity.ExactlyOne }
-                        .FromAmong("wheat", "sourdough", "rye")),
-                new Option(
-                    "--cheese", "",
-                    new Argument { Arity = ArgumentArity.ExactlyOne }
-                        .FromAmong("provolone", "cheddar", "cream cheese")));
+                new Option("--bread")
+                {
+                    Argument = new Argument { Arity = ArgumentArity.ExactlyOne }
+                        .FromAmong("wheat", "sourdough", "rye")
+                },
+                new Option("--cheese")
+                {
+                    Argument = new Argument { Arity = ArgumentArity.ExactlyOne }
+                        .FromAmong("provolone", "cheddar", "cream cheese")
+                });
 
             var commandLine = "--bread";
             var result = parser.Parse(commandLine);
@@ -320,16 +345,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Subcommand_names_are_available_as_suggestions()
         {
-            var command = new Command(
-                "test", "",
-                new[] {
-                    new Command("one", "Command one"),
-                    new Command("two", "Command two")
-                },
+            var command = new Command("test")
+            {
+                new Command("one", "Command one"),
+                new Command("two", "Command two"),
                 new Argument
                 {
                     Arity = ArgumentArity.ExactlyOne
-                });
+                }
+            };
 
             var commandLine = "test";
             command.Parse(commandLine)
@@ -341,17 +365,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Both_subcommands_and_options_are_available_as_suggestions()
         {
-            var command = new Command(
-                "test", "",
-                new Symbol[]
-                {
-                    new Command("one", "Command one"),
-                    new Option("--one", "Option one")
-                },
+            var command = new Command("test")
+            {
+                new Command("one"),
+                new Option("--one"),
                 new Argument
                 {
                     Arity = ArgumentArity.ExactlyOne
-                });
+                }
+            };
 
             var commandLine = "test";
 
@@ -366,12 +388,14 @@ namespace System.CommandLine.Tests
         [InlineData("outer -")]
         public void Option_suggestions_are_not_provided_without_matching_prefix(string input)
         {
-            var parser = new Parser(
-                new Command("outer", "", new[] {
-                    new Option("--one", "Option one"),
-                    new Option("--two", "Option two"),
-                    new Option("--three", "Option three")
-                }));
+            var command = new Command("outer")
+            {
+                new Option("--one"),
+                new Option("--two"),
+                new Option("--three")
+            };
+
+            var parser = new Parser(command);
 
             ParseResult result = parser.Parse(input);
             result.Suggestions().Should().BeEmpty();
@@ -381,11 +405,12 @@ namespace System.CommandLine.Tests
         public void Option_suggestions_can_be_based_on_the_proximate_option()
         {
             var parser = new Parser(
-                new Command("outer", "", new[] {
-                    new Option("--one", "Option one"),
-                    new Option("--two", "Option two"),
-                    new Option("--three", "Option three")
-                }));
+                new Command("outer")
+                {
+                    new Option("--one"),
+                    new Option("--two"),
+                    new Option("--three")
+                });
 
             var commandLine = "outer";
             ParseResult result = parser.Parse(commandLine);
@@ -397,18 +422,25 @@ namespace System.CommandLine.Tests
         public void Argument_suggestions_can_be_based_on_the_proximate_option()
         {
             var parser = new Parser(
-                new Command("outer", "",
-                            new[]
+                new Command("outer")
+                {
+                    new Option("--one")
+                    {
+                        Argument = new Argument
                             {
-                                new Option(
-                                    "--one",
-                                    argument: new Argument { Arity = ArgumentArity.ExactlyOne }
-                                        .FromAmong("one-a", "one-b")),
-                                new Option(
-                                    "--two",
-                                    argument: new Argument { Arity = ArgumentArity.ExactlyOne }
-                                        .FromAmong("two-a", "two-b"))
-                            }));
+                                Arity = ArgumentArity.ExactlyOne
+                            }
+                            .FromAmong("one-a", "one-b")
+                    },
+                    new Option("--two")
+                    {
+                        Argument = new Argument
+                            {
+                                Arity = ArgumentArity.ExactlyOne
+                            }
+                            .FromAmong("two-a", "two-b")
+                    }
+                });
 
             var commandLine = "outer --two";
             ParseResult result = parser.Parse(commandLine);
@@ -420,13 +452,12 @@ namespace System.CommandLine.Tests
         public void Option_suggestions_can_be_based_on_the_proximate_option_and_partial_input()
         {
             var parser = new Parser(
-                new Command(
-                    "outer", "",
-                    new[] {
-                        new Command("one", "Command one"),
-                        new Command("two", "Command two"),
-                        new Command("three", "Command three")
-                    }));
+                new Command("outer")
+                {
+                    new Command("one", "Command one"),
+                    new Command("two", "Command two"),
+                    new Command("three", "Command three")
+                });
 
             ParseResult result = parser.Parse("outer o");
 
@@ -436,16 +467,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Suggestions_can_be_provided_in_the_absence_of_validation()
         {
-            var command = new Command(
-                "the-command", "",
-                new[] {
-                    new Option("-t", "",
-                               new Argument
-                                   {
-                                       Arity = ArgumentArity.ExactlyOne
-                                   }
-                                   .WithSuggestions("vegetable", "mineral", "animal"))
-                });
+            var command = new Command("the-command")
+                {
+                    new Option("-t")
+                    {
+                        Argument = new Argument
+                            {
+                                Arity = ArgumentArity.ExactlyOne
+                            }
+                            .WithSuggestions("vegetable", "mineral", "animal")
+                    }
+                };
 
             command.Parse("the-command -t m")
                    .Suggestions()
@@ -459,21 +491,22 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Suggestions_can_be_provided_using_a_delegate()
         {
-            var command = new Command(
-                "the-command", "",
-                new[] {
-                    new Command(
-                        "one", "",
-                        argument: new Argument
-                            {
-                                Arity = ArgumentArity.ExactlyOne
-                            }
-                            .WithSuggestionSource(_=> new[] {
-                                "vegetable",
-                                "mineral",
-                                "animal"
-                            }))
-                });
+            var command = new Command("the-command")
+            {
+                new Command("one")
+                {
+                    new Argument
+                        {
+                            Arity = ArgumentArity.ExactlyOne
+                        }
+                        .WithSuggestionSource(_ => new[]
+                        {
+                            "vegetable",
+                            "mineral",
+                            "animal"
+                        })
+                }
+            };
 
             command.Parse("the-command one m")
                    .Suggestions()
@@ -484,34 +517,36 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_caller_does_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_option()
         {
-            var command = new Command("outer");
-            command.AddOption(
-                new Option("one",
-                           argument: new Argument
-                                     {
-                                         Arity = ArgumentArity.ExactlyOne
-                                     }.FromAmong("one-a", "one-b", "one-c"))
-            );
-            command.AddOption(
-                new Option("two",
-                           argument: new Argument
-                                     {
-                                         Arity = ArgumentArity.ExactlyOne
-                                     }.FromAmong("two-a", "two-b", "two-c"))
-            );
-            command.AddOption(
-                new Option("three",
-                           argument: new Argument
-                                     {
-                                         Arity = ArgumentArity.ExactlyOne
-                                     }.FromAmong("three-a", "three-b", "three-c"))
-            );
+            var command = new Command("outer")
+            {
+                new Option("one")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("one-a", "one-b", "one-c")
+                },
+                new Option("two")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("two-a", "two-b", "two-c")
+                },
+                new Option("three")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("three-a", "three-b", "three-c")
+                }
+            };
 
             var parser = new CommandLineBuilder()
                          .AddCommand(command)
                          .Build();
 
-            ParseResult result = parser.Parse("outer two b" );
+            var result = parser.Parse("outer two b" );
 
             result.Suggestions()
                   .Should()
@@ -521,25 +556,30 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_caller_does_not_do_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_option()
         {
-            var command = new Command("outer");
-            command.AddOption(
-                new Option("one", "",
-                           new Argument
-                           {
-                               Arity = ArgumentArity.ExactlyOne
-                           }.FromAmong("one-a", "one-b", "one-c")));
-            command.AddOption(
-                new Option("two", "",
-                           new Argument
-                           {
-                               Arity = ArgumentArity.ExactlyOne
-                           }.FromAmong("two-a", "two-b", "two-c")));
-            command.AddOption(
-                new Option("three", "",
-                           new Argument
-                           {
-                               Arity = ArgumentArity.ExactlyOne
-                           }.FromAmong("three-a", "three-b", "three-c")));
+            var command = new Command("outer")
+            {
+                new Option("one")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("one-a", "one-b", "one-c")
+                },
+                new Option("two")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("two-a", "two-b", "two-c")
+                },
+                new Option("three")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("three-a", "three-b", "three-c")
+                }
+            };
 
             var result = command.Parse("outer two b");
 
@@ -551,30 +591,32 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_caller_does_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_command()
         {
-            var outer = new Command("outer");
-            var one = new Command(
-                "one",
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne
-                          }.FromAmong("one-a", "one-b", "one-c"));
-            var two = new Command(
-                "two",
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne
-                          }.FromAmong("two-a", "two-b", "two-c"));
-            var three = new Command(
-                "three",
-                argument: new Argument
-                          {
-                              Arity = ArgumentArity.ExactlyOne
-                          }.FromAmong("three-a", "three-b", "three-c"));
-            outer.AddCommand(one);
-            outer.AddCommand(two);
-            outer.AddCommand(three);
+            var outer = new Command("outer")
+            {
+                new Command("one")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("one-a", "one-b", "one-c")
+                },
+                new Command("two")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("two-a", "two-b", "two-c")
+                },
+                new Command("three")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("three-a", "three-b", "three-c")
+                }
+            };
 
-            ParseResult result = outer.Parse("outer two b");
+            var result = outer.Parse("outer two b");
 
             result.Suggestions()
                   .Should()
@@ -585,26 +627,29 @@ namespace System.CommandLine.Tests
         public void When_caller_does_not_do_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_command()
         {
             var outer = new Command("outer")
-                        {
-                            new Command(
-                                "one",
-                                argument: new Argument
-                                          {
-                                              Arity = ArgumentArity.ExactlyOne
-                                          }.FromAmong("one-a", "one-b", "one-c")),
-                            new Command(
-                                "two",
-                                argument: new Argument
-                                          {
-                                              Arity = ArgumentArity.ExactlyOne
-                                          }.FromAmong("two-a", "two-b", "two-c")),
-                            new Command(
-                                "three",
-                                argument: new Argument
-                                          {
-                                              Arity = ArgumentArity.ExactlyOne
-                                          }.FromAmong("three-a", "three-b", "three-c"))
-                        };
+            {
+                new Command("one")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("one-a", "one-b", "one-c")
+                },
+                new Command("two")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("two-a", "two-b", "two-c")
+                },
+                new Command("three")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("three-a", "three-b", "three-c")
+                }
+            };
 
             ParseResult result = outer.Parse("outer two b");
 
@@ -616,8 +661,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Arguments_of_type_enum_provide_enum_values_as_suggestions()
         {
-            var command = new Command("the-command",
-                                      argument: new Argument<FileMode>());
+            var command = new Command("the-command")
+            {
+                new Argument<FileMode>()
+            };
 
             var suggestions = command.Parse("the-command create")
                                      .Suggestions();
@@ -628,11 +675,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_that_have_been_specified_to_their_maximum_arity_are_not_suggested()
         {
-            var command = new Command("command");
-            command.AddOption(new Option("--allows-one",
-                                         argument: new Argument<string>()));
-            command.AddOption(new Option("--allows-many",
-                                         argument: new Argument<string[]>()));
+            var command = new Command("command")
+            {
+                new Option("--allows-one")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--allows-many")
+                {
+                    Argument = new Argument<string[]>()
+                }
+            };
 
             var commandLine = "--allows-one x";
             var suggestions = command.Parse(commandLine).Suggestions(commandLine.Length + 1);
@@ -644,8 +697,14 @@ namespace System.CommandLine.Tests
         public void When_current_symbol_is_an_option_that_requires_arguments_then_parent_symbol_suggestions_are_omitted()
         {
             var parser = new CommandLineBuilder()
-                         .AddOption(new Option("--allows-one", argument: new Argument<string>()))
-                         .AddOption(new Option("--allows-many", argument: new Argument<string[]>()))
+                         .AddOption(new Option("--allows-one")
+                         {
+                             Argument = new Argument<string>()
+                         })
+                         .AddOption(new Option("--allows-many")
+                         {
+                             Argument = new Argument<string[]>()
+                         })
                          .UseSuggestDirective()
                          .Build();
 
@@ -657,13 +716,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_substring_matching_when_arguments_have_default_values()
         {
-            var command = new Command("the-command");
-            command.AddOption(
-                new Option("--implicit",
-                           argument: new Argument<string>(defaultValue: "the-default")));
-            command.AddOption(
-                new Option("--not",
-                           argument: new Argument<string>("the-default")));
+            var command = new Command("the-command")
+            {
+                new Option("--implicit")
+                {
+                    Argument = new Argument<string>(defaultValue: () => "the-default")
+                },
+                new Option("--not")
+                {
+                    Argument = new Argument<string>("the-default")
+                }
+            };
 
             var suggestions = command.Parse("m").Suggestions();
 
@@ -675,12 +738,22 @@ namespace System.CommandLine.Tests
             [Fact]
             public void When_position_is_unspecified_in_string_command_line_not_ending_with_a_space_then_it_returns_final_token()
             {
-                var command = new Command("the-command", "",
-                                          new[]
-                                          {
-                                              new Option("--option1", ""),
-                                              new Option("--option2", "")
-                                          });
+                IReadOnlyCollection<Symbol> symbols = new[]
+                {
+                    new Option("--option1"),
+                    new Option("--option2")
+                };
+                var command1 = new Command(
+                    "the-command",
+                    ""
+                );
+
+                foreach (var symbol in symbols)
+                {
+                    command1.Add(symbol);
+                }
+
+                var command = command1;
 
                 string textToMatch = command.Parse("the-command t")
                                             .TextToMatch();
@@ -691,12 +764,22 @@ namespace System.CommandLine.Tests
             [Fact]
             public void When_position_is_unspecified_in_string_command_line_ending_with_a_space_then_it_returns_empty()
             {
-                Command command = new Command("the-command", "",
-                                              new[]
-                                              {
-                                                  new Option("--option1", ""),
-                                                  new Option("--option2", "")
-                                              });
+                IReadOnlyCollection<Symbol> symbols = new[]
+                {
+                    new Option("--option1"),
+                    new Option("--option2")
+                };
+                var command1 = new Command(
+                    "the-command",
+                    ""
+                );
+
+                foreach (var symbol in symbols)
+                {
+                    command1.Add(symbol);
+                }
+
+                Command command = command1;
 
                 var commandLine = "the-command t";
                 string textToMatch = command.Parse(commandLine)
@@ -708,16 +791,21 @@ namespace System.CommandLine.Tests
             [Fact]
             public void When_position_is_greater_than_input_length_in_a_string_command_line_then_it_returns_empty()
             {
-                Command command = new Command("the-command", "",
-                                              new[]
-                                              {
-                                                  new Option("--option1", "", new Argument<string>().FromAmong("apple", "banana", "cherry", "durian")),
-                                                  new Option("--option2", "", new Argument<string>())
-                                              });
-                command.Argument = new Argument<string>();
+                var command = new Command("the-command")
+                {
+                    new Argument<string>(),
+                    new Option("--option1")
+                    {
+                        Argument = new Argument<string>().FromAmong("apple", "banana", "cherry", "durian")
+                    },
+                    new Option("--option2")
+                    {
+                        Argument = new Argument<string>()
+                    }
+                };
 
-                string textToMatch = command.Parse("the-command --option1 a")
-                                            .TextToMatch(1000);
+                var textToMatch = command.Parse("the-command --option1 a")
+                                         .TextToMatch(1000);
 
                 textToMatch.Should().Be("");
             }
@@ -725,12 +813,22 @@ namespace System.CommandLine.Tests
             [Fact]
             public void When_position_is_unspecified_in_array_command_line_and_final_token_is_unmatched_then_it_returns_final_token()
             {
-                var command = new Command("the-command", "",
-                                          new[]
-                                          {
-                                              new Option("--option1", ""),
-                                              new Option("--option2", "")
-                                          });
+                IReadOnlyCollection<Symbol> symbols = new[]
+                {
+                    new Option("--option1"),
+                    new Option("--option2")
+                };
+                var command1 = new Command(
+                    "the-command",
+                    ""
+                );
+
+                foreach (var symbol in symbols)
+                {
+                    command1.Add(symbol);
+                }
+
+                var command = command1;
 
                 string textToMatch = command.Parse("the-command", "opt")
                                             .TextToMatch();
@@ -741,12 +839,22 @@ namespace System.CommandLine.Tests
             [Fact]
             public void When_position_is_unspecified_in_array_command_line_and_final_token_matches_an_command_then_it_returns_empty()
             {
-                Command command = new Command("the-command", "",
-                                              new[]
-                                              {
-                                                  new Option("--option1", ""),
-                                                  new Option("--option2", "")
-                                              });
+                IReadOnlyCollection<Symbol> symbols = new[]
+                {
+                    new Option("--option1"),
+                    new Option("--option2")
+                };
+                var command1 = new Command(
+                    "the-command",
+                    ""
+                );
+
+                foreach (var symbol in symbols)
+                {
+                    command1.Add(symbol);
+                }
+
+                Command command = command1;
 
                 string textToMatch = command.Parse(new[] { "the-command" })
                                             .TextToMatch();
@@ -757,12 +865,22 @@ namespace System.CommandLine.Tests
             [Fact]
             public void When_position_is_unspecified_in_array_command_line_and_final_token_matches_an_option_then_it_returns_empty()
             {
-                Command command = new Command("the-command", "",
-                                              new[]
-                                              {
-                                                  new Option("--option1", ""),
-                                                  new Option("--option2", "")
-                                              });
+                IReadOnlyCollection<Symbol> symbols = new[]
+                {
+                    new Option("--option1"),
+                    new Option("--option2")
+                };
+                var command1 = new Command(
+                    "the-command",
+                    ""
+                );
+
+                foreach (var symbol in symbols)
+                {
+                    command1.Add(symbol);
+                }
+
+                Command command = command1;
 
                 string textToMatch = command.Parse("the-command", "--option1")
                                             .TextToMatch();
@@ -773,13 +891,18 @@ namespace System.CommandLine.Tests
             [Fact]
             public void When_position_is_unspecified_in_array_command_line_and_final_token_matches_an_argument_then_it_returns_empty()
             {
-                Command command = new Command("the-command", "",
-                                              new[]
-                                              {
-                                                  new Option("--option1", "", new Argument<string>().FromAmong("apple", "banana", "cherry", "durian")),
-                                                  new Option("--option2", "", new Argument<string>())
-                                              });
-                command.Argument = new Argument<string>();
+                var command = new Command("the-command")
+                {
+                    new Option("--option1")
+                    {
+                        Argument = new Argument<string>().FromAmong("apple", "banana", "cherry", "durian")
+                    },
+                    new Option("--option2")
+                    {
+                        Argument = new Argument<string>()
+                    },
+                    new Argument<string>()
+                };
 
                 string textToMatch = command.Parse("the-command", "--option1", "a")
                                             .TextToMatch();
@@ -799,11 +922,13 @@ namespace System.CommandLine.Tests
                 string expected)
             {
                 var command =
-                    new Command("the-command", "",
-                                argument: new Argument
-                                          {
-                                              Arity = ArgumentArity.ZeroOrMore
-                                          });
+                    new Command("the-command")
+                    {
+                        new Argument
+                        {
+                            Arity = ArgumentArity.ZeroOrMore
+                        }
+                    };
 
                 var position = commandLine.IndexOf("$", StringComparison.Ordinal);
 

--- a/src/System.CommandLine.Tests/SymbolTests.cs
+++ b/src/System.CommandLine.Tests/SymbolTests.cs
@@ -75,11 +75,10 @@ namespace System.CommandLine.Tests
                   .WithMessage($"Property {typeof(TestSymbol).Name}.Name cannot have a prefix.");
         }
 
-
         private class TestSymbol : Symbol
         {
-            internal TestSymbol(IReadOnlyCollection<string> aliases, string description, Argument argDef = null)
-                : base(aliases, description, argDef)
+            internal TestSymbol(IReadOnlyCollection<string> aliases, string description, Argument argument = null)
+                : base(aliases, description)
             {
             }
         }

--- a/src/System.CommandLine.Tests/ValidationMessageLocalizationTests.cs
+++ b/src/System.CommandLine.Tests/ValidationMessageLocalizationTests.cs
@@ -15,11 +15,13 @@ namespace System.CommandLine.Tests
         {
             var messages = new FakeValidationMessages("the-message");
 
-            var command = new Command("the-command", "",
-                                      argument: new Argument
-                                      {
-                                          Arity = ArgumentArity.ExactlyOne
-                                      });
+            var command = new Command("the-command", "")
+            {
+                new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            };
             var parser = new Parser(new CommandLineConfiguration(new[] { command }, validationMessages: messages));
             var result = parser.Parse("the-command");
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -15,6 +15,18 @@ namespace System.CommandLine
         private IArgumentArity _arity;
         private TryConvertArgument _convertArguments;
 
+        public Argument()
+        {
+        }
+
+        public Argument(string name)
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                Name = name;
+            }
+        }
+
         internal HashSet<string> AllowedValues { get; private set; }
 
         public IArgumentArity Arity
@@ -108,7 +120,7 @@ namespace System.CommandLine
 
         public bool HasDefaultValue => _defaultValue != null;
 
-        public static Argument None => new Argument { Arity = ArgumentArity.Zero };
+        internal static Argument None => new Argument { Arity = ArgumentArity.Zero };
 
         public void AddSuggestions(IReadOnlyCollection<string> suggestions)
         {

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -5,12 +5,17 @@ namespace System.CommandLine
 {
     public class Argument<T> : Argument
     {
-        public Argument()
+        public Argument(string name) : this()
+        {
+            Name = name;
+        }
+
+        public Argument() : base(null)
         {
             ArgumentType = typeof(T);
         }
 
-        public Argument(T defaultValue) : this()
+        public Argument(string name, T defaultValue) : this(name)
         {
             SetDefaultValue(defaultValue);
         }

--- a/src/System.CommandLine/Binding/BindingContext.cs
+++ b/src/System.CommandLine/Binding/BindingContext.cs
@@ -87,7 +87,7 @@ namespace System.CommandLine.Binding
                 else
                 {
                     var parsed = ArgumentConverter.ConvertObject(
-                        valueDescriptor as IArgument ?? new Argument(), 
+                        valueDescriptor as IArgument ?? new Argument(valueDescriptor.ValueName), 
                         valueDescriptor.Type, 
                         value);
 

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -10,24 +10,8 @@ namespace System.CommandLine
 {
     public class Command : Symbol, ICommand, IEnumerable<Symbol>
     {
-        public Command(
-            string name,
-            string description = "",
-            IReadOnlyCollection<Symbol> symbols = null,
-            Argument argument = null,
-            bool treatUnmatchedTokensAsErrors = true,
-            ICommandHandler handler = null,
-            bool isHidden = false) :
-            base(new[] { name }, description, argument, isHidden)
+        public Command(string name, string description = null) : base(new[] { name }, description)
         {
-            TreatUnmatchedTokensAsErrors = treatUnmatchedTokensAsErrors;
-            Handler = handler;
-            symbols = symbols ?? Array.Empty<Symbol>();
-
-            foreach (var symbol in symbols)
-            {
-                AddSymbol(symbol);
-            }
         }
 
         [Obsolete("Use the Arguments property instead")]
@@ -57,7 +41,9 @@ namespace System.CommandLine
 
         public void Add(Argument argument) => AddArgument(argument);
 
-        public bool TreatUnmatchedTokensAsErrors { get; set; }
+        public void AddAlias(string alias) => AddAliasInner(alias);
+
+        public bool TreatUnmatchedTokensAsErrors { get; set; } = true;
 
         public ICommandHandler Handler { get; set; }
 

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -58,7 +58,14 @@ namespace System.CommandLine
             }
             else
             {
-                RootCommand = new RootCommand(symbols: symbols);
+                rootCommand = new RootCommand();
+
+                foreach (var symbol in symbols)
+                {
+                    rootCommand.Add(symbol);
+                }
+
+                RootCommand = rootCommand;
             }
 
             _symbols.Add(RootCommand);
@@ -75,13 +82,16 @@ namespace System.CommandLine
             {
                 foreach (var symbol in symbols)
                 {
-                    foreach (var alias in symbol.RawAliases.ToList())
+                    if (symbol is Option option)
                     {
-                        if (!prefixes.All(prefix => alias.StartsWith(prefix)))
+                        foreach (var alias in option.RawAliases.ToList())
                         {
-                            foreach (var prefix in prefixes)
+                            if (!prefixes.All(prefix => alias.StartsWith(prefix)))
                             {
-                                symbol.AddAlias(prefix + alias);
+                                foreach (var prefix in prefixes)
+                                {
+                                    option.AddAlias(prefix + alias);
+                                }
                             }
                         }
                     }

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.CommandLine.Binding;
 using System.Linq;
 
@@ -9,24 +8,15 @@ namespace System.CommandLine
 {
     public class Option : Symbol, IOption
     {
-        public Option(
-            IReadOnlyCollection<string> aliases,
-            string description = null,
-            Argument argument = null,
-            bool isHidden = false)
-            : base(aliases, description, argument, isHidden)
-        {
-        }
-
-        public Option(
-            string alias,
-            string description = null,
-            Argument argument = null,
-            bool isHidden = false)
+        public Option(string alias, string description = null)
             : base(new[]
             {
                 alias
-            }, description, argument, isHidden)
+            }, description)
+        {
+        }
+
+        public Option(string[] aliases, string description = null) : base(aliases, description)
         {
         }
 
@@ -43,6 +33,8 @@ namespace System.CommandLine
                 AddArgumentInner(value);
             }
         }
+
+        public void AddAlias(string alias) => AddAliasInner(alias);
 
         IArgument IOption.Argument => Argument;
 

--- a/src/System.CommandLine/RootCommand.cs
+++ b/src/System.CommandLine/RootCommand.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.CommandLine.Invocation;
 using System.IO;
 using System.Reflection;
 
@@ -10,20 +8,7 @@ namespace System.CommandLine
 {
     public class RootCommand : Command
     {
-        public RootCommand(
-            string description = "",
-            IReadOnlyCollection<Symbol> symbols = null,
-            Argument argument = null,
-            bool treatUnmatchedTokensAsErrors = true,
-            ICommandHandler handler = null,
-            bool isHidden = false) :
-            base(ExeName,
-                 description,
-                 symbols,
-                 argument,
-                 treatUnmatchedTokensAsErrors,
-                 handler,
-                 isHidden)
+        public RootCommand(string description = "") : base(ExeName, description)
         {
         }
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -12,6 +12,8 @@ namespace System.CommandLine
         private readonly HashSet<string> _rawAliases = new HashSet<string>();
         private string _longestAlias = "";
         private string _specifiedName;
+
+        // FIX: (Symbol._arguments) remove, use Children 
         private protected readonly ArgumentSet _arguments = new ArgumentSet();
         private readonly List<Symbol> _parents = new List<Symbol>();
 
@@ -20,10 +22,8 @@ namespace System.CommandLine
         }
 
         protected Symbol(
-            IReadOnlyCollection<string> aliases,
-            string description = null,
-            Argument argument = null,
-            bool isHidden = false)
+            IReadOnlyCollection<string> aliases = null,
+            string description = null)
         {
             if (aliases == null)
             {
@@ -37,17 +37,10 @@ namespace System.CommandLine
 
             foreach (var alias in aliases)
             {
-                AddAlias(alias);
+                AddAliasInner(alias);
             }
 
             Description = description;
-
-            IsHidden = isHidden;
-
-            if (argument != null)
-            {
-                AddArgumentInner(argument);
-            }
         }
 
         public IReadOnlyCollection<string> Aliases => _aliases;
@@ -113,7 +106,7 @@ namespace System.CommandLine
 
         public SymbolSet Children { get; } = new SymbolSet();
 
-        public void AddAlias(string alias)
+        protected void AddAliasInner(string alias)
         {
             var unprefixedAlias = alias?.RemovePrefix();
 


### PR DESCRIPTION
This one contains a number of breaking changes. I've simplified the constructors for `Option` and `Command` to remove most of the optional parameters that can be set via properties. 

I welcome opinions about whether this is an improvement. Also, should the `description` parameter be removed as well? Should some of these constructor parameters be kept?

