### PR TITLE
Show help for commands with no descriptions

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -1135,6 +1135,41 @@ namespace System.CommandLine.Tests.Help
             _console.Out.ToString().Should().Contain(expected);
         }
 
+        [Fact]
+        public void Subcommand_help_contains_command_with_empty_description()
+        {
+            var command = new Command("the-command", "Does things.");
+            var subCommand = new Command("the-subcommand", description: null);
+            command.AddCommand(subCommand);
+
+            _helpBuilder.Write(command);
+            var help = _console.Out.ToString();
+
+            help.Should().Contain("the-subcommand");
+        }
+
+        [Fact]
+        public void Subcommand_help_does_not_contain_hidden_command()
+        {
+            var command = new Command("the-command", "Does things.");
+            var hiddenSubCommand = new Command("the-hidden")
+            {
+                IsHidden = true
+            };
+            var visibleSubCommand = new Command("the-visible")
+            {
+                IsHidden = false
+            };
+            command.AddCommand(hiddenSubCommand);
+            command.AddCommand(visibleSubCommand);
+
+            _helpBuilder.Write(command);
+            var help = _console.Out.ToString();
+
+            help.Should().NotContain("the-hidden");
+            help.Should().Contain("the-visible");
+        }
+
         #endregion Subcommands
     }
 }

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -665,21 +665,7 @@ namespace System.CommandLine
 
         internal bool ShouldShowHelp(ISymbol symbol)
         {
-            if (symbol.IsHidden)
-            {
-                return false;
-            }
-
-            if (symbol is IArgument)
-            {
-                return !symbol.IsHidden;
-            }
-            else
-            {
-                return !symbol.IsHidden &&
-                       (!string.IsNullOrWhiteSpace(symbol.Description) ||
-                        symbol.Arguments().Any(ShouldShowHelp));
-            }
+            return !symbol.IsHidden;
         }
     }
 }


### PR DESCRIPTION
The `ShouldShowHelp` method was simplified to only be dependent on the provided symbol's `IsHidden` field.
One test added to validate that subcommands without description now show up in the help section.
A second test added to explicitly validate that any hidden commands do not show up.
This fixes #586 .