### PR TITLE
Add System.CommandLine.Hosting to list of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Package                            | Version |
 System.CommandLine.Experimental    | [![Nuget](https://img.shields.io/nuget/v/System.CommandLine.Experimental.svg)](https://nuget.org/packages/System.CommandLine.Experimental)    |
 System.CommandLine.DragonFruit     | [![Nuget](https://img.shields.io/nuget/v/System.CommandLine.DragonFruit.svg)](https://nuget.org/packages/System.CommandLine.DragonFruit)    |
 System.CommandLine.Rendering       | [![Nuget](https://img.shields.io/nuget/v/System.CommandLine.Rendering.svg)](https://nuget.org/packages/System.CommandLine.Rendering)    |
+System.CommandLine.Hosting         | [![Nuget](https://img.shields.io/nuget/v/System.CommandLine.Hosting.svg)](https://nuget.org/packages/System.CommandLine.Hosting)    |
 
 Daily builds are available if you add this feed to your nuget.config: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json.
 


### PR DESCRIPTION
Since `System.CommandLine.Hosting` is published on NuGet now, it might be nice to also have its shield on the README