### PR TITLE
Add ResultObject to InvocationContext to store return value of command execution

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -193,6 +193,20 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Fact]
+        public async Task When_method_returns_guid_then_return_code_is_set_to_0()
+        {
+            var parser = new CommandLineBuilder()
+                         .ConfigureRootCommandFromMethod(
+                             GetMethodInfo(nameof(Method_returning_guid)), this)
+                         .Build();
+
+            var guid = new Guid("7F7EDB92-516F-4C69-AC42-369B16820299");
+            var result = await parser.InvokeAsync($"-g {guid}", _testConsole);
+
+            result.Should().Be(0);
+        }
+
+        [Fact]
         public async Task When_method_returns_Task_of_int_then_return_code_is_set_to_return_value()
         {
             var parser = new CommandLineBuilder()
@@ -203,6 +217,20 @@ namespace System.CommandLine.DragonFruit.Tests
             var result = await parser.InvokeAsync("-i 123", _testConsole);
 
             result.Should().Be(123);
+        }
+
+        [Fact]
+        public async Task When_method_returns_Task_of_guid_then_return_code_is_set_to_0()
+        {
+            var parser = new CommandLineBuilder()
+                         .ConfigureRootCommandFromMethod(
+                             GetMethodInfo(nameof(Method_returning_Task_of_guid)), this)
+                         .Build();
+
+            var guid = new Guid("7F7EDB92-516F-4C69-AC42-369B16820299");
+            var result = await parser.InvokeAsync($"-g {guid}", _testConsole);
+
+            result.Should().Be(0);
         }
 
         [Theory]
@@ -259,6 +287,17 @@ namespace System.CommandLine.DragonFruit.Tests
         {
             await Task.Yield();
             return i;
+        }
+
+        internal Guid Method_returning_guid(Guid g)
+        {
+            return g;
+        }
+
+        internal async Task<Guid> Method_returning_Task_of_guid(Guid g)
+        {
+            await Task.Yield();
+            return g;
         }
 
         internal void Method_having_string_argument(string stringOption, int intOption, string argument)

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -156,5 +156,22 @@ namespace System.CommandLine.Invocation
                     throw new NotSupportedException();
             }
         }
+        
+        internal static void SetResultObject(object value, InvocationContext context)
+        {
+            if (value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition() == typeof(Task<>))
+            {
+                var taskResult = value.GetType().GetProperty("Result").GetValue(value);
+
+                if (taskResult.GetType().Name != "VoidTaskResult")
+                {
+                    context.ResultObject = taskResult;
+                }
+            }
+            else
+            {
+                context.ResultObject = value;
+            }
+        }
     }
 }

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -154,21 +154,5 @@ namespace System.CommandLine.Invocation
                     return context.ResultCode;
             }
         }
-        
-        internal static void SetResultObject(object value, InvocationContext context)
-        {
-            switch (value)
-            {
-                case Task task:
-                    value = task.GetType().GetProperty("Result").GetValue(value);
-                    SetResultObject(value, context);
-                    break;
-                case null:
-                    break;
-                default:
-                    context.ResultObject = value;
-                    break;
-            }
-        }
     }
 }

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -150,27 +150,24 @@ namespace System.CommandLine.Invocation
                     return context.ResultCode;
                 case int resultCode:
                     return resultCode;
-                case null:
-                    return context.ResultCode;
                 default:
-                    throw new NotSupportedException();
+                    return context.ResultCode;
             }
         }
         
         internal static void SetResultObject(object value, InvocationContext context)
         {
-            if (value.GetType().IsGenericType && value.GetType().GetGenericTypeDefinition() == typeof(Task<>))
+            switch (value)
             {
-                var taskResult = value.GetType().GetProperty("Result").GetValue(value);
-
-                if (taskResult.GetType().Name != "VoidTaskResult")
-                {
-                    context.ResultObject = taskResult;
-                }
-            }
-            else
-            {
-                context.ResultObject = value;
+                case Task task:
+                    value = task.GetType().GetProperty("Result").GetValue(value);
+                    SetResultObject(value, context);
+                    break;
+                case null:
+                    break;
+                default:
+                    context.ResultObject = value;
+                    break;
             }
         }
     }

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -4,6 +4,7 @@
 using System.CommandLine.Binding;
 using System.CommandLine.Parsing;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation
 {
@@ -35,7 +36,7 @@ namespace System.CommandLine.Invocation
 
         public int ResultCode { get; set; }
 
-        public object ResultObject { get; set; }
+        internal object InvokeResult { get; set; }
 
         public IInvocationResult InvocationResult { get; set; }
 
@@ -66,6 +67,27 @@ namespace System.CommandLine.Invocation
             }
 
             return _cts.Token;
+        }
+
+        /// <summary>
+        /// Set <see cref="InvokeResult"/> to the result of the command that was invoked.
+        /// </summary>
+        /// <param name="value">The result of the command invocation. When a task, it's assumed to already have been awaited.</param>
+        internal void SetInvokeResult(object value)
+        {
+            if (value is Task task)
+            {
+                var result = task.GetType().GetProperty("Result").GetValue(value);
+
+                if (result != null)
+                {
+                    InvokeResult = result;
+                }
+            }
+            else if (value != null)
+            {
+                InvokeResult = value;
+            }
         }
 
         public void Dispose()

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -35,6 +35,8 @@ namespace System.CommandLine.Invocation
 
         public int ResultCode { get; set; }
 
+        public object ResultObject { get; set; }
+
         public IInvocationResult InvocationResult { get; set; }
 
         internal event Action<CancellationTokenSource> CancellationHandlingAdded

--- a/src/System.CommandLine/Invocation/InvocationExtensions.cs
+++ b/src/System.CommandLine/Invocation/InvocationExtensions.cs
@@ -372,6 +372,17 @@ namespace System.CommandLine.Invocation
             return builder;
         }
 
+        public static CommandLineBuilder UseReturnValue(
+            this CommandLineBuilder builder)
+        {
+            builder.AddMiddleware(async (context, next) =>
+            {
+                context.InvocationResult = new ReturnValueResult();
+                await next(context);
+            }, CommandLineBuilder.MiddlewareOrder.Middle);
+            return builder;
+        }
+
         public static CommandLineBuilder RegisterWithDotnetSuggest(
             this CommandLineBuilder builder)
         {

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -69,8 +69,8 @@ namespace System.CommandLine.Invocation
             }
 
             var resultCode = await CommandHandler.GetResultCodeAsync(result, context);
-            
-            CommandHandler.SetResultObject(result, context);
+
+            context.SetInvokeResult(result);
             
             return resultCode;
         }

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -68,7 +68,11 @@ namespace System.CommandLine.Invocation
                 result = _handlerDelegate.DynamicInvoke(invocationArguments);
             }
 
-            return await CommandHandler.GetResultCodeAsync(result, context);
+            var resultCode = await CommandHandler.GetResultCodeAsync(result, context);
+            
+            CommandHandler.SetResultObject(result, context);
+            
+            return resultCode;
         }
     }
 }

--- a/src/System.CommandLine/Invocation/ReturnValueResult.cs
+++ b/src/System.CommandLine/Invocation/ReturnValueResult.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine.Invocation
+{
+    public class ReturnValueResult : IInvocationResult
+    {
+        private InvocationContext _context;
+
+        public object Value => _context?.InvokeResult;
+
+        public ReturnValueResult()
+        {
+        }
+
+        public void Apply(InvocationContext context)
+        {
+            _context = context;
+        }
+    }
+}


### PR DESCRIPTION
Please see the changes I've made so far for #166 to access the return value of a command. I'm not sure if this is the desired approach for accomplishing this but hopefully this helps explain further what I'm trying to accomplish. A lot of the tests fail now though, so there must be something problematic about what I've done. I would appreciate any recommendations for alternate desired implementation approaches to take.

I added a `InvocationContext.ResultObject` to store the return value of a command. I did not try to set the value on the `InvocationContext.InvocationResult` because it seems that property is reserved for storing parsing results and I wasn't sure if that made sense to use, and it has the `IInvocationResult` interface which I couldn't just set to the return value.