### PR TITLE
add global options, make -h a proper option

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Rendering;
-using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -64,7 +63,7 @@ namespace System.CommandLine.DragonFruit.Tests
                   .Contain("<args>    These are arguments")
                   .And.Contain("Arguments:");
             stdOut.Should()
-                  .Contain("--name <name>    Specifies the name option")
+                  .ContainAll("--name <name>", "Specifies the name option")
                   .And.Contain("Options:");
             stdOut.Should()
                   .Contain("Help for the test program");
@@ -88,7 +87,7 @@ namespace System.CommandLine.DragonFruit.Tests
                 .Contain("<args>    These are arguments")
                 .And.Contain("Arguments:");
             stdOut.Should()
-                .Contain("--name <name>    Specifies the name option")
+                .ContainAll("--name <name>","Specifies the name option")
                 .And.Contain("Options:");
             stdOut.Should()
                 .Contain("Help for the test program");

--- a/src/System.CommandLine.Suggest.Tests/DotnetSuggestEndToEndTests.cs
+++ b/src/System.CommandLine.Suggest.Tests/DotnetSuggestEndToEndTests.cs
@@ -155,7 +155,7 @@ namespace System.CommandLine.Suggest.Tests
 
             stdOut.ToString()
                 .Should()
-                .Be($"--apple{NewLine}--banana{NewLine}--cherry{NewLine}--durian{NewLine}--version{NewLine}");
+                .Be($"/?{NewLine}/h{NewLine}-?{NewLine}--apple{NewLine}--banana{NewLine}--cherry{NewLine}--durian{NewLine}-h{NewLine}--help{NewLine}--version{NewLine}");
         }
     }
 }

--- a/src/System.CommandLine.Suggest.Tests/DotnetSuggestEndToEndTests.cs
+++ b/src/System.CommandLine.Suggest.Tests/DotnetSuggestEndToEndTests.cs
@@ -155,7 +155,7 @@ namespace System.CommandLine.Suggest.Tests
 
             stdOut.ToString()
                 .Should()
-                .Be($"/?{NewLine}/h{NewLine}-?{NewLine}--apple{NewLine}--banana{NewLine}--cherry{NewLine}--durian{NewLine}-h{NewLine}--help{NewLine}--version{NewLine}");
+                .Be($"--apple{NewLine}--banana{NewLine}--cherry{NewLine}--durian{NewLine}--help{NewLine}--version{NewLine}-?{NewLine}-h{NewLine}/?{NewLine}/h{NewLine}");
         }
     }
 }

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -323,16 +323,44 @@ namespace System.CommandLine.Tests
             var command = new Command("the-command")
             {
                 new Option("--same")
-                {
-                    Argument = new Argument<string>()
-                }
             };
 
             command
-                .Invoking(c => c.Add(new Option("--same")
-                {
-                    Argument = new Argument<string>()
-                }))
+                .Invoking(c => c.Add(new Option("--same")))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .Message
+                .Should()
+                .Be("Alias '--same' is already in use.");
+        }
+
+        [Fact]
+        public void When_global_options_are_added_then_they_must_differ_from_local_options_by_name()
+        {
+            var command = new Command("the-command")
+            {
+                new Option("--same")
+            };
+
+            command
+                .Invoking(c => c.AddGlobalOption(new Option("--same")))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .Message
+                .Should()
+                .Be("Alias '--same' is already in use.");
+        }
+
+        [Fact]
+        public void When_local_options_are_added_then_they_must_differ_from_global_options_by_name()
+        {
+            var command = new Command("the-command");
+            command.AddGlobalOption(new Option("--same"));
+
+            command
+                .Invoking(c => c.Add(new Option("--same")))
                 .Should()
                 .Throw<ArgumentException>()
                 .And

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -1106,6 +1106,21 @@ namespace System.CommandLine.Tests.Help
                 .Contain("-r, --required <ARG> (REQUIRED)");
         }
 
+        [Fact]
+        public void Help_option_is_shown_in_help()
+        {
+            var parser = new CommandLineBuilder()
+                         .UseHelp()
+                         .Build();
+
+            _helpBuilder.Write(parser.Configuration.RootCommand);
+
+            var help = _console.Out.ToString();
+
+            help.Should()
+                .Contain($"--help{_columnPadding}Show help and usage information");
+        }
+
         #endregion Options
 
         #region Subcommands

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -1118,7 +1118,37 @@ namespace System.CommandLine.Tests.Help
             var help = _console.Out.ToString();
 
             help.Should()
-                .Contain($"--help{_columnPadding}Show help and usage information");
+                .Contain($"-?, -h, --help{_columnPadding}Show help and usage information");
+        }
+
+        [Fact]
+        public void Options_aliases_differing_only_by_prefix_are_deduplicated_favoring_dashed_prefixes()
+        {
+            var command = new RootCommand
+            {
+                new Option(new[] { "-x", "/x" })
+            };
+
+            _helpBuilder.Write(command);
+            
+            var help = _console.Out.ToString();
+
+            help.Should().NotContain("/x");
+        }
+        
+        [Fact]
+        public void Options_aliases_differing_only_by_prefix_are_deduplicated_favoring_double_dashed_prefixes()
+        {
+            var command = new RootCommand
+            {
+                new Option(new[] { "--long", "/long" })
+            };
+
+            _helpBuilder.Write(command);
+            
+            var help = _console.Out.ToString();
+
+            help.Should().NotContain("/long");
         }
 
         #endregion Options

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1625,26 +1625,6 @@ namespace System.CommandLine.Tests
             valueForOption.Should().Be("-y");
         }
 
-        [Theory]
-        [InlineData("/o")]
-        [InlineData("-o")]
-        [InlineData("--o")]
-        [InlineData("/output")]
-        [InlineData("-output")]
-        [InlineData("--output")]
-        public void Option_aliases_can_be_specified_and_are_prefixed_with_defaults(string input)
-        {
-            var option = new Option(new[] { "output", "o" });
-            var configuration = new CommandLineConfiguration(
-                new[] { option },
-                prefixes: new[] { "-", "--", "/" });
-            var parser = new Parser(configuration);
-
-            ParseResult parseResult = parser.Parse(input);
-            parseResult["output"].Should().NotBeNull();
-            parseResult["o"].Should().NotBeNull();
-        }
-
         [Fact]
         public void Option_aliases_do_not_need_to_be_prefixed()
         {
@@ -1653,27 +1633,6 @@ namespace System.CommandLine.Tests
             var result = new RootCommand { option }.Parse("noprefix");
 
             result.HasOption(option).Should().BeTrue();
-        }
-
-        [Theory]
-        [InlineData("/o")]
-        [InlineData("-o")]
-        [InlineData("--output")]
-        [InlineData("--out")]
-        [InlineData("-out")]
-        [InlineData("/out")]
-        public void Option_aliases_can_be_specified_for_particular_prefixes(string input)
-        {
-            var option = new Option(new[] { "--output", "-o", "/o", "out" });
-            var configuration = new CommandLineConfiguration(
-                new[] { option },
-                prefixes: new[] { "-", "--", "/" });
-            var parser = new Parser(configuration);
-
-            ParseResult parseResult = parser.Parse(input);
-            parseResult["o"].Should().NotBeNull();
-            parseResult["out"].Should().NotBeNull();
-            parseResult["output"].Should().NotBeNull();
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -55,21 +55,6 @@ namespace System.CommandLine.Tests
             wasCalled.Should().BeFalse();
         }
 
-        [Fact]
-        public async Task UseHelp_allows_help_for_all_configured_prefixes()
-        {
-            var parser =
-                new CommandLineBuilder()
-                    .AddCommand(new Command("command"))
-                    .UseHelp()
-                    .UsePrefixes(new[] { "~" })
-                    .Build();
-
-            await parser.InvokeAsync("command ~help", _console);
-
-            _console.Out.ToString().Should().StartWith("Usage:");
-        }
-
         [Theory]
         [InlineData("-h")]
         [InlineData("--help")]
@@ -89,12 +74,12 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public async Task UseHelp_accepts_collection_of_help_options()
+        public async Task UseHelp_accepts_custom_aliases()
         {
             var parser =
                 new CommandLineBuilder()
                     .AddCommand(new Command("command"))
-                    .UseHelp(new[] { "~cthulhu" })
+                    .UseHelp(new Option(new[] { "~cthulhu" }))
                     .Build();
 
             await parser.InvokeAsync("command ~cthulhu", _console);
@@ -119,6 +104,39 @@ namespace System.CommandLine.Tests
             await result.InvokeAsync(_console);
 
             _console.Out.ToString().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void There_are_no_parse_errors_when_help_is_invoked_on_root_command()
+        {
+            var parser = new CommandLineBuilder()
+                .UseDefaults()
+                .Build();
+
+            var result = parser.Parse("-h");
+
+            result.Errors
+                  .Should()
+                  .BeEmpty();
+        }
+        
+        [Fact]
+        public void There_are_no_parse_errors_when_help_is_invoked_on_subcommand()
+        {
+            var command = new RootCommand
+            {
+                new Command("subcommand")
+            };
+
+            var parser = new CommandLineBuilder(command)
+                         .UseDefaults()
+                         .Build();
+
+            var result = parser.Parse("subcommand -h");
+
+            result.Errors
+                  .Should()
+                  .BeEmpty();
         }
     }
 }

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -110,7 +110,7 @@ namespace System.CommandLine.Tests
         public void There_are_no_parse_errors_when_help_is_invoked_on_root_command()
         {
             var parser = new CommandLineBuilder()
-                .UseDefaults()
+                .UseHelp()
                 .Build();
 
             var result = parser.Parse("-h");
@@ -129,7 +129,7 @@ namespace System.CommandLine.Tests
             };
 
             var parser = new CommandLineBuilder(command)
-                         .UseDefaults()
+                         .UseHelp()
                          .Build();
 
             var result = parser.Parse("subcommand -h");

--- a/src/System.CommandLine.Tests/VersionOptionTests.cs
+++ b/src/System.CommandLine.Tests/VersionOptionTests.cs
@@ -66,7 +66,7 @@ namespace System.CommandLine.Tests
             console.Out
                    .ToString()
                    .Should()
-                   .Match("*Options:*--version*Display version information*");
+                   .Match("*Options:*--version*Show version information*");
         }
 
         [Fact]

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -192,7 +192,7 @@ namespace System.CommandLine
                    .Concat(dynamicSuggestions)
                    .Concat(typeSuggestions)
                    .Distinct()
-                   .OrderBy(c => c)
+                   .OrderBy(c => c, StringComparer.OrdinalIgnoreCase)
                    .Containing(textToMatch);
         }
 

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -23,11 +23,11 @@ namespace System.CommandLine.Builder
 
         public bool EnablePosixBundling { get; set; } = true;
 
-        public IReadOnlyCollection<string> Prefixes { get; set; }
-
         public ResponseFileHandling ResponseFileHandling { get; set; }
 
         internal Func<BindingContext, IHelpBuilder> HelpBuilderFactory { get; set; }
+
+        internal Option HelpOption { get; set; }
 
         public Parser Build()
         {
@@ -36,7 +36,6 @@ namespace System.CommandLine.Builder
             return new Parser(
                 new CommandLineConfiguration(
                     new[] { rootCommand },
-                    prefixes: Prefixes,
                     enablePosixBundling: EnablePosixBundling,
                     enableDirectives: EnableDirectives,
                     validationMessages: ValidationMessages.Instance,

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -275,7 +275,7 @@ namespace System.CommandLine.Builder
                 "--help",
                 "-?",
                 "/?"
-            });
+            }, "Show help and usage information");
 
             return builder.UseHelp(helpOption);
         }
@@ -428,7 +428,7 @@ namespace System.CommandLine.Builder
                 return builder;
             }
 
-            var versionOption = new Option("--version", "Display version information");
+            var versionOption = new Option("--version", "Show version information");
 
             builder.AddOption(versionOption);
 

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine.IO;
+using System.CommandLine.Parsing;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -331,8 +332,14 @@ namespace System.CommandLine.Help
         /// <returns>A new <see cref="HelpItem"/></returns>
         private IEnumerable<HelpItem> GetOptionHelpItems(ISymbol symbol)
         {
-            var rawAliases = symbol.RawAliases
-                .OrderBy(alias => alias.Length);
+            var rawAliases = symbol
+                             .RawAliases
+                             .Select(r => r.SplitPrefix())
+                             .OrderBy(r => r.alias)
+                             .ThenBy(r => r.prefix)
+                             .GroupBy(t => t.alias)
+                             .Select(t => t.First())
+                             .Select(t => $"{t.prefix}{t.alias}");
 
             var invocation = string.Join(", ", rawAliases);
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -66,18 +66,13 @@ namespace System.CommandLine
 
         public ISymbolSet Parents => _parents; 
 
-        private protected void AddParent(Symbol symbol)
+        internal void AddParent(Symbol symbol)
         {
             _parents.AddWithoutAliasCollisionCheck(symbol);
         }
 
-        private protected void AddSymbol(Symbol symbol)
+        private protected virtual void AddSymbol(Symbol symbol)
         {
-            if (this is Command command)
-            {
-                symbol.AddParent(command);
-            }
-
             Children.Add(symbol);
         }
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -146,7 +146,7 @@ namespace System.CommandLine
             return this.ChildSymbolAliases()
                        .Concat(argumentSuggestions)
                        .Distinct()
-                       .OrderBy(symbol => symbol)
+                       .OrderBy(symbol => symbol, StringComparer.OrdinalIgnoreCase)
                        .Containing(textToMatch);
         }
 


### PR DESCRIPTION
This reimplements help as a proper `Option`, which fixes #691. In order for the help option to be a single instance, looked up using `FindResultFor` after parsing, I also added support for global options (#587). 

This should also fix #766, the root cause of which is #691.

This will also fix #506.