### PR TITLE
Added synchronous API overloads 

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
@@ -33,6 +33,19 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Fact]
+        public void It_executes_method_synchronously_with_string_option()
+        {
+            int exitCode = CommandLine.InvokeMethod(
+                new[] { "--name", "Wayne" },
+                TestProgram.TestMainMethodInfo,
+                null,
+                _testProgram,
+                _terminal);
+            exitCode.Should().Be(0);
+            _terminal.Out.ToString().Should().Be("Wayne");
+        }
+
+        [Fact]
         public async Task It_shows_help_text_based_on_XML_documentation_comments()
         {
             int exitCode = await CommandLine.InvokeMethodAsync(
@@ -57,6 +70,30 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Fact]
+        public void It_synchronously_shows_help_text_based_on_XML_documentation_comments()
+        {
+            int exitCode = CommandLine.InvokeMethod(
+                new[] { "--help" },
+                TestProgram.TestMainMethodInfo,
+                null,
+                _testProgram,
+                _terminal);
+
+            exitCode.Should().Be(0);
+
+            var stdOut = _terminal.Out.ToString();
+
+            stdOut.Should()
+                .Contain("<args>    These are arguments")
+                .And.Contain("Arguments:");
+            stdOut.Should()
+                .Contain("--name <name>    Specifies the name option")
+                .And.Contain("Options:");
+            stdOut.Should()
+                .Contain("Help for the test program");
+        }
+
+        [Fact]
         public async Task It_executes_method_with_string_option_with_default()
         {
             int exitCode = await CommandLine.InvokeMethodAsync(
@@ -70,7 +107,21 @@ namespace System.CommandLine.DragonFruit.Tests
             _terminal.Out.ToString().Should().Be("Bruce");
         }
 
-        private void TestMainThatThrows() => throw new InvalidOperationException("This threw an error");
+        [Fact]
+        public void It_executes_method_synchronously_with_string_option_with_default()
+        {
+            int exitCode = CommandLine.InvokeMethod(
+                Array.Empty<string>(),
+                TestProgram.TestMainMethodInfoWithDefault,
+                null,
+                _testProgram,
+                _terminal);
+
+            exitCode.Should().Be(0);
+            _terminal.Out.ToString().Should().Be("Bruce");
+        }
+
+        private static void TestMainThatThrows() => throw new InvalidOperationException("This threw an error");
 
         [Fact]
         public async Task It_shows_error_without_invoking_method()
@@ -93,6 +144,26 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Fact]
+        public void It_shows_error_without_invoking_method_synchronously()
+        {
+            Action action = TestMainThatThrows;
+
+            int exitCode = CommandLine.InvokeMethod(
+                new[] { "--unknown" },
+                action.Method,
+                null,
+                this,
+                _terminal);
+
+            exitCode.Should().Be(1);
+            _terminal.Error.ToString()
+                .Should().NotBeEmpty()
+                .And
+                .Contain("--unknown");
+            _terminal.ForegroundColor.Should().Be(ConsoleColor.Red);
+        }
+
+        [Fact]
         public async Task It_handles_uncaught_exceptions()
         {
             Action action = TestMainThatThrows;
@@ -109,6 +180,26 @@ namespace System.CommandLine.DragonFruit.Tests
                     .Should().NotBeEmpty()
                     .And
                     .Contain("This threw an error");
+            _terminal.ForegroundColor.Should().Be(ConsoleColor.Red);
+        }
+
+        [Fact]
+        public void It_handles_uncaught_exceptions_synchronously()
+        {
+            Action action = TestMainThatThrows;
+
+            int exitCode = CommandLine.InvokeMethod(
+                Array.Empty<string>(),
+                action.Method,
+                null,
+                this,
+                _terminal);
+
+            exitCode.Should().Be(1);
+            _terminal.Error.ToString()
+                .Should().NotBeEmpty()
+                .And
+                .Contain("This threw an error");
             _terminal.ForegroundColor.Should().Be(ConsoleColor.Red);
         }
     }

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -46,6 +46,36 @@ namespace System.CommandLine.DragonFruit
             return await InvokeMethodAsync(args, entryMethod, xmlDocsFilePath, null, console);
         }
 
+        /// <summary>
+        /// Finds and executes 'Program.Main', but with strong types.
+        /// </summary>
+        /// <param name="entryAssembly">The entry assembly</param>
+        /// <param name="args">The string arguments.</param>
+        /// <param name="entryPointFullTypeName">Explicitly defined entry point</param>
+        /// <param name="xmlDocsFilePath">Explicitly defined path to xml file containing XML Docs</param>
+        /// <param name="console">Output console</param>
+        /// <returns>The exit code.</returns>
+        public static int ExecuteAssembly(
+            Assembly entryAssembly,
+            string[] args,
+            string entryPointFullTypeName,
+            string xmlDocsFilePath = null,
+            IConsole console = null)
+        {
+            if (entryAssembly == null)
+            {
+                throw new ArgumentNullException(nameof(entryAssembly));
+            }
+
+            args = args ?? Array.Empty<string>();
+            entryPointFullTypeName = entryPointFullTypeName?.Trim();
+
+            MethodInfo entryMethod = EntryPointDiscoverer.FindStaticEntryMethod(entryAssembly, entryPointFullTypeName);
+
+            //TODO The xml docs file name and location can be customized using <DocumentationFile> project property.
+            return InvokeMethod(args, entryMethod, xmlDocsFilePath, null, console);
+        }
+
         public static async Task<int> InvokeMethodAsync(
             string[] args,
             MethodInfo method,
@@ -53,15 +83,34 @@ namespace System.CommandLine.DragonFruit
             object target = null,
             IConsole console = null)
         {
-            var builder = new CommandLineBuilder()
-                          .ConfigureRootCommandFromMethod(method, target)
-                          .ConfigureHelpFromXmlComments(method, xmlDocsFilePath)
-                          .UseDefaults()
-                          .UseAnsiTerminalWhenAvailable();
-
-            Parser parser = builder.Build();
+            Parser parser = BuildParser(method, xmlDocsFilePath, target);
 
             return await parser.InvokeAsync(args, console);
+        }
+
+        public static int InvokeMethod(
+            string[] args,
+            MethodInfo method,
+            string xmlDocsFilePath = null,
+            object target = null,
+            IConsole console = null)
+        {
+            Parser parser = BuildParser(method, xmlDocsFilePath, target);
+
+            return parser.Invoke(args, console);
+        }
+
+        private static Parser BuildParser(MethodInfo method,
+            string xmlDocsFilePath,
+            object target)
+        {
+            var builder = new CommandLineBuilder()
+                .ConfigureRootCommandFromMethod(method, target)
+                .ConfigureHelpFromXmlComments(method, xmlDocsFilePath)
+                .UseDefaults()
+                .UseAnsiTerminalWhenAvailable();
+
+            return  builder.Build();
         }
 
         public static CommandLineBuilder ConfigureRootCommandFromMethod(

--- a/src/System.CommandLine.Tests/Invocation/InvocationExtensionsTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationExtensionsTests.cs
@@ -28,6 +28,23 @@ namespace System.CommandLine.Tests.Invocation
         }
 
         [Fact]
+        public void Command_Invoke_uses_default_pipeline_by_default()
+        {
+            var command = new Command("the-command");
+            var theHelpText = "the help text";
+            command.Description = theHelpText;
+
+            var console = new TestConsole();
+
+            command.Invoke("-h", console);
+
+            console.Out
+                   .ToString()
+                   .Should()
+                   .Contain(theHelpText);
+        }
+
+        [Fact]
         public async Task RootCommand_InvokeAsync_returns_0_when_handler_is_successful()
         {
             var wasCalled = false;
@@ -36,6 +53,20 @@ namespace System.CommandLine.Tests.Invocation
             rootCommand.Handler = CommandHandler.Create(() => wasCalled = true);
 
             var result = await rootCommand.InvokeAsync("");
+
+            wasCalled.Should().BeTrue();
+            result.Should().Be(0);
+        }
+
+        [Fact]
+        public void RootCommand_Invoke_returns_0_when_handler_is_successful()
+        {
+            var wasCalled = false;
+            var rootCommand = new RootCommand();
+
+            rootCommand.Handler = CommandHandler.Create(() => wasCalled = true);
+
+            int result = rootCommand.Invoke("");
 
             wasCalled.Should().BeTrue();
             result.Should().Be(0);
@@ -65,6 +96,29 @@ namespace System.CommandLine.Tests.Invocation
         }
 
         [Fact]
+        public void RootCommand_Invoke_returns_1_when_handler_throws()
+        {
+            var wasCalled = false;
+            var rootCommand = new RootCommand();
+
+            rootCommand.Handler = CommandHandler.Create(() =>
+            {
+                wasCalled = true;
+                throw new Exception("oops!");
+
+                // Help the compiler pick a CommandHandler.Create overload.
+#pragma warning disable CS0162 // Unreachable code detected
+                return 0;
+#pragma warning restore CS0162
+            });
+
+            var resultCode = rootCommand.Invoke("");
+
+            wasCalled.Should().BeTrue();
+            resultCode.Should().Be(1);
+        }
+
+        [Fact]
         public async Task RootCommand_InvokeAsync_can_set_custom_result_code()
         {
             var rootCommand = new RootCommand();
@@ -75,6 +129,21 @@ namespace System.CommandLine.Tests.Invocation
             });
 
             var resultCode = await rootCommand.InvokeAsync("");
+
+            resultCode.Should().Be(123);
+        }
+
+        [Fact]
+        public void RootCommand_Invoke_can_set_custom_result_code()
+        {
+            var rootCommand = new RootCommand();
+
+            rootCommand.Handler = CommandHandler.Create<InvocationContext>(context =>
+            {
+                context.ResultCode = 123;
+            });
+
+            int resultCode = rootCommand.Invoke("");
 
             resultCode.Should().Be(123);
         }

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -112,12 +112,10 @@ namespace System.CommandLine
         public ValidationMessages ValidationMessages { get; }
 
         internal Func<BindingContext, IHelpBuilder> HelpBuilderFactory =>
-            _helpBuilderFactory ??
-            (_helpBuilderFactory = context => new HelpBuilder(context.Console));
+            _helpBuilderFactory ??= context => new HelpBuilder(context.Console);
 
         internal IReadOnlyCollection<InvocationMiddleware> Middleware =>
-            _middlewarePipeline ??
-            (_middlewarePipeline = new List<InvocationMiddleware>());
+            _middlewarePipeline ??= new List<InvocationMiddleware>();
 
         public ICommand RootCommand { get; }
 

--- a/src/System.CommandLine/Invocation/InvocationExtensions.cs
+++ b/src/System.CommandLine/Invocation/InvocationExtensions.cs
@@ -258,14 +258,50 @@ namespace System.CommandLine.Invocation
             string[] args,
             IConsole console = null)
         {
+            return await GetInvocationPipeline(command, args).InvokeAsync(console);
+        }
+
+        public static int Invoke(
+            this Parser parser,
+            ParseResult parseResult,
+            IConsole console = null) =>
+            new InvocationPipeline(parseResult).Invoke(console);
+
+        public static int Invoke(
+            this Parser parser,
+            string commandLine,
+            IConsole console = null) =>
+            parser.Invoke(commandLine.SplitCommandLine().ToArray(), console);
+
+        public static int Invoke(
+            this Parser parser,
+            string[] args,
+            IConsole console = null) =>
+            parser.Invoke(parser.Parse(args), console);
+
+        public static int Invoke(
+            this Command command,
+            string commandLine,
+            IConsole console = null) =>
+            command.Invoke(commandLine.SplitCommandLine().ToArray(), console);
+
+        public static int Invoke(
+            this Command command,
+            string[] args,
+            IConsole console = null)
+        {
+            return GetInvocationPipeline(command, args).Invoke(console);
+        }
+
+        private static InvocationPipeline GetInvocationPipeline(Command command, string[] args)
+        {
             var parser = new CommandLineBuilder(command)
-                         .UseDefaults()
-                         .Build();
+                .UseDefaults()
+                .Build();
 
-            var parseResult = parser.Parse(args);
+            ParseResult parseResult = parser.Parse(args);
 
-            return await new InvocationPipeline(parseResult)
-                       .InvokeAsync(console);
+            return new InvocationPipeline(parseResult);
         }
 
         public static CommandLineBuilder UseHelp(this CommandLineBuilder builder)

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -33,7 +33,7 @@ namespace System.CommandLine.Invocation
 
             InvocationMiddleware invocationChain = BuildInvocationChain(context);
 
-            Task.Run(() => invocationChain(context, invocationContext => Task.CompletedTask)).Wait();
+            Task.Run(() => invocationChain(context, invocationContext => Task.CompletedTask)).GetAwaiter().GetResult();
 
             return GetResultCode(context);
         }

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -18,9 +18,28 @@ namespace System.CommandLine.Invocation
 
         public async Task<int> InvokeAsync(IConsole console = null)
         {
-            var context = new InvocationContext(parseResult,
-                                                console);
+            var context = new InvocationContext(parseResult, console);
 
+            InvocationMiddleware invocationChain = BuildInvocationChain(context);
+
+            await invocationChain(context, invocationContext => Task.CompletedTask);
+
+            return GetResultCode(context);
+        }
+
+        public int Invoke(IConsole console = null)
+        {
+            var context = new InvocationContext(parseResult, console);
+
+            InvocationMiddleware invocationChain = BuildInvocationChain(context);
+
+            Task.Run(() => invocationChain(context, invocationContext => Task.CompletedTask)).Wait();
+
+            return GetResultCode(context);
+        }
+
+        private static InvocationMiddleware BuildInvocationChain(InvocationContext context)
+        {
             var invocations = new List<InvocationMiddleware>(context.Parser.Configuration.Middleware);
 
             invocations.Add(async (invocationContext, next) =>
@@ -39,14 +58,15 @@ namespace System.CommandLine.Invocation
                 }
             });
 
-            var invocationChain = invocations.Aggregate(
+            return invocations.Aggregate(
                 (first, second) =>
                     (ctx, next) =>
                         first(ctx,
-                              c => second(c, next)));
+                            c => second(c, next)));
+        }
 
-            await invocationChain(context, invocationContext => Task.CompletedTask);
-
+        private static int GetResultCode(InvocationContext context)
+        {
             context.InvocationResult?.Apply(context);
 
             return context.ResultCode;


### PR DESCRIPTION
Fixes #412

This add a synchronous overload for InvocationPipeleine.Invoke. This change propagates up to Parser.Invoke in System.CommandLine and up to CommandLine.ExecuteAssembly in SystemCommnadLine.DragonFruit