### PR TITLE
Change list used to format argument usage

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -416,6 +416,34 @@ namespace System.CommandLine.Tests.Help
             _console.Out.ToString().Should().Contain(expected);
         }
 
+        [Fact]
+        public void Usage_section_does_not_contain_hidden_argument()
+        {
+            var commandName = "the-command";
+            var visibleArgName = "visible";
+            var command = new Command(commandName, "Does things");
+            var hiddenArg = new Argument<int>
+            {
+                Name = "hidden", 
+                IsHidden = true
+            };
+            var visibleArg = new Argument<int>
+            {
+                Name = visibleArgName,
+                IsHidden = false
+            };
+            command.AddArgument(hiddenArg);
+            command.AddArgument(visibleArg);
+
+            _helpBuilder.Write(command);
+
+            var expected =
+                $"Usage:{NewLine}" +
+                $"{_indentation}{commandName} <{visibleArgName}>{NewLine}{NewLine}";
+            
+            _console.Out.ToString().Should().Contain(expected);
+        }
+
         #endregion Usage
 
         #region Arguments

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -432,7 +432,7 @@ namespace System.CommandLine
 
             for (var i = 0; i < args.Count; i++)
             {
-                var argument = arguments.ElementAt(i);
+                var argument = args.ElementAt(i);
 
                 var arityIndicator =
                     argument.Arity.MaximumNumberOfValues > 1


### PR DESCRIPTION
Bug fix for issue #596.
Added test case to validate that no hidden arguments show up in usage section.