### PR TITLE
strip whitespace from inferred root command name

### DIFF
--- a/src/System.CommandLine/IOption.cs
+++ b/src/System.CommandLine/IOption.cs
@@ -8,5 +8,7 @@ namespace System.CommandLine
     public interface IOption : ISymbol, IValueDescriptor
     {
         IArgument Argument { get; }
+
+        bool Required { get; }
     }
 }

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -213,19 +213,16 @@ namespace System.CommandLine.Parsing
                                    .Command
                                    .Arguments)
             {
-                if (symbol is Argument argument)
-                {
-                    var arityFailure = ArgumentArity.Validate(
-                        commandResult,
-                        argument,
-                        argument.Arity.MinimumNumberOfValues,
-                        argument.Arity.MaximumNumberOfValues);
+                var arityFailure = ArgumentArity.Validate(
+                    commandResult,
+                    symbol,
+                    symbol.Arity.MinimumNumberOfValues,
+                    symbol.Arity.MaximumNumberOfValues);
 
-                    if (arityFailure != null)
-                    {
-                        _errors.Add(
-                            new ParseError(arityFailure.ErrorMessage, commandResult));
-                    }
+                if (arityFailure != null)
+                {
+                    _errors.Add(
+                        new ParseError(arityFailure.ErrorMessage, commandResult));
                 }
             }
         }
@@ -272,11 +269,11 @@ namespace System.CommandLine.Parsing
                 }
             }
 
-            foreach (var a in optionResult.Children
-                                          .OfType<ArgumentResult>()
-                                          .ToArray())
+            foreach (var argumentResult in optionResult
+                                           .Children
+                                           .OfType<ArgumentResult>())
             {
-                ValidateArgumentResult(a);
+                ValidateArgumentResult(argumentResult);
             }
         }
 

--- a/src/System.CommandLine/RootCommand.cs
+++ b/src/System.CommandLine/RootCommand.cs
@@ -35,7 +35,7 @@ namespace System.CommandLine
             {
                 location = Environment.GetCommandLineArgs().FirstOrDefault();
             }
-            return Path.GetFileNameWithoutExtension(location);
+            return Path.GetFileNameWithoutExtension(location).Replace(" ", "");
         });
 
         private static Assembly GetAssembly() =>


### PR DESCRIPTION
This fixes #684. 