### PR TITLE
more Option<T> constructors

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -286,6 +286,14 @@ namespace System.CommandLine.Tests
                   .Be($"Argument must be of type {typeof(Argument<int>)} but was {argument.GetType()}");
         }
 
+        [Fact]
+        public void Option_T_default_value_can_be_set()
+        {
+            var option = new Option<int>("-x", parseArgument: parsed => , isDefault: );
+
+            throw new NotImplementedException("test not written");
+        }
+
         protected override Symbol CreateSymbol(string name) => new Option(name);
     }
 }

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -1,14 +1,23 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.CommandLine.Tests
 {
     public class OptionTests : SymbolTests
     {
+        private ITestOutputHelper _output;
+
+        public OptionTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void When_an_option_has_only_one_alias_then_that_alias_is_its_name()
         {
@@ -289,9 +298,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_T_default_value_can_be_set()
         {
-            var option = new Option<int>("-x", parseArgument: parsed => , isDefault: );
+            var option = new Option<int>(
+                "-x",
+                parseArgument: parsed => 123,
+                isDefault: true);
 
-            throw new NotImplementedException("test not written");
+            var result = option
+                         .Parse("")
+                         .FindResultFor(option)
+                         .GetValueOrDefault()
+                         .Should()
+                         .Be(123);
         }
 
         protected override Symbol CreateSymbol(string name) => new Option(name);

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -67,6 +67,11 @@ namespace System.CommandLine
 
         public Argument(ParseArgument<T> parse, bool isDefault = false) : this()
         {
+            if (parse == null)
+            {
+                throw new ArgumentNullException(nameof(parse));
+            }
+
             if (isDefault)
             {
                 SetDefaultValueFactory(() =>

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -1,18 +1,79 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Parsing;
+
 namespace System.CommandLine
 {
     public class Option<T> : Option
     {
-        public Option(string alias, string description = null) : base(alias, description)
+        public Option(string alias) : base(alias)
         {
             Argument = new Argument<T>();
         }
 
-        public Option(string[] aliases, string description = null) : base(aliases, description)
+        public Option(string alias, string description) : base(alias, description)
         {
             Argument = new Argument<T>();
+        }
+
+        public Option(string[] aliases, string description) : base(aliases, description)
+        {
+            Argument = new Argument<T>();
+        }
+
+        public Option(
+            string alias,
+            ParseArgument<T> parseArgument,
+            bool isDefault = false,
+            string description = null) : base(alias, description)
+        {
+            if (parseArgument is null)
+            {
+                throw new ArgumentNullException(nameof(parseArgument));
+            }
+
+            Argument = new Argument<T>(parseArgument, isDefault);
+        }
+
+        public Option(
+            string[] aliases,
+            ParseArgument<T> parseArgument,
+            bool isDefault = false,
+            string description = null) : base(aliases, description)
+        {
+            if (parseArgument is null)
+            {
+                throw new ArgumentNullException(nameof(parseArgument));
+            }
+
+            Argument = new Argument<T>(parseArgument, isDefault);
+        }
+
+        public Option(
+            string alias,
+            Func<T> getDefaultValue,
+            string description = null) : base(alias, description)
+        {
+            if (getDefaultValue is null)
+            {
+                throw new ArgumentNullException(nameof(getDefaultValue));
+            }
+
+            Argument = new Argument<T>(getDefaultValue);
+        }
+
+        public Option(
+            string[] aliases,
+            Func<T> getDefaultValue,
+            string description = null) : base(aliases, description)
+        {
+            if (getDefaultValue is null)
+            {
+                throw new ArgumentNullException(nameof(getDefaultValue));
+            }
+
+            Argument = new Argument<T>(getDefaultValue);
         }
 
         public override Argument Argument


### PR DESCRIPTION
This adds constructors to `Option<T>` so that the child `Argument<T>` doesn't need to be instantiated directly, allowing for more concise instantiation.