### PR TITLE
Hide hidden args from options and subcommand help

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -1010,6 +1010,36 @@ namespace System.CommandLine.Tests.Help
             _console.Out.ToString().Should().Contain(expected);
         }
 
+        [Fact]
+        public void Options_section_does_not_contain_hidden_argument()
+        {
+            var command = new Command("the-command", "Does things.");
+            var opt1 = new Option("option1")
+            {
+                Argument = new Argument<int>()
+                {
+                    Name = "the-hidden",
+                    IsHidden = true
+                }
+            };
+            var opt2 = new Option("option2")
+            {
+                Argument = new Argument<int>()
+                {
+                    Name = "the-visible",
+                    IsHidden = false
+                }
+            };
+            command.AddOption(opt1);
+            command.AddOption(opt2);
+
+            _helpBuilder.Write(command);
+            var help = _console.Out.ToString();
+
+            help.Should().NotContain("the-hidden");
+            help.Should().Contain("the-visible");
+        }
+
         #endregion Options
 
         #region Subcommands
@@ -1162,6 +1192,32 @@ namespace System.CommandLine.Tests.Help
             };
             command.AddCommand(hiddenSubCommand);
             command.AddCommand(visibleSubCommand);
+
+            _helpBuilder.Write(command);
+            var help = _console.Out.ToString();
+
+            help.Should().NotContain("the-hidden");
+            help.Should().Contain("the-visible");
+        }
+
+        [Fact]
+        public void Subcommand_help_does_not_contain_hidden_argument()
+        {
+            var command = new Command("the-command", "Does things.");
+            var subCommand = new Command("the-subcommand");
+            var hidden = new Argument<int>()
+            {
+                Name = "the-hidden", 
+                IsHidden = true
+            };
+            var visible = new Argument<int>()
+            {
+                Name = "the-visible", 
+                IsHidden = false
+            };
+            subCommand.AddArgument(hidden);
+            subCommand.AddArgument(visible);
+            command.AddCommand(subCommand);
 
             _helpBuilder.Write(command);
             var help = _console.Out.ToString();

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -334,7 +334,7 @@ namespace System.CommandLine
             {
                 foreach (var argument in symbol.Arguments())
                 {
-                    if (!string.IsNullOrWhiteSpace(argument.Name))
+                    if (ShouldShowHelp(argument) && !string.IsNullOrWhiteSpace(argument.Name))
                     {
                         var argumentDescriptor = ArgumentDescriptor(argument);
                         if (!string.IsNullOrWhiteSpace(argumentDescriptor))


### PR DESCRIPTION
Added call to `ShouldShowHelp` method in `OptionFormatter` to evaluate whether an argument should be included in the Options or Subcommand help sections.
Added two test cases to verify this functionality.

A suggestion would be to reconsider the name of the `OptionFormatter` method, since it is used not only for options, but also for commands that may take arguments.

This fixes #589