### PR TITLE
Adding global options to the builder.

### DIFF
--- a/src/System.CommandLine.Tests/Builder/CommandLineBuilderExtensionsTests.cs
+++ b/src/System.CommandLine.Tests/Builder/CommandLineBuilderExtensionsTests.cs
@@ -1,0 +1,25 @@
+﻿using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests.Builder
+{
+    public class CommandLineBuilderExtensionsTests
+    {
+        [Fact]
+        public void Global_options_are_added_to_the_root_command()
+        {
+            var globalOption = new Option("global");
+            var builder = new CommandLineBuilder()
+                .AddGlobalOption(globalOption);
+
+            Parser parser = builder.Build();
+
+            Command rootCommand = (Command)parser.Configuration.RootCommand;
+            rootCommand.GlobalOptions
+                .Should()
+                .Contain(globalOption);
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.CommandLine.Binding;
-using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
 using FluentAssertions;
+using System.CommandLine.Parsing;
 using System.Linq;
 using Xunit;
 

--- a/src/System.CommandLine/Builder/CommandBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandBuilder.cs
@@ -21,6 +21,8 @@ namespace System.CommandLine.Builder
 
         internal void AddOption(Option option) => Command.AddOption(option);
 
+        internal void AddGlobalOption(Option option) => Command.AddGlobalOption(option);
+
         internal void AddArgument(Argument argument) => Command.AddArgument(argument);
     }
 }

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -64,6 +64,16 @@ namespace System.CommandLine.Builder
             return builder;
         }
 
+        public static TBuilder AddGlobalOption<TBuilder>(
+            this TBuilder builder, 
+            Option option)
+            where TBuilder : CommandBuilder
+        {
+            builder.AddGlobalOption(option);
+
+            return builder;
+        }
+
         public static CommandLineBuilder CancelOnProcessTermination(this CommandLineBuilder builder)
         {
             builder.AddMiddleware(async (context, next) =>


### PR DESCRIPTION
The global options part of the API was not being exposed via the builder. 
