### PR TITLE
Add option count

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -253,6 +253,17 @@ namespace System.CommandLine.Tests
             option.Argument.Name.Should().Be("arg");
         }
 
+        [Fact]
+        public void Option_Result_Count_equals_to_occurences_of_option()
+        {
+            var option = new Option(new[] { "--verbose", "-v" });
+
+            var result = option.Parse("-vv --verbose");
+            var optionResult = result.FindResultFor(option);
+
+            Assert.Equal(3, optionResult.Count);
+        }
+
         protected override Symbol CreateSymbol(string name) => new Option(name);
     }
 }

--- a/src/System.CommandLine/OptionResult.cs
+++ b/src/System.CommandLine/OptionResult.cs
@@ -20,6 +20,8 @@ namespace System.CommandLine
 
         public IOption Option { get; }
 
+        public int Count { get; internal set; } = 1;
+
         public bool IsImplicit => Token is ImplicitToken;
 
         private protected override int RemainingArgumentCapacity

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -100,9 +100,10 @@ namespace System.CommandLine.Parsing
 
         protected override void VisitOptionNode(OptionNode optionNode)
         {
-            if (_innermostCommandResult.Children.ResultFor(optionNode.Option) == null)
+            var optionResult = (OptionResult)_innermostCommandResult.Children.ResultFor(optionNode.Option);
+            if (optionResult == null)
             {
-                var optionResult = new OptionResult(
+                optionResult = new OptionResult(
                     optionNode.Option,
                     optionNode.Token,
                     _innermostCommandResult);
@@ -110,6 +111,10 @@ namespace System.CommandLine.Parsing
                 _innermostCommandResult
                     .Children
                     .Add(optionResult);
+            }
+            else
+            {
+                optionResult.Count += 1;
             }
         }
 


### PR DESCRIPTION
This PR adds a `Count` property to the `OptionResult` class, which is incremented whenever that option is visited during parsing. This allows for count-like options (which works like flags, except you can repeat them).

I was mainly just going to experiment a bit to look at how #669 could be resolved, but then I figured this is a potentially pretty easy solution to the issue, and given that there is so little code change needed I figured showing it as a PR would be the simplest.

I think this might make for a good starting point to deal with count-like options, enabling the core functionality, and allowing for validation and similar to be added later.

Resolves #669