### PR TITLE
Added support for binding MethodInfo with target object in CommandHandler.Create and Command.ConfigureFromMethod

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -221,6 +221,17 @@ namespace System.CommandLine.DragonFruit.Tests
                    .NotContain(o => o.Argument.ArgumentType == type);
         }
 
+        [Fact]
+        public async Task Method_parameters_on_the_invoked_member_method_are_bound_to_matching_option_names_by_MethodInfo_with_target()
+        {
+            var command = new Command("test");
+            command.ConfigureFromMethod(GetMethodInfo(nameof(Method_taking_bool)), this);
+
+            await command.InvokeAsync("--value");
+
+            _receivedValues.Should().BeEquivalentTo(true);
+        }
+
         internal void Method_taking_bool(bool value = false)
         {
             _receivedValues = new object[] { value };

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -81,27 +81,8 @@ namespace System.CommandLine.DragonFruit
 
             builder.Command.ConfigureFromMethod(method, target);
 
-            if (target != null)
-            {
-                builder.UseMiddleware(
-                    async (context, next) =>
-                    {
-                        context.BindingContext
-                               .AddService(
-                                   target.GetType(),
-                                   () => target);
-                        await next(context);
-                    });
-            }
-
             return builder;
         }
-
-        internal static void ConfigureFromMethod(
-            this Command command,
-            MethodInfo method,
-            object target = null) =>
-            command.ConfigureFromMethod(method, () => target);
 
         private static readonly string[] _argumentParameterNames =
         {
@@ -113,7 +94,7 @@ namespace System.CommandLine.DragonFruit
         public static void ConfigureFromMethod(
             this Command command,
             MethodInfo method,
-            Func<object> target)
+            object target = null)
         {
             if (command == null)
             {
@@ -147,7 +128,7 @@ namespace System.CommandLine.DragonFruit
                 command.AddArgument(argument);
             }
 
-            command.Handler = CommandHandler.Create(method);
+            command.Handler = CommandHandler.Create(method, target);
         }
 
         public static CommandLineBuilder ConfigureHelpFromXmlComments(

--- a/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
@@ -350,5 +350,44 @@ namespace System.CommandLine.Tests.Invocation
 
             boundContext.ParseResult.ValueForOption("-x").Should().Be(123);
         }
+
+
+        private class ExecuteTestClass
+        {
+            public string boundName = default;
+            public int boundAge = default;
+
+            public void Execute(string name, int age)
+            {
+                boundName = name;
+                boundAge = age;
+            }
+        }
+
+        private delegate void ExecuteTestDelegate(string name, int age);
+
+        [Fact]
+        public async Task Member_method_parameters_on_the_invoked_method_are_bound_to_matching_option_names_by_delegate()
+        {
+            var testClass = new ExecuteTestClass();
+
+            var command = new Command("command")
+            {
+                new Option("--name")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--age")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
+            command.Handler = CommandHandler.Create((ExecuteTestDelegate)testClass.Execute);
+
+            await command.InvokeAsync("command --age 425 --name Gandalf", _console);
+
+            testClass.boundName.Should().Be("Gandalf");
+            testClass.boundAge.Should().Be(425);
+        }
     }
 }

--- a/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
@@ -367,7 +367,7 @@ namespace System.CommandLine.Tests.Invocation
         private delegate void ExecuteTestDelegate(string name, int age);
 
         [Fact]
-        public async Task Member_method_parameters_on_the_invoked_method_are_bound_to_matching_option_names_by_delegate()
+        public async Task Method_parameters_on_the_invoked_member_method_are_bound_to_matching_option_names_by_delegate()
         {
             var testClass = new ExecuteTestClass();
 
@@ -383,6 +383,32 @@ namespace System.CommandLine.Tests.Invocation
                 }
             };
             command.Handler = CommandHandler.Create((ExecuteTestDelegate)testClass.Execute);
+
+            await command.InvokeAsync("command --age 425 --name Gandalf", _console);
+
+            testClass.boundName.Should().Be("Gandalf");
+            testClass.boundAge.Should().Be(425);
+        }
+
+        [Fact]
+        public async Task Method_parameters_on_the_invoked_member_method_are_bound_to_matching_option_names_by_MethodInfo_with_target()
+        {
+            var testClass = new ExecuteTestClass();
+
+            var command = new Command("command")
+            {
+                new Option("--name")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--age")
+                {
+                    Argument = new Argument<int>()
+                }
+            };
+            command.Handler = CommandHandler.Create(
+                testClass.GetType().GetMethod(nameof(ExecuteTestClass.Execute)),
+                testClass);
 
             await command.InvokeAsync("command --age 425 --name Gandalf", _console);
 

--- a/src/System.CommandLine/Binding/HandlerDescriptor.cs
+++ b/src/System.CommandLine/Binding/HandlerDescriptor.cs
@@ -25,8 +25,8 @@ namespace System.CommandLine.Binding
         public override string ToString() =>
             $"{Parent} ({string.Join(", ", ParameterDescriptors)})";
 
-        public static HandlerDescriptor FromMethodInfo(MethodInfo methodInfo) =>
-            new MethodInfoHandlerDescriptor(methodInfo);
+        public static HandlerDescriptor FromMethodInfo(MethodInfo methodInfo, object target = null) =>
+            new MethodInfoHandlerDescriptor(methodInfo, target);
 
         public static HandlerDescriptor FromDelegate(Delegate @delegate) =>
             new DelegateHandlerDescriptor(@delegate);

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -12,8 +12,8 @@ namespace System.CommandLine.Invocation
         public static ICommandHandler Create(Delegate @delegate) =>
             HandlerDescriptor.FromDelegate(@delegate).GetCommandHandler();
 
-        public static ICommandHandler Create(MethodInfo method) =>
-            HandlerDescriptor.FromMethodInfo(method).GetCommandHandler();
+        public static ICommandHandler Create(MethodInfo method, object target = null) =>
+            HandlerDescriptor.FromMethodInfo(method, target).GetCommandHandler();
 
         public static ICommandHandler Create(Action action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -9,6 +9,9 @@ namespace System.CommandLine.Invocation
 {
     public static class CommandHandler
     {
+        public static ICommandHandler Create(Delegate @delegate) =>
+            HandlerDescriptor.FromDelegate(@delegate).GetCommandHandler();
+
         public static ICommandHandler Create(MethodInfo method) =>
             HandlerDescriptor.FromMethodInfo(method).GetCommandHandler();
 

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -12,6 +12,7 @@ namespace System.CommandLine.Invocation
     internal class ModelBindingCommandHandler : ICommandHandler
     {
         private readonly Delegate _handlerDelegate;
+        private readonly object _invocationTarget;
         private readonly ModelBinder _invocationTargetBinder;
         private readonly MethodInfo _handlerMethodInfo;
         private readonly IReadOnlyCollection<ModelBinder> _parameterBinders;
@@ -22,6 +23,16 @@ namespace System.CommandLine.Invocation
             ModelBinder invocationTargetBinder = null)
         {
             _invocationTargetBinder = invocationTargetBinder;
+            _handlerMethodInfo = handlerMethodInfo;
+            _parameterBinders = parameterBinders;
+        }
+
+        public ModelBindingCommandHandler(
+            MethodInfo handlerMethodInfo,
+            IReadOnlyCollection<ModelBinder> parameterBinders,
+            object invocationTarget)
+        {
+            _invocationTarget = invocationTarget;
             _handlerMethodInfo = handlerMethodInfo;
             _parameterBinders = parameterBinders;
         }
@@ -42,7 +53,7 @@ namespace System.CommandLine.Invocation
                 _parameterBinders.Select(p => p.CreateInstance(bindingContext))
                     .ToArray();
 
-            var invocationTarget =
+            var invocationTarget = _invocationTarget ??
                 _invocationTargetBinder?.CreateInstance(bindingContext);
 
             object result;


### PR DESCRIPTION
Sometimes the command handler is a member method of a class instance, and it has too many parameters to use the generic create methods.

`Create from MethodInfo` cannot be used because `MethodInfo` lacks the `Target` object, i.e. `this`.
So, adding `Create from Delegate` to `CommandHandler` will be helpful.