### PR TITLE
set appropriate package version numbers

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,8 +6,22 @@
   </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
+    <!-- Default version number. -->
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(UseBetaVersion) == 'true'">
     <VersionPrefix>2.0.0</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(UseAlphaVersion) == 'true'">
+    <VersionPrefix>0.3.0</VersionPrefix>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(UseGlobalToolVersion) == 'true'">
+    <VersionPrefix>1.1</VersionPrefix>
+    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup>
     <UsingToolSourceLink>true</UsingToolSourceLink>

--- a/src/System.CommandLine.DragonFruit/Directory.Build.props
+++ b/src/System.CommandLine.DragonFruit/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseAlphaVersion>true</UseAlphaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/System.CommandLine.Hosting/Directory.Build.props
+++ b/src/System.CommandLine.Hosting/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseAlphaVersion>true</UseAlphaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/System.CommandLine.Rendering/Directory.Build.props
+++ b/src/System.CommandLine.Rendering/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseAlphaVersion>true</UseAlphaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/System.CommandLine.Suggest/Directory.Build.props
+++ b/src/System.CommandLine.Suggest/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseGlobalToolVersion>true</UseGlobalToolVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/System.CommandLine.Tests/Directory.Build.props
+++ b/src/System.CommandLine.Tests/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>

--- a/src/System.CommandLine/Directory.Build.props
+++ b/src/System.CommandLine/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <UseBetaVersion>true</UseBetaVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+</Project>


### PR DESCRIPTION
The result of faking an official build with `.\build.cmd -pack -ci /p:OfficialBuildId=20200124.0` results in the following package versions:

- `dotnet-suggest.1.1.107400.nupkg` (greater than the currently published `1.1.19174.3`)
- `System.CommandLine.2.0.0-beta1.20074.0.nupkg` (greater than the currently published `2.0.0-beta1.20071.2`)
- `System.CommandLine.DragonFruit.0.3.0-alpha.20074.0.nupkg` (greater than the currently published `0.3.0-alpha.20070.2`)
- `System.CommandLine.Hosting.0.3.0-alpha.20074.0.nupkg` (greater than the currently published `0.3.0-alpha.20070.2`)
- `System.CommandLine.Rendering.0.3.0-alpha.20074.0.nupkg` (greater than the currently published `0.3.0-alpha.20070.2`)
