### PR TITLE
Fix #603 and #578 (TypoCorrection.GetPossibleTokens)

### DIFF
--- a/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
@@ -102,6 +102,23 @@ namespace System.CommandLine.Tests.Invocation
         }
 
         [Fact]
+        public async Task Arguments_are_not_suggested()
+        {
+            var parser =
+                new CommandLineBuilder()
+                    .AddArgument(new Argument())
+                    .AddCommand(new Command("been"))
+                    .UseTypoCorrections()
+                    .Build();
+
+            var result = parser.Parse("een");
+
+            await parser.InvokeAsync(result, _console);
+
+            _console.Out.ToString().Should().Contain("'een' was not matched. Did you mean 'been'?");
+        }
+
+        [Fact]
         public async Task Hidden_options_are_not_suggested()
         {
             var parser =

--- a/src/System.CommandLine/Builder/CommandBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandBuilder.cs
@@ -20,5 +20,7 @@ namespace System.CommandLine.Builder
         internal void AddCommand(Command command) => Command.AddCommand(command);
 
         internal void AddOption(Option option) => Command.AddOption(option);
+
+        internal void AddArgument(Argument argument) => Command.AddArgument(argument);
     }
 }

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -30,6 +30,16 @@ namespace System.CommandLine.Builder
             return builder;
         }
 
+        public static TBuilder AddArgument<TBuilder>(
+            this TBuilder builder,
+            Argument argument)
+            where TBuilder : CommandBuilder
+        {
+            builder.AddArgument(argument);
+
+            return builder;
+        }
+
         private static readonly Lazy<string> _assemblyVersion =
             new Lazy<string>(() => {
                 var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -37,6 +37,7 @@ namespace System.CommandLine.Invocation
         {
             IEnumerable<string> possibleMatches = targetSymbol.Children
                 .Where(x => !x.IsHidden)
+                .Where(x => x.RawAliases.Count > 0)
                 .Select(symbol => 
                     symbol.RawAliases
                         .Union(symbol.Aliases)


### PR DESCRIPTION
Fixes these two duplicates:

- https://github.com/dotnet/command-line-api/issues/603
- https://github.com/dotnet/command-line-api/issues/578

Instead of filtering by type, I simply skip suggestions when tokens have no name (such as arguments)