### PR TITLE
Start work on required options

### DIFF
--- a/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
@@ -327,7 +327,7 @@ namespace System.CommandLine.Tests.Invocation
             };
             command.Handler = CommandHandler.Create<IConsole>(console => { console.Out.Write("Hello!"); });
 
-            await command.InvokeAsync("command", _console);
+            await command.InvokeAsync("command -x 123", _console);
 
             _console.Out.ToString().Should().Be("Hello!");
         }

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -83,6 +83,24 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void When_a_required_option_is_not_supplied_then_an_error_is_returned()
+        {
+            var parser = new Parser(new Option("-x")
+            {
+                Argument = new Argument
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                }
+            });
+
+            var result = parser.Parse("");
+
+            result.Errors
+                  .Should()
+                  .Contain(e => e.Message == "Required argument missing for option: -x");
+        }
+
+        [Fact]
         public void When_no_option_accepts_arguments_but_one_is_supplied_then_an_error_is_returned()
         {
             var parser = new Parser(

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -162,6 +162,23 @@ namespace System.CommandLine.Parsing
 
                 ValidateCommand(commandResult);
 
+                foreach (var option in commandResult.Command.Children.OfType<Option>()
+                    .Where(o => o.Argument.Arity.MinimumNumberOfValues > 0))
+                {
+                    var symbolResult = commandResult.Children.ResultFor(option);
+                    if (symbolResult == null)
+                    {
+                        var argument = option.Argument;
+                        var optionResult = new OptionResult(
+                            option,
+                            option.CreateImplicitToken());
+                        
+                        _errors.Add(new ParseError(
+                            optionResult.ValidationMessages.RequiredArgumentMissing(optionResult),
+                            optionResult));
+                    }
+                }
+
                 foreach (var result in commandResult.Children)
                 {
                     switch (result)


### PR DESCRIPTION
This PR attempts to add support for required options, by making options with arguments that have a minimum arity of 1 to be required. This is based on discussions in #560. Note that there are currently failing tests (as mentioned in https://github.com/dotnet/command-line-api/issues/560#issuecomment-540692266). This PR is published as a draft to show the work as it's ongoing and allow for feedback. It might also be better to continue the discussion of the broken tests here, rather than in #560, given that they are more implementation-specific than required options in general.