### PR TITLE
Accept IValueDescriptor in ModelBinder

### DIFF
--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -324,7 +324,7 @@ namespace System.CommandLine.Tests.Binding
 
             var binder = new ModelBinder<ClassWithMultiLetterSetters>();
 
-            binder.BindMemberFromOption(
+            binder.BindMemberFromValue(
                 c => c.IntOption,
                 option);
 

--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -377,5 +377,65 @@ namespace System.CommandLine.Tests.Binding
 
             instance.IntOption.Should().Be(42);
         }
+
+        [Fact]
+        public void PropertyInfo_can_be_bound_to_argument()
+        {
+            var command = new Command("the-command");
+            var argument = new Argument<int> { Arity = ArgumentArity.ExactlyOne };
+            command.AddArgument(argument);
+
+            var type = typeof(ClassWithMultiLetterSetters);
+            var binder = new ModelBinder(type);
+            var propertyInfo = type.GetProperty(nameof(ClassWithMultiLetterSetters.IntOption));
+
+            binder.BindMemberFromValue(propertyInfo, argument);
+
+            var bindingContext = new BindingContext(command.Parse("the-command 42"));
+
+            var instance = (ClassWithMultiLetterSetters)binder.CreateInstance(bindingContext);
+
+            instance.IntOption.Should().Be(42);
+        }
+
+        [Fact]
+        public void PropertyExpression_can_be_bound_to_option()
+        {
+            var command = new Command("the-command");
+            var option = new Option("--fred") { Argument = new Argument<int>() };
+            command.AddOption(option);
+
+            var binder = new ModelBinder<ClassWithMultiLetterSetters>();
+
+            binder.BindMemberFromValue(
+                i => i.IntOption,
+                option);
+
+            var bindingContext = new BindingContext(command.Parse("the-command --fred 42"));
+
+            var instance = (ClassWithMultiLetterSetters)binder.CreateInstance(bindingContext);
+
+            instance.IntOption.Should().Be(42);
+        }
+
+        [Fact]
+        public void PropertyExpression_can_be_bound_to_argument()
+        {
+            var command = new Command("the-command");
+            var argument = new Argument<int> { Arity = ArgumentArity.ExactlyOne };
+            command.AddArgument(argument);
+
+            var binder = new ModelBinder<ClassWithMultiLetterSetters>();
+
+            binder.BindMemberFromValue(
+                i => i.IntOption,
+                argument);
+
+            var bindingContext = new BindingContext(command.Parse("the-command 42"));
+
+            var instance = (ClassWithMultiLetterSetters)binder.CreateInstance(bindingContext);
+
+            instance.IntOption.Should().Be(42);
+        }
     }
 }

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -31,11 +31,11 @@ namespace System.CommandLine.Binding
         internal Dictionary<(Type valueSourceType, string valueSourceName), IValueSource> NamedValueSources { get; }
             = new Dictionary<(Type valueSourceType, string valueSourceName), IValueSource>();
 
-        public void BindMemberFromValue(PropertyInfo property, Option option)
+        public void BindMemberFromValue(PropertyInfo property, IValueDescriptor valueDescriptor)
         {
             NamedValueSources.Add(
                 (property.PropertyType, property.Name),
-                new OptionValueSource(option));
+                new SpecificSymbolValueSource(valueDescriptor));
         }
 
         public object CreateInstance(BindingContext context)

--- a/src/System.CommandLine/Binding/ModelBinder{T}.cs
+++ b/src/System.CommandLine/Binding/ModelBinder{T}.cs
@@ -11,13 +11,13 @@ namespace System.CommandLine.Binding
         {
         }
 
-        public void BindMemberFromOption<TValue>(
+        public void BindMemberFromValue<TValue>(
             Expression<Func<TModel, TValue>> property,
-            IOption option)
+            IValueDescriptor valueDescriptor)
         {
             NamedValueSources.Add(
                 property.MemberTypeAndName(),
-                new OptionValueSource(option));
+                new SpecificSymbolValueSource(valueDescriptor));
         }
 
         public void BindMemberFromValue<TValue>(

--- a/src/System.CommandLine/Binding/SpecificSymbolValueSource.cs
+++ b/src/System.CommandLine/Binding/SpecificSymbolValueSource.cs
@@ -3,32 +3,24 @@
 
 namespace System.CommandLine.Binding
 {
-    internal class OptionValueSource : IValueSource
+    internal class SpecificSymbolValueSource : IValueSource
     {
-        public OptionValueSource(IOption option)
+        public SpecificSymbolValueSource(IValueDescriptor valueDescriptor)
         {
-            Option = option;
+            symbolValueSource = new CurrentSymbolResultValueSource();
+            ValueDescriptor = valueDescriptor;
         }
 
-        public IOption Option { get; }
+        private readonly CurrentSymbolResultValueSource symbolValueSource;
 
-        public bool TryGetValue(
-            IValueDescriptor valueDescriptor, 
-            BindingContext bindingContext, 
+        public IValueDescriptor ValueDescriptor { get; }
+
+        public bool TryGetValue(IValueDescriptor valueDescriptor,
+            BindingContext bindingContext,
             out object boundValue)
         {
-            var result = bindingContext.ParseResult.FindResultFor(Option);
-
-            switch (result)
-            {
-                case OptionResult optionResult:
-                    boundValue = optionResult.GetValueOrDefault();
-                    return true;
-
-                default:
-                    boundValue = Option.GetDefaultValue();
-                    return true;
-            }
+            return symbolValueSource.TryGetValue(ValueDescriptor,
+                bindingContext, out boundValue);
         }
     }
 }


### PR DESCRIPTION
Currently the `BindMemberFrom...` methods on `ModelBinder` and `ModelBinder<T>` currently only accept `Option` or `IOption`. Thus, binding an `Argument` will only work if the target member matches the argument name. `BindMemberFrom...` can be used to configure the binder to bind any option to any member regardless of name matching.

There is no real reason why you should not be able to use `BindMemberFrom...` with an `Argument` or `IArgument`.

* Renames internal class `OptionValueSource` to `SpecificSymbolValueSource` (matching the filename the type is located in)  
   Changes its `TryGetValue` implementation to use `CurrentSymbolValueSource` with value descriptor provided at construction.
* **Renames publically visible method `BindMemberFromOption` to `BindMemberFromValue`**
* Changes argument in `BindMemberFrom...` from `Option` and `IOption` to `IValueDescriptor`

As this will introduce a breaking change, we can also choose to not rename the public method `BindMemberFromOption`, add the new method, and forward the call from the old one to the new more general one.