### PR TITLE
Bind options by name

### DIFF
--- a/src/System.CommandLine/Binding/Binder.cs
+++ b/src/System.CommandLine/Binding/Binder.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Binding
                           StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsMatch(this string parameterName, ISymbol symbol) =>
-            symbol.Aliases.Any(parameterName.IsMatch);
+            parameterName.IsMatch(symbol.Name) || symbol.Aliases.Any(parameterName.IsMatch);
 
         internal static bool IsNullable(this Type t)
         {


### PR DESCRIPTION
This PR fixes #798 by matching parameter name with option name in addition to option aliases.