### PR TITLE
fix: default values for option arguments was not validated

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -309,6 +310,38 @@ namespace System.CommandLine.Tests
                          .GetValueOrDefault()
                          .Should()
                          .Be(123);
+        }
+
+        [Fact]
+        public void Option_T_default_value_is_validated()
+        {
+            var arg = new Argument<int>(() => 123);
+            arg.AddValidator( symbol =>
+                    symbol.Tokens
+                    .Select(t => t.Value)
+                    .Where(v => v == "123")
+                    .Select(x => "ERR")
+                    .FirstOrDefault());
+
+            var option = new Option("-x")
+            { 
+                Argument = arg
+            };
+
+            option
+                .Parse("-x 123")
+                .Errors
+                .Select(e => e.Message)
+                .Should()
+                .BeEquivalentTo(new[] { "ERR" });
+
+            option
+                .Parse("")
+                .Errors
+                .Select(e => e.Message)
+                .Should()
+                .BeEquivalentTo(new[] { "ERR" });
+
         }
 
         protected override Symbol CreateSymbol(string name) => new Option(name);

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -327,13 +327,14 @@ namespace System.CommandLine.Parsing
                                     optionResult.GetDefaultValueFor(option.Argument),
                                     TokenType.Argument);
 
-                                optionResult.Children.Add(
-                                    new ArgumentResult(
+                                var childArgumentResult = new ArgumentResult(
                                         option.Argument,
-                                        optionResult));
+                                        optionResult);
 
+                                optionResult.Children.Add(childArgumentResult);
                                 commandResult.Children.Add(optionResult);
                                 optionResult.AddToken(token);
+                                childArgumentResult.AddToken(token);
                                 _rootCommandResult.AddToSymbolMap(optionResult);
 
                                 break;


### PR DESCRIPTION
When a default is specified for an option's argument, it is not validated.
In my use-case i have this setup:
```
var ret = new Command(...)
{
  new Option("-gv", "...")
  {
    Required = true,                    
    Argument = new Argument<FileInfo>(() => new FileInfo("defaultfile.dat"))
      .ExistingOnly()
  },
};
```

and at run time i don't receive any error when `defaultfile.dat` does not exists...

My PR will fix this issue.



