### PR TITLE
Validator for paths that can be files or directories

### DIFF
--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -219,6 +219,35 @@ namespace System.CommandLine.Tests
                                 e.Message == $"File does not exist: {guid}");
         }
 
+        [Fact]
+        public void An_argument_can_be_invalid_based_on_file_or_directory_existence()
+        {
+            var command = new Command("move")
+            {
+                new Argument<FileSystemInfo>
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }.ExistingOnly(),
+                new Option("--to")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                }
+            };
+
+            Guid guid = Guid.NewGuid();
+            var result =
+                command.Parse(
+                    $@"move ""{guid}"" --to ""{Path.Combine(Directory.GetCurrentDirectory(), ".trash")}""");
+
+            result.Errors
+                  .Should()
+                  .Contain(e => e.SymbolResult.Name == "move" &&
+                                e.Message == $"File or directory does not exist: {guid}");
+        }
+
         [Fact] 
         public void An_argument_with_multiple_file_info_can_be_invalid_based_on_first_file_existence()
         {

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -249,6 +249,64 @@ namespace System.CommandLine.Tests
         }
 
         [Fact] 
+        public void An_argument_with_multiple_file_system_info_can_be_invalid_based_on_first_file_existence()
+        {
+            var command = new Command("move")
+            {
+                new Argument<FileSystemInfo[]>
+                {
+                    Arity = ArgumentArity.ZeroOrMore
+                }.ExistingOnly(),
+                new Option("--to")
+                {
+                    Argument = new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                }
+            };
+
+            Guid guid1 = Guid.NewGuid();
+            Guid guid2 = Guid.NewGuid();
+            var result =
+                command.Parse(
+                    $@"move ""{guid1}"" ""{guid2}"" --to ""{Path.Combine(Directory.GetCurrentDirectory(), ".trash")}""");
+
+            result.Errors
+                  .Should()
+                  .Contain(e => e.SymbolResult.Name == "move" && e.Message == $"File or directory does not exist: {guid1}");
+        }
+
+        [Fact]
+        public void An_argument_with_multiple_file_system_info_can_be_invalid_based_on_second_directory_existence()
+        {
+            var command = new Command("move")
+                {
+                    new Argument<FileSystemInfo[]>
+                    {
+                        Arity = ArgumentArity.ZeroOrMore
+                    }.ExistingOnly(),
+                    new Option("--to")
+                    {
+                        Argument = new Argument
+                        {
+                            Arity = ArgumentArity.ExactlyOne
+                        }
+                    }
+                };
+
+            var executingAssemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var guid = Guid.NewGuid();
+            var result =
+                command.Parse(
+                    $@"move ""{executingAssemblyLocation}"" ""{guid}"" --to ""{Path.Combine(Directory.GetCurrentDirectory(), ".trash")}""");
+
+            result.Errors
+                .Should()
+                .Contain(e => e.SymbolResult.Name == "move" && e.Message == $"File or directory does not exist: {guid}");
+        }
+
+        [Fact] 
         public void An_argument_with_multiple_file_info_can_be_invalid_based_on_first_file_existence()
         {
             var command = new Command("move")

--- a/src/System.CommandLine/Builder/ArgumentExtensions.cs
+++ b/src/System.CommandLine/Builder/ArgumentExtensions.cs
@@ -94,6 +94,17 @@ namespace System.CommandLine.Builder
             return argument;
         }
 
+        public static Argument<FileSystemInfo[]> ExistingOnly(this Argument<FileSystemInfo[]> argument)
+        {
+            argument.AddValidator(symbol =>
+                                      symbol.Tokens
+                                            .Select(t => t.Value)
+                                            .Where(filePath => !Directory.Exists(filePath) && !File.Exists(filePath))
+                                            .Select(symbol.ValidationMessages.FileOrDirectoryDoesNotExist)
+                                            .FirstOrDefault());
+            return argument;
+        }
+
         public static TArgument LegalFilePathsOnly<TArgument>(
             this TArgument argument)
             where TArgument : Argument

--- a/src/System.CommandLine/Builder/ArgumentExtensions.cs
+++ b/src/System.CommandLine/Builder/ArgumentExtensions.cs
@@ -61,6 +61,17 @@ namespace System.CommandLine.Builder
             return argument;
         }
 
+        public static Argument<FileSystemInfo> ExistingOnly(this Argument<FileSystemInfo> argument)
+        {
+            argument.AddValidator(symbol =>
+                                      symbol.Tokens
+                                            .Select(t => t.Value)
+                                            .Where(filePath => !Directory.Exists(filePath) && !File.Exists(filePath))
+                                            .Select(symbol.ValidationMessages.FileOrDirectoryDoesNotExist)
+                                            .FirstOrDefault());
+            return argument;
+        }
+
         public static Argument<FileInfo[]> ExistingOnly(this Argument<FileInfo[]> argument)
         {
             argument.AddValidator(symbol =>

--- a/src/System.CommandLine/ValidationMessages.cs
+++ b/src/System.CommandLine/ValidationMessages.cs
@@ -39,6 +39,9 @@ namespace System.CommandLine
         public virtual string FileDoesNotExist(string filePath) =>
             $"File does not exist: {filePath}";
 
+        public virtual string FileOrDirectoryDoesNotExist(string path) =>
+            $"File or directory does not exist: {path}";
+
         public virtual string InvalidCharactersInPath(char invalidChar) =>
             $"Character not allowed in a path: {invalidChar}";
 


### PR DESCRIPTION
Right now it's possible to check if a file or directory exists using built-in validators, but it's not possible to check if a provided path is a valid file OR a directory! The best example I can think of is:

> my-copy C:\file.txt c:\folder\
> my-copy C:\file.txt C:\folder\new-name.txt

The syntax is the same as usual, but using `FileSystemInfo` instead, the base class for both `FileInfo` and `DirectoryInfo`:

```csharp
new Argument<FileSystemInfo>().ExistingOnly<FileSystemInfo>()
```