### PR TITLE
Custom type converter support for collections

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1767,14 +1767,14 @@ namespace System.CommandLine.Tests
 
             public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
             {
-                return value switch
+                if (value is string stringValue)
                 {
-                    string stringValue => new ClassWithCustomTypeConverter
+                    return new ClassWithCustomTypeConverter
                     {
                         Values = stringValue.Split(';')
-                    },
-                    _ => base.ConvertFrom(context, culture, value)
-                };
+                    };
+                }
+                return base.ConvertFrom(context, culture, value);
             }
         }
 
@@ -1798,11 +1798,11 @@ namespace System.CommandLine.Tests
 
             public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
             {
-                return value switch
+                if (value is string stringValue)
                 {
-                    string stringValue => new CollectionWithCustomTypeConverter(stringValue.Split(';')),
-                    _ => base.ConvertFrom(context, culture, value)
-                };
+                    return new CollectionWithCustomTypeConverter(stringValue.Split(';'));
+                }
+                return base.ConvertFrom(context, culture, value);
             }
         }
     }

--- a/src/System.CommandLine/ArgumentConverter.cs
+++ b/src/System.CommandLine/ArgumentConverter.cs
@@ -28,7 +28,7 @@ namespace System.CommandLine
             switch (value)
             {
                 case string singleValue:
-                    if (type.IsEnumerable())
+                    if (type.IsEnumerable() && !type.HasStringTypeConverter())
                     {
                         return ConvertStrings(argument, type, new[] { singleValue });
                     }
@@ -162,6 +162,12 @@ namespace System.CommandLine
         {
             return i.IsGenericType &&
                    i.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+        }
+
+        private static bool HasStringTypeConverter(this Type type)
+        {
+            return TypeDescriptor.GetConverter(type) is TypeConverter typeConverter
+                && typeConverter.CanConvertFrom(typeof(string));
         }
 
         private static FailedArgumentConversionResult Failure(


### PR DESCRIPTION
Custom types that implement IEnumerable should respect custom TypeConverters.

Previously types that implemented `IEnumerable<T>` would not use custom type converters.