### PR TITLE
don't mutate command on subsequent calls to Invoke extension

### DIFF
--- a/src/System.CommandLine.Tests/CommandExtensionsTests.cs
+++ b/src/System.CommandLine.Tests/CommandExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public class CommandExtensionsTests
+    {
+        [Fact]
+        public void Mulitple_invocations_via_Invoke_extension_will_not_reconfigure_implicit_parser()
+        {
+            var command = new RootCommand("Root command description")
+            {
+                new Command("inner")
+            };
+
+            var console1 = new TestConsole();
+
+            command.Invoke("-h", console1);
+
+            console1.Out.ToString().Should().Contain(command.Description);
+
+            var console2 = new TestConsole();
+
+            command.Invoke("-h", console2);
+
+            console2.Out.ToString().Should().Contain(command.Description);
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/CommandExtensionsTests.cs
+++ b/src/System.CommandLine.Tests/CommandExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Builder;
 using System.CommandLine.IO;
 using FluentAssertions;
 using Xunit;
@@ -10,7 +11,7 @@ namespace System.CommandLine.Tests
     public class CommandExtensionsTests
     {
         [Fact]
-        public void Mulitple_invocations_via_Invoke_extension_will_not_reconfigure_implicit_parser()
+        public void Command_Invoke_can_be_called_more_than_once_for_the_same_command()
         {
             var command = new RootCommand("Root command description")
             {
@@ -22,12 +23,34 @@ namespace System.CommandLine.Tests
             command.Invoke("-h", console1);
 
             console1.Out.ToString().Should().Contain(command.Description);
-
+            
             var console2 = new TestConsole();
 
             command.Invoke("-h", console2);
 
             console2.Out.ToString().Should().Contain(command.Description);
+        }
+
+        [Fact]
+        public void When_CommandLineBuilder_is_used_then_Command_Invoke_uses_its_configuration()
+        {
+            var command = new RootCommand();
+
+            new CommandLineBuilder(command)
+                .UseMiddleware(context =>
+                {
+                    context.Console.Out.Write("hello!");
+                })
+                .Build();
+
+            var console = new TestConsole();
+
+            command.Invoke("", console);
+
+            console.Out
+                   .ToString()
+                   .Should()
+                   .Contain("hello!");
         }
     }
 }

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -336,7 +336,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void When_global_options_are_added_then_they_must_differ_from_local_options_by_name()
+        public void Global_options_may_be_added_with_aliases_that_conflict_with_local_options()
         {
             var command = new Command("the-command")
             {
@@ -346,8 +346,21 @@ namespace System.CommandLine.Tests
             command
                 .Invoking(c => c.AddGlobalOption(new Option("--same")))
                 .Should()
+                .NotThrow<ArgumentException>();
+        }
+
+        [Fact]
+        public void Global_options_may_not_have_aliases_conflicting_with_other_global_option_aliases()
+        {
+            var command = new Command("the-command");
+
+            command.AddGlobalOption(new Option("--same"));
+
+            command
+                .Invoking(c => c.AddGlobalOption(new Option("--same")))
+                .Should()
                 .Throw<ArgumentException>()
-                .And
+                .Which
                 .Message
                 .Should()
                 .Be("Alias '--same' is already in use.");

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -17,6 +17,10 @@ namespace System.CommandLine.Builder
         public CommandLineBuilder(Command rootCommand = null)
             : base(rootCommand ?? new RootCommand())
         {
+            if (rootCommand?.ImplicitParser != null)
+            {
+                throw new ArgumentException($"Command \"{rootCommand.Name}\" has already been configured.");
+            }
         }
 
         public bool EnableDirectives { get; set; } = true;
@@ -33,7 +37,7 @@ namespace System.CommandLine.Builder
         {
             var rootCommand = Command;
 
-            return new Parser(
+            var parser = new Parser(
                 new CommandLineConfiguration(
                     new[] { rootCommand },
                     enablePosixBundling: EnablePosixBundling,
@@ -44,6 +48,10 @@ namespace System.CommandLine.Builder
                                                        .Select(m => m.middleware)
                                                        .ToArray(),
                     helpBuilderFactory: HelpBuilderFactory));
+
+            Command.ImplicitParser = parser;
+
+            return parser;
         }
 
         internal void AddMiddleware(

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -401,7 +401,6 @@ namespace System.CommandLine.Builder
             return builder;
         }
 
-
         public static CommandLineBuilder UseTypoCorrections(
             this CommandLineBuilder builder, int maxLevenshteinDistance = 3)
         {

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.CommandLine.Builder;
 using System.CommandLine.Collections;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
@@ -32,7 +33,6 @@ namespace System.CommandLine
 
         public void AddGlobalOption(Option option)
         {
-            Children.ThrowIfAnyAliasIsInUse(option);
             _globalOptions.Add(option);
             Children.AddWithoutAliasCollisionCheck(option);
         }
@@ -68,5 +68,7 @@ namespace System.CommandLine
         IEnumerable<IArgument> ICommand.Arguments => Arguments;
 
         IEnumerable<IOption> ICommand.Options => Options;
+
+        internal Parser ImplicitParser { get; set; }
     }
 }

--- a/src/System.CommandLine/CommandExtensions.cs
+++ b/src/System.CommandLine/CommandExtensions.cs
@@ -42,11 +42,12 @@ namespace System.CommandLine
 
         private static InvocationPipeline GetInvocationPipeline(Command command, string[] args)
         {
-            var parser = new CommandLineBuilder(command)
-                         .UseDefaults()
-                         .Build();
+            var parser = command.ImplicitParser ??=
+                             new CommandLineBuilder(command)
+                                 .UseDefaults()
+                                 .Build();
 
-            ParseResult parseResult = parser.Parse(args);
+            var parseResult = parser.Parse(args);
 
             return new InvocationPipeline(parseResult);
         }


### PR DESCRIPTION
This fixes a bug where calling the `Command.Invoke` / `Command.InvokeAsync` extension methods more than once on the same `Command` instance would throw due to global options being added twice to the implictly-created parser. Now, that parser is cached and reused.