### PR TITLE
Fix NRE in ScreenView.Render when there is no terminal

### DIFF
--- a/src/System.CommandLine.Rendering/Views/ScreenView.cs
+++ b/src/System.CommandLine.Rendering/Views/ScreenView.cs
@@ -68,7 +68,7 @@ namespace System.CommandLine.Rendering.Views
         // may not want this?
         public void Render(Region region)
         {
-            _console.GetTerminal().HideCursor();
+            _console.GetTerminal()?.HideCursor();
 
             Child?.Render(Renderer, region);
         }
@@ -82,7 +82,7 @@ namespace System.CommandLine.Rendering.Views
 
         public void Dispose()
         {
-            _console.GetTerminal().ShowCursor();
+            _console.GetTerminal()?.ShowCursor();
 
             if (_child is View child)
             {


### PR DESCRIPTION
When using redirected output (e.g. `myapp > out` or `myapp | less`), `_console.GetTerminal()` would return `null` and `_console.GetTerminal().HideCursor()` results in a NRE, with a stack trace like this:

```
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at System.CommandLine.Rendering.Views.ScreenView.Render(Region region)
   at scrach.Program.List(InvocationContext context) in /home/fcarlier/scrach/Program.cs:line 61
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.Delegate.DynamicInvoke(Object[] args)
   at System.CommandLine.Invocation.ModelBindingCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<UseParseErrorReporting>b__22_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c__DisplayClass8_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<UseSuggestDirective>b__7_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<UseParseDirective>b__6_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<UseHelp>b__20_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass4_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<RegisterWithDotnetSuggest>b__23_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c__DisplayClass5_0.<<UseExceptionHandler>b__0>d.MoveNext()
```
