### PR TITLE
Parentage improvements

### DIFF
--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine.Hosting
 {
     public static class HostingExtensions
     {
-        public const string ConfigurationDirectiveName = "config";
+        private const string ConfigurationDirectiveName = "config";
 
         public static CommandLineBuilder UseHost(this CommandLineBuilder builder,
             Func<string[], IHostBuilder> hostBuilderFactory,

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -461,11 +461,8 @@ namespace System.CommandLine.Tests.Help
         public void Arguments_section_is_not_included_if_there_are_commands_but_no_arguments_configured()
         {
             var command = new Command("the-command", "command help");
-            var commandLineBuilder = new CommandLineBuilder()
-                                     .AddCommand(command)
-                                     .Command;
 
-            _helpBuilder.Write(commandLineBuilder);
+            _helpBuilder.Write(command);
             _console.Out.ToString().Should().NotContain("Arguments:");
             
             _helpBuilder.Write(command);
@@ -493,15 +490,13 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_is_not_included_if_there_are_options_with_no_arguments_configured()
         {
-            var commandLineBuilder = new CommandLineBuilder
-                                     {
-                                     }
-                                     .AddOption(
-                                         new Option(new[] { "-v", "--verbosity" },
-                                                    "Sets the verbosity."))
-                                     .Command;
+            var command = new RootCommand
+            {
+                new Option(new[] { "-v", "--verbosity" },
+                           "Sets the verbosity.")
+            };
 
-            _helpBuilder.Write(commandLineBuilder);
+            _helpBuilder.Write(command);
 
             _console.Out.ToString().Should().NotContain("Arguments:");
         }
@@ -539,13 +534,8 @@ namespace System.CommandLine.Tests.Help
                     Description = "Sets the verbosity."
                 }
             };
-            var commandLineBuilder = new CommandLineBuilder()
-                                     .AddCommand(command)
-                                     .Command;
-
-            var subcommand = commandLineBuilder
-                .Subcommand("the-command");
-            _helpBuilder.Write(subcommand);
+          
+            _helpBuilder.Write(command);
 
             var help = _console.Out.ToString();
             help.Should().Contain("-v, --verbosity <LEVEL>");
@@ -908,15 +898,9 @@ namespace System.CommandLine.Tests.Help
             {
                 IsHidden = false
             });
+            
 
-            var commandLineBuilder = new CommandLineBuilder()
-                                     .AddCommand(command)
-                                     .Command;
-
-            Command subcommand = commandLineBuilder
-                .Subcommand("the-command");
-
-            _helpBuilder.Write(subcommand);
+            _helpBuilder.Write(command);
 
             var help = _console.Out.ToString();
             help.Should().Contain("-n");
@@ -1005,20 +989,17 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_section_removes_added_newlines()
         {
-            var commandLineBuilder = new CommandLineBuilder().AddCommand(
-                                                                 new Command(
-                                                                     "test-command",
-                                                                     "Help text for the command")
-                                                                 {
-                                                                     new Option(
-                                                                         new[] { "-a", "--aaa" },
-                                                                         $"Help{NewLine}for {NewLine} the{NewLine}option")
-                                                                 })
-                                                             .Command;
+            var command =
+                new Command(
+                    "test-command",
+                    "Help text for the command")
+                {
+                    new Option(
+                        new[] { "-a", "--aaa" },
+                        $"Help{NewLine}for {NewLine} the{NewLine}option")
+                };
 
-            Command subcommand = commandLineBuilder
-                .Subcommand("test-command");
-            _helpBuilder.Write(subcommand);
+            _helpBuilder.Write(command);
 
             var expected =
                 $"Options:{NewLine}" +

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1008,9 +1008,46 @@ namespace System.CommandLine.Tests
             result.CommandResult["x"].Arguments.Should().BeEquivalentTo("the-argument");
             result.CommandResult.Arguments.Should().BeEmpty();
         }
+        
+        [Fact]
+        public void Required_arguments_on_parent_commands_do_not_create_parse_errors_when_an_inner_command_is_specified()
+        {
+            var child = new Command("child");
+
+            var parent = new RootCommand
+            {
+                new Argument<string>(),
+                child
+            };
+            parent.Name = "parent";
+
+            var result = parent.Parse("child");
+
+            result.Errors.Should().BeEmpty();
+        }
 
         [Fact]
-        public void When_the_same_option_is_defined_on_both_outer_and_inner_command_and_specified_at_the_end_then_it_attaches_to_the_inner_command()
+        public void Required_arguments_on_grandparent_commands_do_not_create_parse_errors_when_an_inner_command_is_specified()
+        {
+            var grandchild = new Command("grandchild");
+
+            var grandparent = new RootCommand
+            {
+                new Argument<string>(),
+                new Command("parent")
+                {
+                    grandchild
+                }
+            };
+            grandparent.Name = "grandparent";
+
+            var result = grandparent.Parse("parent grandchild");
+
+            result.Errors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void When_options_with_the_same_name_are_defined_on_parent_and_child_commands_and_specified_at_the_end_then_it_attaches_to_the_inner_command()
         {
             var outer = new Command("outer")
                         {
@@ -1035,7 +1072,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void When_the_same_option_is_defined_on_both_outer_and_inner_command_and_specified_in_between_then_it_attaches_to_the_outer_command()
+        public void When_options_with_the_same_name_are_defined_on_parent_and_child_commands_and_specified_in_between_then_it_attaches_to_the_outer_command()
         {
             var outer = new Command("outer");
             outer.AddOption(new Option("-x"));

--- a/src/System.CommandLine/CommandExtensions.cs
+++ b/src/System.CommandLine/CommandExtensions.cs
@@ -8,21 +8,6 @@ namespace System.CommandLine
 {
     public static class CommandExtensions
     {
-        public static TCommand Subcommand<TCommand>(
-            this TCommand command,
-            string name)
-            where TCommand : ICommand
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                throw new ArgumentException("Value cannot be null or whitespace.", nameof(name));
-            }
-
-            return command.Children
-                          .OfType<TCommand>()
-                          .Single(c => c.Name == name);
-        }
-
         public static ParseResult Parse(
             this Command command,
             params string[] args) =>

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -58,11 +58,19 @@ namespace System.CommandLine
             }
             else
             {
-                rootCommand = new RootCommand();
+                // reuse existing auto-generated root command, if one is present, to prevent repeated mutations
+                rootCommand = symbols.SelectMany(s => s.Parents)
+                                     .OfType<RootCommand>()
+                                     .FirstOrDefault();
 
-                foreach (var symbol in symbols)
+                if (rootCommand == null)
                 {
-                    rootCommand.Add(symbol);
+                    rootCommand = new RootCommand();
+
+                    foreach (var symbol in symbols)
+                    {
+                        rootCommand.Add(symbol);
+                    }
                 }
 
                 RootCommand = rootCommand;

--- a/src/System.CommandLine/FailedArgumentTypeConversionResult.cs
+++ b/src/System.CommandLine/FailedArgumentTypeConversionResult.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
+
 namespace System.CommandLine
 {
     internal class FailedArgumentTypeConversionResult : FailedArgumentConversionResult
@@ -23,14 +25,16 @@ namespace System.CommandLine
             {
                 // TODO: (FailedArgumentTypeConversionResult) localize
 
+                var firstParent = a.Parents.First();
+
                 var symbolType =
-                    a.Parents[0] switch {
+                    firstParent switch {
                         ICommand _ => "command",
                         IOption _ => "option",
                         _ => null
                         };
 
-                var alias = a.Parents[0].RawAliases[0];
+                var alias = firstParent.RawAliases[0];
 
                 return $"Cannot parse argument '{value}' for {symbolType} '{alias}' as expected type {type}.";
             }

--- a/src/System.CommandLine/ISymbol.cs
+++ b/src/System.CommandLine/ISymbol.cs
@@ -22,5 +22,7 @@ namespace System.CommandLine
         bool IsHidden { get; }
 
         ISymbolSet Children { get; }
+
+        ISymbolSet Parents { get; }
     }
 }

--- a/src/System.CommandLine/ParseResultExtensions.cs
+++ b/src/System.CommandLine/ParseResultExtensions.cs
@@ -100,7 +100,7 @@ namespace System.CommandLine
             {
                 var includeArgumentName =
                     argumentResult.Argument is Argument argument &&
-                    argument.Parents[0] is ICommand command &&
+                    argument.Parents.First() is ICommand command &&
                     command.Name != argument.Name;
 
                 if (includeArgumentName)

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -219,8 +219,11 @@ namespace System.CommandLine.Parsing
 
                     if (arityFailure != null)
                     {
-                        _errors.Add(
-                            new ParseError(arityFailure.ErrorMessage, commandResult));
+                        if (_innermostCommandResult.Command == commandResult.Command)
+                        {
+                            _errors.Add(
+                                new ParseError(arityFailure.ErrorMessage, commandResult));
+                        }
                     }
 
                     foreach (var validator in argument.SymbolValidators)

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine
         private string _longestAlias = "";
         private string _specifiedName;
 
-        private readonly List<Symbol> _parents = new List<Symbol>();
+        private readonly SymbolSet _parents = new SymbolSet();
 
         private protected Symbol()
         {
@@ -61,7 +61,7 @@ namespace System.CommandLine
             }
         }
 
-        internal IReadOnlyList<Symbol> Parents => _parents; 
+        public ISymbolSet Parents => _parents; 
 
         private protected void AddParent(Symbol symbol)
         {


### PR DESCRIPTION
There are two significant changes here:

* Added `ISymbol.Parents` (making the formerly internal `Symbol.Parents` part of the public API.
* Made it so that when required arguments on a command are not supplied, it only results in a parse error when that command was the actual invoked subcommand. This should prevent the need to assign `ZeroOr*` arities to parent commands just so that subcommands can be invoked, which is a workaround we've seen a few times.