### PR TITLE
fix #728

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -71,7 +71,8 @@ namespace System.CommandLine.DragonFruit.Tests
 
         [Theory]
         [InlineData(nameof(Method_having_string_argument), 1, 1)]
-        [InlineData(nameof(Method_having_string_argument_with_default_value), 0, 1)]
+        [InlineData(nameof(Method_having_string_argument_with_null_default_value), 0, 1)]
+        [InlineData(nameof(Method_having_string_argument_with_non_null_default_value), 0, 1)]
         [InlineData(nameof(Method_having_string_array_arguments), 0, byte.MaxValue)]
         [InlineData(nameof(Method_having_string_array_arguments_with_default_value), 0, byte.MaxValue)]
         [InlineData(nameof(Method_having_FileInfo_argument), 1, 1)]
@@ -95,7 +96,7 @@ namespace System.CommandLine.DragonFruit.Tests
 
         [Theory]
         [InlineData(nameof(Method_having_string_argument), "argument")]
-        [InlineData(nameof(Method_having_string_argument_with_default_value), "argument")]
+        [InlineData(nameof(Method_having_string_argument_with_null_default_value), "argument")]
         [InlineData(nameof(Method_having_string_array_arguments), "arguments")]
         [InlineData(nameof(Method_having_string_array_arguments_with_default_value), "arguments")]
         [InlineData(nameof(Method_having_FileInfo_argument), "argument")]
@@ -116,7 +117,7 @@ namespace System.CommandLine.DragonFruit.Tests
 
         [Theory]
         [InlineData(nameof(Method_having_string_argument))]
-        [InlineData(nameof(Method_having_string_argument_with_default_value))]
+        [InlineData(nameof(Method_having_string_argument_with_null_default_value))]
         [InlineData(nameof(Method_having_string_array_arguments))]
         [InlineData(nameof(Method_having_string_array_arguments_with_default_value))]
         [InlineData(nameof(Method_having_FileInfo_argument))]
@@ -145,7 +146,7 @@ namespace System.CommandLine.DragonFruit.Tests
 
         [Theory]
         [InlineData(nameof(Method_having_string_argument), typeof(string))]
-        [InlineData(nameof(Method_having_string_argument_with_default_value), typeof(string))]
+        [InlineData(nameof(Method_having_string_argument_with_null_default_value), typeof(string))]
         [InlineData(nameof(Method_having_string_array_arguments), typeof(string[]))]
         [InlineData(nameof(Method_having_string_array_arguments_with_default_value), typeof(string[]))]
         [InlineData(nameof(Method_having_FileInfo_argument), typeof(FileInfo))]
@@ -265,7 +266,11 @@ namespace System.CommandLine.DragonFruit.Tests
         {
         }
 
-        internal void Method_having_string_argument_with_default_value(string stringOption, int intOption, string argument = null)
+        internal void Method_having_string_argument_with_null_default_value(string stringOption, int intOption, string argument = null)
+        {
+        }
+
+        internal void Method_having_string_argument_with_non_null_default_value(string stringOption, int intOption, string argument = "the-default-value")
         {
         }
 

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -172,7 +172,14 @@ namespace System.CommandLine.DragonFruit
 
                 if (argsParam.HasDefaultValue)
                 {
-                    argument.SetDefaultValue(argsParam.DefaultValue);
+                    if (argsParam.DefaultValue != null)
+                    {
+                        argument.SetDefaultValue(argsParam.DefaultValue);
+                    }
+                    else
+                    {
+                        argument.SetDefaultValue(() => null);
+                    }
                 }
 
                 command.AddArgument(argument);

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -178,7 +178,7 @@ namespace System.CommandLine.DragonFruit
                     }
                     else
                     {
-                        argument.SetDefaultValue(() => null);
+                        argument.SetDefaultValueFactory(() => null);
                     }
                 }
 
@@ -296,7 +296,7 @@ namespace System.CommandLine.DragonFruit
 
             if (parameter.HasDefaultValue)
             {
-                argument.SetDefaultValue(parameter.GetDefaultValue);
+                argument.SetDefaultValueFactory(parameter.GetDefaultValue);
             }
 
             var option = new Option(

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public class ArgumentTests : SymbolTests
+    {
+        [Fact]
+        public void By_default_there_is_no_default_value()
+        {
+            var argument = new Argument();
+
+            argument.HasDefaultValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void When_default_value_is_set_to_null_then_HasDefaultValue_is_true()
+        {
+            var argument = new Argument();
+
+            argument.SetDefaultValue(null);
+
+            argument.HasDefaultValue.Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_default_value_factory_is_set_then_HasDefaultValue_is_true()
+        {
+            var argument = new Argument();
+
+            argument.SetDefaultValueFactory(() => null);
+
+            argument.HasDefaultValue.Should().BeTrue();
+        }
+
+        [Fact]
+        public void When_there_is_no_default_value_then_GetDefaultValue_throws()
+        {
+            var argument = new Argument<string>("the-arg");
+
+            argument.Invoking(a => a.GetDefaultValue())
+                    .Should()
+                    .Throw<InvalidOperationException>()
+                    .Which
+                    .Message
+                    .Should()
+                    .Be("Argument \"the-arg\" does not have a default value");
+        }
+
+        protected override Symbol CreateSymbol(string name)
+        {
+            return new Argument(name);
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -396,7 +396,7 @@ namespace System.CommandLine.Tests.Binding
                 }
             };
 
-            option.Argument.SetDefaultValue(() => "the-default");
+            option.Argument.SetDefaultValueFactory(() => "the-default");
 
             IReadOnlyCollection<Symbol> symbols = new[]
             {

--- a/src/System.CommandLine.Tests/SymbolResultTests.cs
+++ b/src/System.CommandLine.Tests/SymbolResultTests.cs
@@ -40,7 +40,7 @@ namespace System.CommandLine.Tests
                 };
 
             var i = 0;
-            option.Argument.SetDefaultValue(() => ++i);
+            option.Argument.SetDefaultValueFactory(() => ++i);
 
             var result1 = option.Parse("");
             var result2 = option.Parse("");

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine
 {
     public class Argument : Symbol, IArgument
     {
-        private Func<object> _defaultValue;
+        private Func<object> _getDefaultValue;
         private readonly List<string> _suggestions = new List<string>();
         private readonly List<ISuggestionSource> _suggestionSources = new List<ISuggestionSource>();
         private IArgumentArity _arity;
@@ -114,24 +114,27 @@ namespace System.CommandLine
 
         public void AddValidator(ValidateSymbol<ArgumentResult> validator) => Validators.Add(validator);
 
-        public object GetDefaultValue() => _defaultValue?.Invoke();
+        public object GetDefaultValue()
+        {
+            if (_getDefaultValue is null)
+            {
+                throw new InvalidOperationException($"Argument \"{Name}\" does not have a default value");
+            }
+
+            return _getDefaultValue.Invoke();
+        }
 
         public void SetDefaultValue(object value)
         {
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            SetDefaultValue(() => value);
+            SetDefaultValueFactory(() => value);
         }
 
-        public void SetDefaultValue(Func<object> value)
+        public void SetDefaultValueFactory(Func<object> getValue)
         {
-            _defaultValue = value ?? throw new ArgumentNullException(nameof(value));
+            _getDefaultValue = getValue ?? throw new ArgumentNullException(nameof(getValue));
         }
 
-        public bool HasDefaultValue => _defaultValue != null;
+        public bool HasDefaultValue => _getDefaultValue != null;
 
         internal static Argument None => new Argument { Arity = ArgumentArity.Zero };
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -118,7 +118,7 @@ namespace System.CommandLine
 
         public void SetDefaultValue(object value)
         {
-            if (value == null)
+            if (value is null)
             {
                 throw new ArgumentNullException(nameof(value));
             }

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -116,9 +116,20 @@ namespace System.CommandLine
 
         public object GetDefaultValue() => _defaultValue?.Invoke();
 
-        public void SetDefaultValue(object value) => SetDefaultValue(() => value);
+        public void SetDefaultValue(object value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
 
-        public void SetDefaultValue(Func<object> value) => _defaultValue = value;
+            SetDefaultValue(() => value);
+        }
+
+        public void SetDefaultValue(Func<object> value)
+        {
+            _defaultValue = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         public bool HasDefaultValue => _defaultValue != null;
 

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -122,13 +122,8 @@ namespace System.CommandLine
             }
 
             if (parent is ICommand &&
-                type.IsNullable())
-            {
-                return ZeroOrOne;
-            }
-
-            if (parent is ICommand &&
-                argument.HasDefaultValue)
+                (argument.HasDefaultValue ||
+                 type.IsNullable()))
             {
                 return ZeroOrOne;
             }

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -18,17 +18,17 @@ namespace System.CommandLine
             ArgumentType = typeof(T);
         }
 
-        public Argument(string name, Func<T> defaultValue) : this(name)
+        public Argument(string name, Func<T> getDefaultValue) : this(name)
         {
-            SetDefaultValue(() => defaultValue());
+            SetDefaultValueFactory(() => getDefaultValue());
         }
 
         public Argument(Func<T> defaultValue) : this()
         {
-            SetDefaultValue(() => defaultValue());
+            SetDefaultValueFactory(() => defaultValue());
         }
 
-        public Argument(TryConvertArgument<T> convert, Func<T> defaultValue = default) : this()
+        public Argument(TryConvertArgument<T> convert, Func<T> getDefaultValue = default) : this()
         {
             if (convert == null)
             {
@@ -49,9 +49,9 @@ namespace System.CommandLine
                 }
             };
 
-            if (defaultValue != default)
+            if (getDefaultValue != default)
             {
-                SetDefaultValue(() => defaultValue());
+                SetDefaultValueFactory(() => getDefaultValue());
             }
         }
     }


### PR DESCRIPTION
This addresses #728, in part, by preventing `null` from being set as the default argument via the `Argument.SetDefaultValue(object)` overload. Additional design questions [here](https://github.com/dotnet/command-line-api/issues/728#issuecomment-571883738).