### PR TITLE
Fix issue on CoreRT when Assembly.Location is unavailable

### DIFF
--- a/src/System.CommandLine/RootCommand.cs
+++ b/src/System.CommandLine/RootCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace System.CommandLine
@@ -22,13 +23,20 @@ namespace System.CommandLine
             }
         }
 
-        private static readonly Lazy<string> executablePath =
-            new Lazy<string>(() =>
-                                 GetAssembly().Location);
+        private static readonly Lazy<string> executablePath = new Lazy<string>(() =>
+        {
+            return GetAssembly().Location;
+        });
 
-        private static readonly Lazy<string> executableName =
-            new Lazy<string>(() =>
-                                 Path.GetFileNameWithoutExtension(GetAssembly().Location));
+        private static readonly Lazy<string> executableName = new Lazy<string>(() =>
+        {
+            var location = executablePath.Value;
+            if (string.IsNullOrEmpty(location))
+            {
+                location = Environment.GetCommandLineArgs().FirstOrDefault();
+            }
+            return Path.GetFileNameWithoutExtension(location);
+        });
 
         private static Assembly GetAssembly() =>
             Assembly.GetEntryAssembly() ??


### PR DESCRIPTION
Fixes https://github.com/dotnet/command-line-api/issues/612 in two different ways:

1. When the assembly location is unavailable, fallbacks to the first command line argument (the invoked executable name, which may not be the compiled name, but it's much better than a crash)
2. Allow specifying the desired program name manually (in the RootCommand constructor).

I also made a very small change; I noticed you use Lazy to get the executable path, but you were not using it from within executableName. It was simple to reuse the Lazy value once more so I now get the location from executablePath.value instead.

Another note: The ExePath is only used by tests as far as I could see. It will not work in CoreRT either, but since it is actually unused (and could potentialy be deleted), I did not change it's behavior.