### PR TITLE
Support multiple arguments in DragonFruit

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -221,6 +221,19 @@ namespace System.CommandLine.DragonFruit.Tests
                    .NotContain(o => o.Argument.ArgumentType == type);
         }
 
+        [Fact]
+        public void Parameters_with_Argument_suffix_is_treated_as_arguments()
+        {
+            var parser = new CommandLineBuilder()
+             .ConfigureRootCommandFromMethod(GetMethodInfo(nameof(Method_having_two_arguments)))
+             .Build();
+
+            var rootCommandArgument = parser.Configuration.RootCommand.Arguments.ToList();
+            rootCommandArgument.Should().HaveCount(2);
+            rootCommandArgument.Select(a => a.Name).Should().BeEquivalentSequenceTo("destinationArgument", "sourceArgument");
+            rootCommandArgument.Select(a => a.Type).Should().BeEquivalentSequenceTo(typeof(string), typeof(int));
+        }
+
         internal void Method_taking_bool(bool value = false)
         {
             _receivedValues = new object[] { value };
@@ -273,6 +286,10 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         internal void Method_having_FileInfo_array_args(string stringOption, int intOption, FileInfo[] args)
+        {
+        }
+
+        internal void Method_having_two_arguments(string destinationArgument, int sourceArgument)
         {
         }
 

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -103,13 +103,6 @@ namespace System.CommandLine.DragonFruit
             object target = null) =>
             command.ConfigureFromMethod(method, () => target);
 
-        private static readonly string[] _argumentParameterNames =
-        {
-            "arguments",
-            "argument",
-            "args"
-        };
-
         public static void ConfigureFromMethod(
             this Command command,
             MethodInfo method,
@@ -130,24 +123,32 @@ namespace System.CommandLine.DragonFruit
                 command.AddOption(option);
             }
 
-            if (method.GetParameters()
-                      .FirstOrDefault(p => _argumentParameterNames.Contains(p.Name)) is ParameterInfo argsParam)
+
+            var argumentParameters = method.GetParameters()
+                      .Where(p => IsArgument(p.Name));
+            foreach (var argumentParameter in argumentParameters)
             {
                 var argument = new Argument
                 {
-                    ArgumentType = argsParam.ParameterType,
-                    Name = argsParam.Name
+                    ArgumentType = argumentParameter.ParameterType,
+                    Name = argumentParameter.Name
                 };
 
-                if (argsParam.HasDefaultValue)
+                if (argumentParameter.HasDefaultValue)
                 {
-                    argument.SetDefaultValue(argsParam.DefaultValue);
+                    argument.SetDefaultValue(argumentParameter.DefaultValue);
                 }
 
                 command.AddArgument(argument);
             }
-
             command.Handler = CommandHandler.Create(method);
+        }
+
+        private static bool IsArgument(string parameterName)
+        {
+            return parameterName.EndsWith("Arguments") || parameterName.EndsWith("arguments")
+                || parameterName.EndsWith("Argument") || parameterName.EndsWith("argument")
+                || parameterName.EndsWith("Args") || parameterName.EndsWith("args");
         }
 
         public static CommandLineBuilder ConfigureHelpFromXmlComments(
@@ -189,7 +190,7 @@ namespace System.CommandLine.DragonFruit
                             {
                                 if (string.Equals(
                                         argument.Name,
-                                        kebabCasedParameterName, 
+                                        kebabCasedParameterName,
                                         StringComparison.OrdinalIgnoreCase))
                                 {
                                     argument.Description = parameterDescription.Value;
@@ -241,8 +242,8 @@ namespace System.CommandLine.DragonFruit
                                };
 
             foreach (var option in descriptor.ParameterDescriptors
-                                             .Where(d => !omittedTypes.Contains (d.Type))
-                                             .Where(d => !_argumentParameterNames.Contains(d.ValueName))
+                                             .Where(d => !omittedTypes.Contains(d.Type))
+                                             .Where(d => !IsArgument(d.ValueName))
                                              .Select(p => p.BuildOption()))
             {
                 yield return option;
@@ -252,9 +253,9 @@ namespace System.CommandLine.DragonFruit
         public static Option BuildOption(this ParameterDescriptor parameter)
         {
             var argument = new Argument
-                           {
-                               ArgumentType = parameter.Type
-                           };
+            {
+                ArgumentType = parameter.Type
+            };
 
             if (parameter.HasDefaultValue)
             {


### PR DESCRIPTION
All arguments that ends with "Arguments",  "Argument",  "Args" are required.

Example:
`static void Main(string destinationArgument, string sourceArgument)`