### PR TITLE
Fix for multiple parameters that have the same type and default values

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -235,6 +235,17 @@ namespace System.CommandLine.DragonFruit.Tests
             _receivedValues.Should().BeEquivalentTo(true);
         }
 
+        [Fact]
+        public async Task Method_with_multiple_parameters_with_default_values_are_resolved_correctly()
+        {
+            var command = new Command("test");
+            command.ConfigureFromMethod(GetMethodInfo(nameof(Method_with_multiple_default_values)), this);
+
+            await command.InvokeAsync("");
+
+            _receivedValues.Should().BeEquivalentTo(1, 2);
+        }
+
         internal void Method_taking_bool(bool value = false)
         {
             _receivedValues = new object[] { value };
@@ -292,6 +303,11 @@ namespace System.CommandLine.DragonFruit.Tests
 
         internal void Method_having_FileInfo_array_args(string stringOption, int intOption, FileInfo[] args)
         {
+        }
+
+        internal void Method_with_multiple_default_values(int firstValue = 1, int secondValue = 2)
+        {
+            _receivedValues = new object[] { firstValue, secondValue };
         }
 
         private MethodInfo GetMethodInfo(string name)

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -265,9 +265,9 @@ namespace System.CommandLine.DragonFruit
                        : $"-{parameterName.ToLowerInvariant()}";
         }
 
-        public static IEnumerable<Option> BuildOptions(this MethodInfo type)
+        public static IEnumerable<Option> BuildOptions(this MethodInfo method)
         {
-            var descriptor = HandlerDescriptor.FromMethodInfo(type);
+            var descriptor = HandlerDescriptor.FromMethodInfo(method);
 
             var omittedTypes = new[]
                                {

--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -616,5 +616,30 @@ namespace System.CommandLine.Tests.Binding
 
             boundInstance.Value.Should().Be(456);
         }
+
+        [Fact]
+        public void Default_values_from_options_with_the_same_type_are_bound_and_use_their_own_defaults()
+        {
+            int first = 0, second = 0;
+
+            var rootCommand = new RootCommand
+            {
+                new Option<int>("one", () => 1),
+                new Option<int>("two", () => 2)
+            };
+            rootCommand.Handler = CommandHandler.Create<int, int>((one, two) =>
+            {
+                first = one;
+                second = two;
+            });
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .Build();
+
+            parser.Invoke("");
+
+            first.Should().Be(1);
+            second.Should().Be(2);
+        }
     }
 }

--- a/src/System.CommandLine.Tests/Binding/TestModels.cs
+++ b/src/System.CommandLine.Tests/Binding/TestModels.cs
@@ -5,26 +5,6 @@ using System.Threading.Tasks;
 
 namespace System.CommandLine.Tests.Binding
 {
-    public class ClassWithSingleLetterCtorParameter
-    {
-        public ClassWithSingleLetterCtorParameter(int x, string y)
-        {
-            X = x;
-            Y = y;
-        }
-
-        public int X { get; }
-
-        public string Y { get; }
-    }
-
-    public class ClassWithSingleLetterProperty
-    {
-        public int X { get; set; }
-
-        public int Y { get; set; }
-    }
-
     public class ClassWithMultiLetterCtorParameters
     {
         public ClassWithMultiLetterCtorParameters(
@@ -59,23 +39,6 @@ namespace System.CommandLine.Tests.Binding
             IntOption = i;
             StringOption = s;
             BoolOption = b;
-        }
-
-        public int IntOption { get; set; }
-        public string StringOption { get; set; }
-        public bool BoolOption { get; set; }
-    }
-
-    public class ClassWithSettersAndCtorParametersWithMatchingNames
-    {
-        public ClassWithSettersAndCtorParametersWithMatchingNames(
-            int intOption = 123,
-            string stringOption = "the default",
-            bool boolOption = false)
-        {
-            IntOption = intOption;
-            StringOption = stringOption;
-            BoolOption = boolOption;
         }
 
         public int IntOption { get; set; }
@@ -123,79 +86,6 @@ namespace System.CommandLine.Tests.Binding
         }
 
         public T ReceivedValue { get; set; }
-    }
-
-    public class TypeWithInvokeAndCtor
-    {
-        public TypeWithInvokeAndCtor(int intFromCtor, string stringFromCtor)
-        {
-            IntValueFromCtor = intFromCtor;
-            StringValueFromCtor = stringFromCtor;
-        }
-
-        public int IntValueFromCtor { get; }
-
-        public string StringValueFromCtor { get; }
-
-        public int IntProperty { get; set; }
-        public string StringProperty { get; set; }
-
-        public Task<int> Invoke(string stringParam, int intParam)
-        {
-            return Task.FromResult(76);
-        }
-    }
-
-    public class ClassWithInvokeAndDefaultCtor
-    {
-        public int IntProperty { get; set; }
-        public string StringProperty { get; set; }
-
-        public Task<int> Invoke(string stringParam, int intParam)
-        {
-            return Task.FromResult(66);
-        }
-
-        public Task<int> SomethingElse(int intParam, string stringParam)
-        {
-            return Task.FromResult(67);
-        }
-    }
-
-    public class ClassWithStaticsInvokeAndCtor
-    {
-        public ClassWithStaticsInvokeAndCtor(int intFromCtor, string stringFromCtor)
-        {
-            IntValueFromCtor = intFromCtor;
-            StringValueFromCtor = stringFromCtor;
-        }
-
-        public static int StaticIntProperty { get; set; } = 67;
-
-        public static string StaticStringProperty { get; set; }
-
-        public int IntValueFromCtor { get; }
-
-        public string StringValueFromCtor { get; }
-
-        public int IntProperty { get; set; }
-        public string StringProperty { get; set; }
-
-        public static Task<int> Invoke(string stringParam, int intParam)
-        {
-            return Task.FromResult(96);
-        }
-    }
-
-    public class ClassWithParameterlessInvokeAndDefaultCtor
-    {
-        public int IntProperty { get; set; }
-        public string StringProperty { get; set; }
-
-        public Task<int> Invoke()
-        {
-            return Task.FromResult(86);
-        }
     }
 
     public class ClassWithMultipleCtor

--- a/src/System.CommandLine/Binding/BindingContext.cs
+++ b/src/System.CommandLine/Binding/BindingContext.cs
@@ -53,10 +53,14 @@ namespace System.CommandLine.Binding
         public void AddModelBinder(ModelBinder binder) => 
             _modelBindersByValueDescriptor.Add(binder.ValueDescriptor.ValueType, binder);
 
-        public ModelBinder GetModelBinder(IValueDescriptor valueDescriptor) =>
-            _modelBindersByValueDescriptor.GetOrAdd(
-                valueDescriptor.ValueType, 
-                _ => new ModelBinder(valueDescriptor));
+        public ModelBinder GetModelBinder(IValueDescriptor valueDescriptor)
+        {
+            if (_modelBindersByValueDescriptor.TryGetValue(valueDescriptor.ValueType, out ModelBinder binder))
+            {
+                return binder;
+            }
+            return new ModelBinder(valueDescriptor);
+        }
 
         public void AddService(Type serviceType, Func<IServiceProvider, object> factory)
         {


### PR DESCRIPTION
Previously this was caching the first model binder that was resolved based on the parameter's type. This would cause the second parameter to get resolved with the first parameter's default value.

This change stop caching the generated model binders. 