### PR TITLE
Add GetInvocationContext extension methods

### DIFF
--- a/src/System.CommandLine.Hosting.Tests/HostingTests.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingTests.cs
@@ -197,7 +197,7 @@ namespace System.CommandLine.Hosting.Tests
         {
             const int myValue = 4224;
             string commandLine = $"-{nameof(MyOptions.MyArgument)} {myValue}";
-            IOptions<MyOptions> options = null;
+            MyOptions options = null;
 
             var rootCmd = new RootCommand();
             rootCmd.AddOption(
@@ -206,7 +206,9 @@ namespace System.CommandLine.Hosting.Tests
                 );
             rootCmd.Handler = CommandHandler.Create((IHost host) =>
             {
-                options = host.Services.GetRequiredService<IOptions<MyOptions>>();
+                options = host.Services
+                    .GetRequiredService<IOptions<MyOptions>>()
+                    .Value;
             });
 
             int result = new CommandLineBuilder(rootCmd)
@@ -222,8 +224,7 @@ namespace System.CommandLine.Hosting.Tests
 
             Assert.Equal(0, result);
             Assert.NotNull(options);
-            Assert.NotNull(options.Value);
-            Assert.Equal(myValue, options.Value.MyArgument);
+            Assert.Equal(myValue, options.MyArgument);
         }
 
         private class MyOptions

--- a/src/System.CommandLine.Hosting.Tests/HostingTests.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingTests.cs
@@ -197,6 +197,7 @@ namespace System.CommandLine.Hosting.Tests
         {
             const int myValue = 4224;
             string commandLine = $"-{nameof(MyOptions.MyArgument)} {myValue}";
+            IOptions<MyOptions> options = null;
 
             var rootCmd = new RootCommand();
             rootCmd.AddOption(
@@ -205,11 +206,10 @@ namespace System.CommandLine.Hosting.Tests
                 );
             rootCmd.Handler = CommandHandler.Create((IHost host) =>
             {
-                var options = host.Services.GetRequiredService<IOptions<MyOptions>>();
-                Assert.Equal(myValue, options.Value.MyArgument);
+                options = host.Services.GetRequiredService<IOptions<MyOptions>>();
             });
 
-            Assert.Equal(0, new CommandLineBuilder(rootCmd)
+            int result = new CommandLineBuilder(rootCmd)
                 .UseHost(host =>
                 {
                     host.ConfigureServices(services =>
@@ -218,7 +218,12 @@ namespace System.CommandLine.Hosting.Tests
                     });
                 })
                 .Build()
-                .Invoke(commandLine));
+                .Invoke(commandLine);
+
+            Assert.Equal(0, result);
+            Assert.NotNull(options);
+            Assert.NotNull(options.Value);
+            Assert.Equal(myValue, options.Value.MyArgument);
         }
 
         private class MyOptions

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -67,19 +67,24 @@ namespace System.CommandLine.Hosting
             });
         }
 
-        public static InvocationContext GetInvocationContext(this IHostBuilder hostBuilder) =>
-            GetInvocationContext(hostBuilder?.Properties);
-
-        public static InvocationContext GetInvocationContext(this HostBuilderContext context) =>
-            GetInvocationContext(context?.Properties);
-
-        private static InvocationContext GetInvocationContext(IDictionary<object, object> properties)
+        public static InvocationContext GetInvocationContext(this IHostBuilder hostBuilder)
         {
-            object ctxObj = null;
-            if (properties?.TryGetValue(typeof(InvocationContext), out ctxObj) ?? false)
-                return ctxObj as InvocationContext;
-            return null;
+            if (hostBuilder is null)
+                throw new ArgumentNullException(nameof(hostBuilder));
+            return GetInvocationContext(hostBuilder.Properties);
         }
+
+        public static InvocationContext GetInvocationContext(this HostBuilderContext context)
+        {
+            if (context is null)
+                throw new ArgumentNullException(nameof(context));
+            return GetInvocationContext(context.Properties);
+        }
+
+        private static InvocationContext GetInvocationContext(IDictionary<object, object> properties) => 
+            properties.TryGetValue(typeof(InvocationContext), out object ctxObj)
+                ? ctxObj as InvocationContext
+                : null;
 
         public static void ConfigureFromCommandLine<TOptions>(
             this IServiceCollection services, HostBuilderContext context)

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -81,7 +81,7 @@ namespace System.CommandLine.Hosting
             return null;
         }
 
-        public static void ConfigureFromInvocation<TOptions>(
+        public static void ConfigureFromCommandLine<TOptions>(
             this IServiceCollection services, HostBuilderContext context)
             where TOptions : class
         {

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.CommandLine.Builder;
+﻿using System.Collections.Generic;
+using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.Linq;
 
@@ -63,6 +64,20 @@ namespace System.CommandLine.Hosting
                 if (configureOptions is Action<InvocationLifetimeOptions>)
                     services.Configure(configureOptions);
             });
+        }
+
+        public static InvocationContext GetInvocationContext(this IHostBuilder hostBuilder) =>
+            GetInvocationContext(hostBuilder?.Properties);
+
+        public static InvocationContext GetInvocationContext(this HostBuilderContext context) =>
+            GetInvocationContext(context?.Properties);
+
+        private static InvocationContext GetInvocationContext(IDictionary<object, object> properties)
+        {
+            object ctxObj = null;
+            if (properties?.TryGetValue(typeof(InvocationContext), out ctxObj) ?? false)
+                return ctxObj as InvocationContext;
+            return null;
         }
     }
 }

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -68,25 +68,6 @@ namespace System.CommandLine.Hosting
             });
         }
 
-        public static InvocationContext GetInvocationContext(this IHostBuilder hostBuilder)
-        {
-            if (hostBuilder is null)
-                throw new ArgumentNullException(nameof(hostBuilder));
-            return GetInvocationContext(hostBuilder.Properties);
-        }
-
-        public static InvocationContext GetInvocationContext(this HostBuilderContext context)
-        {
-            if (context is null)
-                throw new ArgumentNullException(nameof(context));
-            return GetInvocationContext(context.Properties);
-        }
-
-        private static InvocationContext GetInvocationContext(IDictionary<object, object> properties) => 
-            properties.TryGetValue(typeof(InvocationContext), out object ctxObj)
-                ? ctxObj as InvocationContext
-                : null;
-
         public static OptionsBuilder<TOptions> BindCommandLine<TOptions>(
             this OptionsBuilder<TOptions> optionsBuilder)
             where TOptions : class

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.CommandLine.Binding;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.Linq;
@@ -78,6 +79,18 @@ namespace System.CommandLine.Hosting
             if (properties?.TryGetValue(typeof(InvocationContext), out ctxObj) ?? false)
                 return ctxObj as InvocationContext;
             return null;
+        }
+
+        public static void ConfigureFromInvocation<TOptions>(
+            this IServiceCollection services, HostBuilderContext context)
+            where TOptions : class
+        {
+            var bindingContext = context.GetInvocationContext()?.BindingContext;
+            services.Configure<TOptions>(opts =>
+            {
+                var modelBinder = new ModelBinder<TOptions>();
+                modelBinder.UpdateInstance(opts, bindingContext);
+            });
         }
     }
 }


### PR DESCRIPTION
When using the hosting extensions, you normally need a way to access the `ParseResult` or the `InvocationContext` to actually be able to evaluate the parsed command-line arguments.

Sure, `ParseResult` is registered as a DI-service, so any DI class constructor can accept a `ParseResult` and get it injected, but that approach is not necessary the most typical way to handle this in a Hosted application architecture (like ASP.NET).

You could argue that command-line arguments fit better when transferred to an `IOptions` instance, like most other configurable parts in the Generic Host do (e.g. `ConsoleLiftetimeOptions`, `LoggingOptions`, etc.).

So why not just call `services.ConfigureServices(services => services.Configure<CommandLineOptions>(opts => { }))` in your `ConfigureHost` delegate? Well you very quickly discover that accessing the `ParseResult` instance when configuring the DI container is quirky.

This PR propses to add extension methods to `IHostBuilder` and `HostBuilderContext` to easily obtain the `InvocationContext` (and from there the `ParseResult`) for scenarios within `ConfigureHost`.

Originally, to configure my `MyCommandLineOptions` options, you'd currently have to do this:
``` C#
.UseHost(host =>
{
  InvocationContext invocation = null;
  if (host.Properties.TryGetValue(typeof(InvocationContext), out invocationObj))
    invocation = invocationObj as InvocationContext;
  var parseResult = invocation?.ParseResult;
  host.ConfigureServices(services =>
  {
    services.Configure<MyCommandLineOptions>(opts =>
    {
      // Do something with parseResult here...
    });
  });
})
```

*Alternatively you could also access the `Properties` from the `HostBuilderContext` argument that you can get if you call the other overload of `ConfigureServices`.*

With this PR, this code gets more readable and you can then do this:

``` C#
.UseHost(host =>
{
  host.ConfigureServices((context, services) =>
  {
    var parseResult = context.GetInvocationContext()?.ParseResult;
    services.Configure<MyCommandLineOptions>(opts =>
    {
      // Do something with parseResult here...
    });
  });
})
```