### PR TITLE
rename Exe to Executable

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -31,7 +31,7 @@ namespace System.CommandLine.DragonFruit.Tests
                              GetMethodInfo(nameof(Method_taking_bool)), this)
                          .Build();
 
-            await parser.InvokeAsync($"{RootCommand.ExeName} --value", _testConsole);
+            await parser.InvokeAsync($"{RootCommand.ExecutableName} --value", _testConsole);
 
             _receivedValues.Should().BeEquivalentTo(true);
         }

--- a/src/System.CommandLine.Suggest.Tests/SuggestionDispatcherTests.cs
+++ b/src/System.CommandLine.Suggest.Tests/SuggestionDispatcherTests.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Suggest.Tests
 {
     public class SuggestionDispatcherTests
     {
-        private static readonly string _currentExeName = RootCommand.ExeName;
+        private static readonly string _currentExeName = RootCommand.ExecutableName;
         
         private static readonly string _dotnetExeFullPath = 
             DotnetMuxer.Path.FullName;

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -238,8 +238,8 @@ namespace System.CommandLine.Tests
         {
             var command = new RootCommand();
             command.AddAlias("that");
-            command.Aliases.Should().BeEquivalentTo(RootCommand.ExeName, "that");
-            command.RawAliases.Should().BeEquivalentTo(RootCommand.ExeName, "that");
+            command.Aliases.Should().BeEquivalentTo(RootCommand.ExecutableName, "that");
+            command.RawAliases.Should().BeEquivalentTo(RootCommand.ExecutableName, "that");
 
             var result = command.Parse("that");
 

--- a/src/System.CommandLine.Tests/DirectiveTests.cs
+++ b/src/System.CommandLine.Tests/DirectiveTests.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine.Tests
         {
             var option = new Option("-y");
 
-            var result = option.Parse($"{RootCommand.ExeName} [parse] -y");
+            var result = option.Parse($"{RootCommand.ExecutableName} [parse] -y");
 
             result.UnmatchedTokens.Should().BeEmpty();
         }

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -38,7 +38,7 @@ namespace System.CommandLine.Tests.Help
             _output = output;
             _columnPadding = new string(' ', ColumnGutterWidth);
             _indentation = new string(' ', IndentationWidth);
-            _executableName = RootCommand.ExeName;
+            _executableName = RootCommand.ExecutableName;
         }
 
         private HelpBuilder GetHelpBuilder(int maxWidth)

--- a/src/System.CommandLine.Tests/ParseDiagramTests.cs
+++ b/src/System.CommandLine.Tests/ParseDiagramTests.cs
@@ -74,7 +74,7 @@ namespace System.CommandLine.Tests
 
             result.Diagram()
                   .Should()
-                  .Be($"[ {RootCommand.ExeName} [ -f !<not-an-int> ] ]");
+                  .Be($"[ {RootCommand.ExecutableName} [ -f !<not-an-int> ] ]");
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace System.CommandLine.Tests
             var diagram = result.Diagram();
 
             diagram.Should()
-                   .Be($"[ {RootCommand.ExeName} [ -w <9000> ] *[ --height <10> ] *[ --color <Cyan> ] ]");
+                   .Be($"[ {RootCommand.ExecutableName} [ -w <9000> ] *[ --height <10> ] *[ --color <Cyan> ] ]");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ParseDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/ParseDirectiveTests.cs
@@ -48,7 +48,7 @@ namespace System.CommandLine.Tests
             console.Out
                    .ToString()
                    .Should()
-                   .Be($"[ {RootCommand.ExeName} [ subcommand [ -c <34> ] ] ]   ???--> --nonexistent wat" + Environment.NewLine);
+                   .Be($"[ {RootCommand.ExecutableName} [ subcommand [ -c <34> ] ] ]   ???--> --nonexistent wat" + Environment.NewLine);
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1218,7 +1218,7 @@ namespace System.CommandLine.Tests
 
             ParseResult result1 = command.Parse("inner -x hello");
 
-            ParseResult result2 = command.Parse($"{RootCommand.ExePath} inner -x hello");
+            ParseResult result2 = command.Parse($"{RootCommand.ExecutablePath} inner -x hello");
 
             result1.Diagram().Should().Be(result2.Diagram());
         }
@@ -1243,7 +1243,7 @@ namespace System.CommandLine.Tests
 
             var result1 = rootCommand.Parse("inner -x hello");
             var result2 = rootCommand.Parse("outer inner -x hello");
-            var result3 = rootCommand.Parse($"{RootCommand.ExeName} inner -x hello");
+            var result3 = rootCommand.Parse($"{RootCommand.ExecutableName} inner -x hello");
 
             result2.RootCommandResult.Command.Should().Be(result1.RootCommandResult.Command);
             result3.RootCommandResult.Command.Should().Be(result1.RootCommandResult.Command);
@@ -1704,7 +1704,7 @@ namespace System.CommandLine.Tests
 
             var result = parser.Parse(null);
 
-            result.CommandResult.Command.Name.Should().Be(RootCommand.ExeName);
+            result.CommandResult.Command.Name.Should().Be(RootCommand.ExecutableName);
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/RootCommandTests.cs
+++ b/src/System.CommandLine.Tests/RootCommandTests.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine.Tests
         {
             var rootCommand = new RootCommand();
 
-            rootCommand.Name.Should().Be(RootCommand.ExeName);
+            rootCommand.Name.Should().Be(RootCommand.ExecutableName);
         }
 
         [Fact]
@@ -22,8 +22,8 @@ namespace System.CommandLine.Tests
             var rootCommand = new RootCommand();
             rootCommand.Name = "custom";
 
-            rootCommand.Aliases.Should().BeEquivalentTo("custom", RootCommand.ExeName);
-            rootCommand.RawAliases.Should().BeEquivalentTo("custom", RootCommand.ExeName);
+            rootCommand.Aliases.Should().BeEquivalentTo("custom", RootCommand.ExecutableName);
+            rootCommand.RawAliases.Should().BeEquivalentTo("custom", RootCommand.ExecutableName);
         }
     }
 }

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -32,7 +32,7 @@ namespace System.CommandLine.Tests
 
             await parser.InvokeAsync(result, _console);
 
-            _console.Out.ToString().Should().Contain($"{RootCommand.ExeName} command subcommand");
+            _console.Out.ToString().Should().Contain($"{RootCommand.ExecutableName} command subcommand");
         }
 
         [Fact]

--- a/src/System.CommandLine/RootCommand.cs
+++ b/src/System.CommandLine/RootCommand.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine
 {
     public class RootCommand : Command
     {
-        public RootCommand(string description = "") : base(ExeName, description)
+        public RootCommand(string description = "") : base(ExecutableName, description)
         {
         }
 
@@ -23,14 +23,14 @@ namespace System.CommandLine
             }
         }
 
-        private static readonly Lazy<string> executablePath = new Lazy<string>(() =>
+        private static readonly Lazy<string> _executablePath = new Lazy<string>(() =>
         {
             return GetAssembly().Location;
         });
 
-        private static readonly Lazy<string> executableName = new Lazy<string>(() =>
+        private static readonly Lazy<string> _executableName = new Lazy<string>(() =>
         {
-            var location = executablePath.Value;
+            var location = _executablePath.Value;
             if (string.IsNullOrEmpty(location))
             {
                 location = Environment.GetCommandLineArgs().FirstOrDefault();
@@ -42,8 +42,8 @@ namespace System.CommandLine
             Assembly.GetEntryAssembly() ??
             Assembly.GetExecutingAssembly();
 
-        public static string ExeName => executableName.Value;
+        public static string ExecutableName => _executableName.Value;
 
-        public static string ExePath => executablePath.Value;
+        public static string ExecutablePath => _executablePath.Value;
     }
 }


### PR DESCRIPTION
Renaming this as "exe" is a Windows-centric abbreviation.