### PR TITLE
set parent symbol when custom parse delegate is called on default value

### DIFF
--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -117,7 +117,7 @@ namespace System.CommandLine.Tests
             }
 
             [Fact]
-            public void validation_failure_message()
+            public void Validation_failure_message_can_be_specified()
             {
                 var argument = new Argument<FileSystemInfo>(result =>
                 {
@@ -187,6 +187,79 @@ namespace System.CommandLine.Tests
                         .GetValueOrDefault()
                         .Should()
                         .Be(6);
+            }
+
+            [Fact]
+            public void ArgumentResult_Parent_is_set_correctly_when_token_is_present()
+            {
+                ArgumentResult argumentResult = null;
+
+                var command = new Command("the-command")
+                {
+                    new Option<string>(
+                        "-x",
+                        parseArgument: argResult =>
+                        {
+                            argumentResult = argResult;
+                            return null;
+                        })
+                };
+
+                command.Parse("-x abc");
+
+                argumentResult
+                    .Parent
+                    .Should()
+                    .NotBeNull();
+            }
+
+            [Fact]
+            public void Option_ArgumentResult_Parent_is_set_correctly_when_token_is_implicit()
+            {
+                ArgumentResult argumentResult = null;
+
+                var command = new Command("the-command")
+                {
+                    new Option<string>(
+                        "-x",
+                        parseArgument: argResult =>
+                        {
+                            argumentResult = argResult;
+                            return null;
+                        }, isDefault: true)
+                };
+
+                command.Parse("");
+
+                argumentResult
+                    .Parent
+                    .Symbol
+                    .Should()
+                    .Be(command.Options.Single());
+            }
+
+            [Fact]
+            public void Command_ArgumentResult_Parent_is_set_correctly_when_token_is_implicit()
+            {
+                ArgumentResult argumentResult = null;
+
+                var command = new Command("the-command")
+                {
+                    new Argument<string>(
+                        parse: argResult =>
+                        {
+                            argumentResult = argResult;
+                            return null;
+                        }, isDefault: true)
+                };
+
+                command.Parse("");
+
+                argumentResult
+                    .Parent
+                    .Symbol
+                    .Should()
+                    .Be(command);
             }
         }
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine
 {
     public class Argument : Symbol, IArgument
     {
-        private Func<object> _defaultValueFactory;
+        private Func<ArgumentResult, object> _defaultValueFactory;
         private readonly List<string> _suggestions = new List<string>();
         private readonly List<ISuggestionSource> _suggestionSources = new List<ISuggestionSource>();
         private IArgumentArity _arity;
@@ -116,12 +116,17 @@ namespace System.CommandLine
 
         public object GetDefaultValue()
         {
+            return GetDefaultValue(new ArgumentResult(this, null));
+        }
+
+        internal object GetDefaultValue(ArgumentResult argumentResult)
+        {
             if (_defaultValueFactory is null)
             {
                 throw new InvalidOperationException($"Argument \"{Name}\" does not have a default value");
             }
 
-            return _defaultValueFactory.Invoke();
+            return _defaultValueFactory.Invoke(argumentResult);
         }
 
         public void SetDefaultValue(object value)
@@ -130,6 +135,16 @@ namespace System.CommandLine
         }
 
         public void SetDefaultValueFactory(Func<object> getDefaultValue)
+        {
+            if (getDefaultValue == null)
+            {
+                throw new ArgumentNullException(nameof(getDefaultValue));
+            }
+
+            SetDefaultValueFactory(_ => getDefaultValue());
+        }
+        
+        public void SetDefaultValueFactory(Func<ArgumentResult, object> getDefaultValue)
         {
             _defaultValueFactory = getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue));
         }

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -74,14 +74,7 @@ namespace System.CommandLine
 
             if (isDefault)
             {
-                SetDefaultValueFactory(() =>
-                {
-                    var argumentResult = new ArgumentResult(
-                        this,
-                        null);
-
-                    return parse(argumentResult);
-                });
+                SetDefaultValueFactory(argumentResult => parse(argumentResult));
             }
 
             ConvertArguments = (ArgumentResult argumentResult, out object value) =>

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -102,5 +102,8 @@ namespace System.CommandLine.Parsing
                        optionResult.IsImplicit);
             }
         }
+
+        internal override object CreateDefaultArgumentResultAndGetItsValue(Argument argument) => 
+            argument.GetDefaultValue(this);
     }
 }

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.CommandLine.Binding;
 using System.Linq;
 
 namespace System.CommandLine.Parsing
@@ -63,11 +64,23 @@ namespace System.CommandLine.Parsing
 
         internal void AddToken(Token token) => _tokens.Add(token);
 
-        internal object GetDefaultValueFor(IArgument argument)
+        internal virtual object GetDefaultValueFor(IArgument argument)
         {
             return _defaultArgumentValues.GetOrAdd(
                 argument,
-                a => a.GetDefaultValue());
+                a => a is Argument arg 
+                         ? CreateDefaultArgumentResultAndGetItsValue(arg) 
+                         : a.GetDefaultValue());
+        }
+        
+        internal virtual object CreateDefaultArgumentResultAndGetItsValue(Argument argument)
+        {
+            if (!(Children.ResultFor(argument) is ArgumentResult result))
+            {
+                result = new ArgumentResult(argument, this);
+            }
+
+            return argument.GetDefaultValue(result);
         }
 
         internal bool UseDefaultValueFor(IArgument argument)


### PR DESCRIPTION
This replaces the dummy `ArgumentResult` passed to the `ParseArgument<T>` delegate with a correctly-parented `ArgumentResult`.