### PR TITLE
C# 8 Nullable reference types

### DIFF
--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -56,6 +56,26 @@ namespace System.CommandLine.Tests
                     .Be("Argument \"the-arg\" does not have a default value");
         }
 
+        [Fact]
+        public void When_argument_type_is_set_to_null_then_it_throws()
+        {
+            var argument = new Argument();
+
+            argument.Invoking(a => a.ArgumentType = null)
+                    .Should()
+                    .Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void By_default_the_argument_type_is_void()
+        {
+            var argument = new Argument();
+
+            argument.ArgumentType
+                .Should()
+                .Be(typeof(void));
+        }
+
         public class CustomParsing
         {
             [Fact]

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -573,7 +573,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            var value = result.CommandResult.ValueForOption<object>("x");
+            var value = result.CommandResult.ValueForOption<int>("x");
 
             value.Should().Be(123);
         }

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -573,7 +573,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            var value = result.CommandResult.ValueForOption<int>("x");
+            var value = result.CommandResult.ValueForOption<object>("x");
 
             value.Should().Be(123);
         }

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine
         {
             if (!string.IsNullOrWhiteSpace(name))
             {
-                Name = name;
+                Name = name!;
             }
         }
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -11,17 +11,17 @@ namespace System.CommandLine
 {
     public class Argument : Symbol, IArgument
     {
-        private Func<ArgumentResult, object> _defaultValueFactory;
+        private Func<ArgumentResult, object>? _defaultValueFactory;
         private readonly List<string> _suggestions = new List<string>();
         private readonly List<ISuggestionSource> _suggestionSources = new List<ISuggestionSource>();
-        private IArgumentArity _arity;
-        private TryConvertArgument _convertArguments;
+        private IArgumentArity? _arity;
+        private TryConvertArgument? _convertArguments;
 
         public Argument()
         {
         }
 
-        public Argument(string name) 
+        public Argument(string? name) 
         {
             if (!string.IsNullOrWhiteSpace(name))
             {
@@ -29,7 +29,7 @@ namespace System.CommandLine
             }
         }
 
-        internal HashSet<string> AllowedValues { get; private set; }
+        internal HashSet<string>? AllowedValues { get; private set; }
 
         public IArgumentArity Arity
         {
@@ -52,7 +52,7 @@ namespace System.CommandLine
             set => _arity = value;
         }
 
-        internal TryConvertArgument ConvertArguments
+        internal TryConvertArgument? ConvertArguments
         {
             get
             {
@@ -108,7 +108,7 @@ namespace System.CommandLine
             set => _convertArguments = value;
         }
 
-        public Type ArgumentType { get; set; }
+        public Type? ArgumentType { get; set; }
 
         internal List<ValidateSymbol<ArgumentResult>> Validators { get; } = new List<ValidateSymbol<ArgumentResult>>();
 
@@ -193,7 +193,7 @@ namespace System.CommandLine
             AllowedValues.UnionWith(values);
         }
 
-        public override IEnumerable<string> GetSuggestions(string textToMatch = null)
+        public override IEnumerable<string> GetSuggestions(string? textToMatch = null)
         {
             var fixedSuggestions = _suggestions;
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -35,7 +35,7 @@ namespace System.CommandLine
         {
             get
             {
-                if (_arity == null)
+                if (_arity is null)
                 {
                     if (ArgumentType != null)
                     {
@@ -137,7 +137,7 @@ namespace System.CommandLine
 
         public void SetDefaultValueFactory(Func<object?> getDefaultValue)
         {
-            if (getDefaultValue == null)
+            if (getDefaultValue is null)
             {
                 throw new ArgumentNullException(nameof(getDefaultValue));
             }
@@ -156,7 +156,7 @@ namespace System.CommandLine
 
         public void AddSuggestions(IReadOnlyCollection<string> suggestions)
         {
-            if (suggestions == null)
+            if (suggestions is null)
             {
                 throw new ArgumentNullException(nameof(suggestions));
             }
@@ -166,7 +166,7 @@ namespace System.CommandLine
 
         public void AddSuggestionSource(ISuggestionSource suggest)
         {
-            if (suggest == null)
+            if (suggest is null)
             {
                 throw new ArgumentNullException(nameof(suggest));
             }
@@ -176,7 +176,7 @@ namespace System.CommandLine
 
         public void AddSuggestionSource(Suggest suggest)
         {
-            if (suggest == null)
+            if (suggest is null)
             {
                 throw new ArgumentNullException(nameof(suggest));
             }
@@ -186,7 +186,7 @@ namespace System.CommandLine
 
         internal void AddAllowedValues(IEnumerable<string> values)
         {
-            if (AllowedValues == null)
+            if (AllowedValues is null)
             {
                 AllowedValues = new HashSet<string>();
             }

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -16,6 +16,7 @@ namespace System.CommandLine
         private readonly List<ISuggestionSource> _suggestionSources = new List<ISuggestionSource>();
         private IArgumentArity? _arity;
         private TryConvertArgument? _convertArguments;
+        private Type _argumentType = typeof(void);
 
         public Argument()
         {
@@ -37,7 +38,7 @@ namespace System.CommandLine
             {
                 if (_arity is null)
                 {
-                    if (ArgumentType != null)
+                    if (ArgumentType != typeof(void))
                     {
                         return ArgumentArity.Default(ArgumentType, this, Parents.FirstOrDefault());
                     }
@@ -57,7 +58,7 @@ namespace System.CommandLine
             get
             {
                 if (_convertArguments == null &&
-                    ArgumentType != null)
+                    ArgumentType != typeof(void))
                 {
                     if (ArgumentType.CanBeBoundFromScalarValue())
                     {
@@ -108,8 +109,11 @@ namespace System.CommandLine
             set => _convertArguments = value;
         }
 
-        //TODO: What if null gets set?
-        public Type ArgumentType { get; set; } = typeof(void);
+        public Type ArgumentType
+        {
+            get => _argumentType;
+            set => _argumentType = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         internal List<ValidateSymbol<ArgumentResult>> Validators { get; } = new List<ValidateSymbol<ArgumentResult>>();
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine
 {
     public class Argument : Symbol, IArgument
     {
-        private Func<ArgumentResult, object>? _defaultValueFactory;
+        private Func<ArgumentResult, object?>? _defaultValueFactory;
         private readonly List<string> _suggestions = new List<string>();
         private readonly List<ISuggestionSource> _suggestionSources = new List<ISuggestionSource>();
         private IArgumentArity? _arity;
@@ -64,7 +64,7 @@ namespace System.CommandLine
                         if (Arity.MaximumNumberOfValues == 1 &&
                             ArgumentType == typeof(bool))
                         {
-                            _convertArguments = (ArgumentResult symbol, out object value) =>
+                            _convertArguments = (ArgumentResult symbol, out object? value) =>
                             {
                                 value = ArgumentConverter.ConvertObject(
                                     this,
@@ -114,12 +114,12 @@ namespace System.CommandLine
 
         public void AddValidator(ValidateSymbol<ArgumentResult> validator) => Validators.Add(validator);
 
-        public object GetDefaultValue()
+        public object? GetDefaultValue()
         {
             return GetDefaultValue(new ArgumentResult(this, null));
         }
 
-        internal object GetDefaultValue(ArgumentResult argumentResult)
+        internal object? GetDefaultValue(ArgumentResult argumentResult)
         {
             if (_defaultValueFactory is null)
             {
@@ -134,7 +134,7 @@ namespace System.CommandLine
             SetDefaultValueFactory(() => value);
         }
 
-        public void SetDefaultValueFactory(Func<object> getDefaultValue)
+        public void SetDefaultValueFactory(Func<object?> getDefaultValue)
         {
             if (getDefaultValue == null)
             {
@@ -144,7 +144,7 @@ namespace System.CommandLine
             SetDefaultValueFactory(_ => getDefaultValue());
         }
         
-        public void SetDefaultValueFactory(Func<ArgumentResult, object> getDefaultValue)
+        public void SetDefaultValueFactory(Func<ArgumentResult, object?> getDefaultValue)
         {
             _defaultValueFactory = getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue));
         }

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -108,7 +108,8 @@ namespace System.CommandLine
             set => _convertArguments = value;
         }
 
-        public Type? ArgumentType { get; set; }
+        //TODO: What if null gets set?
+        public Type ArgumentType { get; set; } = typeof(void);
 
         internal List<ValidateSymbol<ArgumentResult>> Validators { get; } = new List<ValidateSymbol<ArgumentResult>>();
 
@@ -193,7 +194,7 @@ namespace System.CommandLine
             AllowedValues.UnionWith(values);
         }
 
-        public override IEnumerable<string> GetSuggestions(string? textToMatch = null)
+        public override IEnumerable<string?> GetSuggestions(string? textToMatch = null)
         {
             var fixedSuggestions = _suggestions;
 

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -30,14 +30,14 @@ namespace System.CommandLine
         public int MaximumNumberOfValues { get; set; }
 
         internal static FailedArgumentConversionArityResult? Validate(
-            SymbolResult symbolResult,
+            SymbolResult? symbolResult,
             IArgument argument,
             int minimumNumberOfValues,
             int maximumNumberOfValues)
         {
             var argumentResult = symbolResult switch
             {
-                CommandResult commandResult => commandResult.Root.FindResultFor(argument),
+                CommandResult commandResult => commandResult.Root?.FindResultFor(argument),
                 OptionResult optionResult => optionResult.Children.ResultFor(argument),
                 _ => symbolResult
             };
@@ -46,7 +46,7 @@ namespace System.CommandLine
 
             if (tokenCount < minimumNumberOfValues)
             {
-                if (symbolResult.UseDefaultValueFor(argument))
+                if (symbolResult!.UseDefaultValueFor(argument))
                 {
                     return null;
                 }
@@ -96,6 +96,11 @@ namespace System.CommandLine
                  type.IsNullable()))
             {
                 return ZeroOrOne;
+            }
+
+            if (type == typeof(void))
+            {
+                return Zero;
             }
 
             return ExactlyOne;

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -60,7 +60,7 @@ namespace System.CommandLine
             {
                 return new TooManyArgumentsConversionResult(
                     argument,
-                    symbolResult.ValidationMessages.ExpectsOneArgument(symbolResult));
+                    symbolResult!.ValidationMessages.ExpectsOneArgument(symbolResult));
             }
 
             return null;

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -29,7 +29,7 @@ namespace System.CommandLine
 
         public int MaximumNumberOfValues { get; set; }
 
-        internal static FailedArgumentConversionArityResult Validate(
+        internal static FailedArgumentConversionArityResult? Validate(
             SymbolResult symbolResult,
             IArgument argument,
             int minimumNumberOfValues,

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine
             Func<T> getDefaultValue, 
             string description = null) : this(name)
         {
-            if (getDefaultValue == null)
+            if (getDefaultValue is null)
             {
                 throw new ArgumentNullException(nameof(getDefaultValue));
             }
@@ -37,7 +37,7 @@ namespace System.CommandLine
 
         public Argument(Func<T> getDefaultValue) : this()
         {
-            if (getDefaultValue == null)
+            if (getDefaultValue is null)
             {
                 throw new ArgumentNullException(nameof(getDefaultValue));
             }
@@ -46,8 +46,8 @@ namespace System.CommandLine
         }
 
         public Argument(
-            string name,
-            ParseArgument<T> parse,
+            string? name,
+            ParseArgument<T> parse, 
             bool isDefault = false) : this()
         {
             if (!string.IsNullOrWhiteSpace(name))
@@ -55,7 +55,7 @@ namespace System.CommandLine
                 Name = name;
             }
 
-            if (parse == null)
+            if (parse is null)
             {
                 throw new ArgumentNullException(nameof(parse));
             }
@@ -65,7 +65,7 @@ namespace System.CommandLine
                 SetDefaultValueFactory(argumentResult => parse(argumentResult));
             }
 
-            ConvertArguments = (ArgumentResult argumentResult, out object value) =>
+            ConvertArguments = (ArgumentResult argumentResult, out object? value) =>
             {
                 var result = parse(argumentResult);
 

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine
 
         public Argument(
             string name, 
-            string description = null) : base(name)
+            string? description = null) : base(name)
         {
             ArgumentType = typeof(T);
             Description = description;
@@ -23,7 +23,7 @@ namespace System.CommandLine
         public Argument(
             string name, 
             Func<T> getDefaultValue, 
-            string description = null) : this(name)
+            string? description = null) : this(name)
         {
             if (getDefaultValue is null)
             {

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -76,7 +76,7 @@ namespace System.CommandLine
                 }
                 else
                 {
-                    value = default(T);
+                    value = default(T)!;
                     return false;
                 }
             };

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -52,7 +52,7 @@ namespace System.CommandLine
         {
             if (!string.IsNullOrWhiteSpace(name))
             {
-                Name = name;
+                Name = name!;
             }
 
             if (parse is null)

--- a/src/System.CommandLine/Binding/ArgumentConversionResult.cs
+++ b/src/System.CommandLine/Binding/ArgumentConversionResult.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Binding
 
         public IArgument Argument { get; }
 
-        internal string ErrorMessage { get; set; }
+        internal string? ErrorMessage { get; set; }
 
         internal static FailedArgumentConversionResult Failure(IArgument argument, string error) => new FailedArgumentConversionResult(argument, error);
 

--- a/src/System.CommandLine/Binding/ArgumentConversionResult.cs
+++ b/src/System.CommandLine/Binding/ArgumentConversionResult.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine.Binding
 
         internal static FailedArgumentConversionResult Failure(IArgument argument, string error) => new FailedArgumentConversionResult(argument, error);
 
-        public static SuccessfulArgumentConversionResult Success(IArgument argument, object value) => new SuccessfulArgumentConversionResult(argument, value);
+        public static SuccessfulArgumentConversionResult Success(IArgument argument, object? value) => new SuccessfulArgumentConversionResult(argument, value);
 
         internal static NoArgumentConversionResult None(IArgument argument) => new NoArgumentConversionResult(argument);
     }

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -184,7 +184,7 @@ namespace System.CommandLine.Binding
 
         private static FailedArgumentConversionResult Failure(
             IArgument argument,
-            Type type, 
+            Type type,
             string value)
         {
             return new FailedArgumentTypeConversionResult(argument, type, value);
@@ -209,7 +209,7 @@ namespace System.CommandLine.Binding
                 return true;
             }
 
-            if (TryFindConstructorWithSingleParameterOfType(type, typeof(string), out _) )
+            if (TryFindConstructorWithSingleParameterOfType(type, typeof(string), out _))
             {
                 return true;
             }
@@ -285,7 +285,7 @@ namespace System.CommandLine.Binding
         internal static object? GetValueOrDefault(this ArgumentConversionResult result) =>
             result.GetValueOrDefault<object?>();
 
-        [return:MaybeNull]
+        [return: MaybeNull]
         internal static T GetValueOrDefault<T>(this ArgumentConversionResult result)
         {
             switch (result)

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -108,12 +108,12 @@ namespace System.CommandLine.Binding
             Type type,
             IReadOnlyCollection<string> arguments)
         {
-            if (type == null)
+            if (type is null)
             {
                 throw new ArgumentNullException(nameof(type));
             }
 
-            if (arguments == null)
+            if (arguments is null)
             {
                 throw new ArgumentNullException(nameof(arguments));
             }
@@ -154,7 +154,7 @@ namespace System.CommandLine.Binding
                       .GetInterfaces()
                       .FirstOrDefault(IsEnumerable);
 
-            if (enumerableInterface == null)
+            if (enumerableInterface is null)
             {
                 return null;
             }
@@ -250,7 +250,7 @@ namespace System.CommandLine.Binding
             SymbolResult symbolResult,
             Type type)
         {
-            if (conversionResult == null)
+            if (conversionResult is null)
             {
                 throw new ArgumentNullException(nameof(conversionResult));
             }

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.CommandLine.Parsing;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -89,9 +90,9 @@ namespace System.CommandLine.Binding
             }
 
             if (type.TryFindConstructorWithSingleParameterOfType(
-                typeof(string), out (ConstructorInfo? ctor, ParameterDescriptor? parameterDescriptor) tuple))
+                typeof(string), out (ConstructorInfo ctor, ParameterDescriptor parameterDescriptor)? tuple))
             {
-                var instance = tuple.ctor.Invoke(new object[]
+                var instance = tuple.Value.ctor.Invoke(new object[]
                 {
                     value
                 });
@@ -224,7 +225,7 @@ namespace System.CommandLine.Binding
         private static bool TryFindConstructorWithSingleParameterOfType(
             this Type type,
             Type parameterType,
-            out (ConstructorInfo? ctor, ParameterDescriptor? parameterDescriptor) info)
+            [NotNullWhen(true)]out (ConstructorInfo ctor, ParameterDescriptor parameterDescriptor)? info)
         {
             var (x, y) = type.GetConstructors()
                              .Select(c => (ctor: c, parameters: c.GetParameters()))
@@ -239,7 +240,7 @@ namespace System.CommandLine.Binding
             }
             else
             {
-                info = (null, null);
+                info = null;
                 return false;
             }
         }
@@ -281,9 +282,10 @@ namespace System.CommandLine.Binding
             }
         }
 
-        internal static object GetValueOrDefault(this ArgumentConversionResult result) =>
-            result.GetValueOrDefault<object>();
+        internal static object? GetValueOrDefault(this ArgumentConversionResult result) =>
+            result.GetValueOrDefault<object?>();
 
+        [return:MaybeNull]
         internal static T GetValueOrDefault<T>(this ArgumentConversionResult result)
         {
             switch (result)

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -90,9 +90,9 @@ namespace System.CommandLine.Binding
             }
 
             if (type.TryFindConstructorWithSingleParameterOfType(
-                typeof(string), out (ConstructorInfo ctor, ParameterDescriptor parameterDescriptor)? tuple))
+                typeof(string), out ConstructorInfo? ctor))
             {
-                var instance = tuple.Value.ctor.Invoke(new object[]
+                var instance = ctor.Invoke(new object[]
                 {
                     value
                 });
@@ -225,7 +225,7 @@ namespace System.CommandLine.Binding
         private static bool TryFindConstructorWithSingleParameterOfType(
             this Type type,
             Type parameterType,
-            [NotNullWhen(true)] out (ConstructorInfo ctor, ParameterDescriptor parameterDescriptor)? info)
+            [NotNullWhen(true)] out ConstructorInfo? ctor)
         {
             var (x, y) = type.GetConstructors()
                              .Select(c => (ctor: c, parameters: c.GetParameters()))
@@ -235,12 +235,12 @@ namespace System.CommandLine.Binding
 
             if (x != null)
             {
-                info = (x, new ParameterDescriptor(y[0], new ConstructorDescriptor(x, ModelDescriptor.FromType(type))));
+                ctor = x;
                 return true;
             }
             else
             {
-                info = null;
+                ctor = null;
                 return false;
             }
         }

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -225,7 +225,7 @@ namespace System.CommandLine.Binding
         private static bool TryFindConstructorWithSingleParameterOfType(
             this Type type,
             Type parameterType,
-            [NotNullWhen(true)]out (ConstructorInfo ctor, ParameterDescriptor parameterDescriptor)? info)
+            [NotNullWhen(true)] out (ConstructorInfo ctor, ParameterDescriptor parameterDescriptor)? info)
         {
             var (x, y) = type.GetConstructors()
                              .Select(c => (ctor: c, parameters: c.GetParameters()))
@@ -291,13 +291,13 @@ namespace System.CommandLine.Binding
             switch (result)
             {
                 case SuccessfulArgumentConversionResult successful:
-                    return (T)successful.Value;
+                    return (T)successful.Value!;
                 case FailedArgumentConversionResult failed:
                     throw new InvalidOperationException(failed.ErrorMessage);
                 case NoArgumentConversionResult _:
-                    return default;
+                    return default!;
                 default:
-                    return default;
+                    return default!;
             }
         }
     }

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -36,7 +36,7 @@ namespace System.CommandLine.Binding
         internal static ArgumentConversionResult ConvertObject(
             IArgument argument,
             Type type,
-            object value)
+            object? value)
         {
             switch (value)
             {
@@ -59,7 +59,7 @@ namespace System.CommandLine.Binding
 
         private static ArgumentConversionResult ConvertString(
             IArgument argument,
-            Type type,
+            Type? type,
             string value)
         {
             type ??= typeof(string);
@@ -89,7 +89,7 @@ namespace System.CommandLine.Binding
             }
 
             if (type.TryFindConstructorWithSingleParameterOfType(
-                typeof(string), out (ConstructorInfo ctor, ParameterDescriptor parameterDescriptor) tuple))
+                typeof(string), out (ConstructorInfo? ctor, ParameterDescriptor? parameterDescriptor) tuple))
             {
                 var instance = tuple.ctor.Invoke(new object[]
                 {
@@ -139,7 +139,7 @@ namespace System.CommandLine.Binding
             return Success(argument, value);
         }
 
-        private static Type GetItemTypeIfEnumerable(Type type)
+        private static Type? GetItemTypeIfEnumerable(Type type)
         {
             if (type.IsArray)
             {
@@ -224,7 +224,7 @@ namespace System.CommandLine.Binding
         private static bool TryFindConstructorWithSingleParameterOfType(
             this Type type,
             Type parameterType,
-            out (ConstructorInfo ctor, ParameterDescriptor parameterDescriptor) info)
+            out (ConstructorInfo? ctor, ParameterDescriptor? parameterDescriptor) info)
         {
             var (x, y) = type.GetConstructors()
                              .Select(c => (ctor: c, parameters: c.GetParameters()))

--- a/src/System.CommandLine/Binding/Binder.cs
+++ b/src/System.CommandLine/Binding/Binder.cs
@@ -23,7 +23,7 @@ namespace System.CommandLine.Binding
                    t.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
 
-        public static object GetDefaultValueForType(this Type type)
+        public static object? GetDefaultValueForType(this Type type)
         {
             return type.IsValueType ? Activator.CreateInstance(type) : null;
         }

--- a/src/System.CommandLine/Binding/BindingContext.cs
+++ b/src/System.CommandLine/Binding/BindingContext.cs
@@ -98,7 +98,7 @@ namespace System.CommandLine.Binding
         {
             if (valueSource.TryGetValue(valueDescriptor, this, out var value))
             {
-                if (value == null || valueDescriptor.ValueType.IsInstanceOfType(value))
+                if (value is null || valueDescriptor.ValueType.IsInstanceOfType(value))
                 {
                     boundValue = new BoundValue(value, valueDescriptor, valueSource);
                     return true;

--- a/src/System.CommandLine/Binding/BindingContext.cs
+++ b/src/System.CommandLine/Binding/BindingContext.cs
@@ -88,7 +88,7 @@ namespace System.CommandLine.Binding
                 return true;
             }
 
-            valueSource = default;
+            valueSource = default!;
             return false;
         }
 

--- a/src/System.CommandLine/Binding/BindingContext.cs
+++ b/src/System.CommandLine/Binding/BindingContext.cs
@@ -70,7 +70,7 @@ namespace System.CommandLine.Binding
         
         public void AddService<T>(Func<IServiceProvider, T> factory)
         {
-            if (factory == null)
+            if (factory is null)
             {
                 throw new ArgumentNullException(nameof(factory));
             }

--- a/src/System.CommandLine/Binding/BindingContext.cs
+++ b/src/System.CommandLine/Binding/BindingContext.cs
@@ -6,6 +6,7 @@ using System.CommandLine.Help;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 #nullable enable
@@ -79,7 +80,7 @@ namespace System.CommandLine.Binding
 
         internal bool TryGetValueSource(
             IValueDescriptor valueDescriptor,
-            out IValueSource? valueSource)
+            [MaybeNullWhen(false)] out IValueSource valueSource)
         {
             if (ServiceProvider.AvailableServiceTypes.Contains(valueDescriptor.ValueType))
             {

--- a/src/System.CommandLine/Binding/BoundValue.cs
+++ b/src/System.CommandLine/Binding/BoundValue.cs
@@ -6,7 +6,7 @@ namespace System.CommandLine.Binding
     public class BoundValue
     {
         internal BoundValue(
-            object value,
+            object? value,
             IValueDescriptor valueDescriptor,
             IValueSource valueSource)
         {
@@ -25,7 +25,7 @@ namespace System.CommandLine.Binding
 
         public IValueSource ValueSource { get; }
 
-        public object Value { get; }
+        public object? Value { get; }
 
         public override string ToString() => $"{ValueDescriptor}: {Value}";
 

--- a/src/System.CommandLine/Binding/ConstructorDescriptor.cs
+++ b/src/System.CommandLine/Binding/ConstructorDescriptor.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Binding
 {
     public class ConstructorDescriptor : IMethodDescriptor
     {
-        private List<ParameterDescriptor> _parameterDescriptors;
+        private List<ParameterDescriptor>? _parameterDescriptors;
 
         private readonly ConstructorInfo _constructorInfo;
 
@@ -24,9 +24,8 @@ namespace System.CommandLine.Binding
         public ModelDescriptor Parent { get; }
 
         public IReadOnlyList<ParameterDescriptor> ParameterDescriptors =>
-            _parameterDescriptors
-            ??
-            (_parameterDescriptors = _constructorInfo.GetParameters().Select(p => new ParameterDescriptor(p, this)).ToList());
+            _parameterDescriptors ??=
+                _constructorInfo.GetParameters().Select(p => new ParameterDescriptor(p, this)).ToList();
 
         internal object Invoke(IReadOnlyCollection<object?> parameters)
         {

--- a/src/System.CommandLine/Binding/ConstructorDescriptor.cs
+++ b/src/System.CommandLine/Binding/ConstructorDescriptor.cs
@@ -28,7 +28,7 @@ namespace System.CommandLine.Binding
             ??
             (_parameterDescriptors = _constructorInfo.GetParameters().Select(p => new ParameterDescriptor(p, this)).ToList());
 
-        internal object Invoke(IReadOnlyCollection<object> parameters)
+        internal object Invoke(IReadOnlyCollection<object?> parameters)
         {
             return _constructorInfo.Invoke(parameters.ToArray());
         }

--- a/src/System.CommandLine/Binding/DelegateHandlerDescriptor.cs
+++ b/src/System.CommandLine/Binding/DelegateHandlerDescriptor.cs
@@ -23,7 +23,7 @@ namespace System.CommandLine.Binding
                 ParameterDescriptors);
         }
 
-        public override ModelDescriptor Parent => null;
+        public override ModelDescriptor? Parent => null;
 
         protected override IEnumerable<ParameterDescriptor> InitializeParameterDescriptors()
         {

--- a/src/System.CommandLine/Binding/DelegateValueSource.cs
+++ b/src/System.CommandLine/Binding/DelegateValueSource.cs
@@ -5,14 +5,14 @@ namespace System.CommandLine.Binding
 {
     internal class DelegateValueSource : IValueSource
     {
-        private readonly Func<BindingContext, object> _getValue;
+        private readonly Func<BindingContext?, object?> _getValue;
 
-        public DelegateValueSource(Func<BindingContext, object> getValue)
+        public DelegateValueSource(Func<BindingContext?, object?> getValue)
         {
             _getValue = getValue;
         }
 
-        public bool TryGetValue(IValueDescriptor valueDescriptor, BindingContext bindingContext, out object boundValue)
+        public bool TryGetValue(IValueDescriptor valueDescriptor, BindingContext? bindingContext, out object? boundValue)
         {
             boundValue = _getValue(bindingContext);
 

--- a/src/System.CommandLine/Binding/ExpressionExtensions.cs
+++ b/src/System.CommandLine/Binding/ExpressionExtensions.cs
@@ -7,30 +7,26 @@ namespace System.CommandLine.Binding
     {
         internal static (Type memberType, string memberName) MemberTypeAndName<T, TValue>(this Expression<Func<T, TValue>> expression)
         {
-            if (expression == null)
+            if (expression is null)
             {
                 throw new ArgumentNullException(nameof(expression));
             }
 
             if (expression.Body is MemberExpression memberExpression)
             {
-                return TypeAndName();
+                return TypeAndName(memberExpression);
             }
 
             // when the return type of the expression is a value type, it contains a call to Convert, resulting in boxing, so we get a UnaryExpression instead
-            if (expression.Body is UnaryExpression unaryExpression)
+            if (expression.Body is UnaryExpression unaryExpression &&
+                unaryExpression.Operand is MemberExpression operandMemberExpression)
             {
-                memberExpression = unaryExpression.Operand as MemberExpression;
-
-                if (memberExpression != null)
-                {
-                    return TypeAndName();
-                }
+                return TypeAndName(operandMemberExpression);
             }
 
             throw new ArgumentException($"Expression {expression} does not specify a member.");
 
-            (Type memberType, string memberName) TypeAndName()
+            static (Type memberType, string memberName) TypeAndName(MemberExpression memberExpression)
             {
                 return (memberExpression.Member.ReturnType(), memberExpression.Member.Name);
             }

--- a/src/System.CommandLine/Binding/HandlerDescriptor.cs
+++ b/src/System.CommandLine/Binding/HandlerDescriptor.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine.Binding
 
         public abstract ICommandHandler GetCommandHandler();
 
-        public abstract ModelDescriptor Parent { get; }
+        public abstract ModelDescriptor? Parent { get; }
 
         public IReadOnlyList<ParameterDescriptor> ParameterDescriptors =>
             _parameterDescriptors ??= new List<ParameterDescriptor>(InitializeParameterDescriptors());

--- a/src/System.CommandLine/Binding/HandlerDescriptor.cs
+++ b/src/System.CommandLine/Binding/HandlerDescriptor.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Binding
 {
     public abstract class HandlerDescriptor : IMethodDescriptor
     {
-        private List<ParameterDescriptor> _parameterDescriptors;
+        private List<ParameterDescriptor>? _parameterDescriptors;
 
         public abstract ICommandHandler GetCommandHandler();
 
@@ -24,7 +24,7 @@ namespace System.CommandLine.Binding
         public override string ToString() =>
             $"{Parent} ({string.Join(", ", ParameterDescriptors)})";
 
-        public static HandlerDescriptor FromMethodInfo(MethodInfo methodInfo, object target = null) =>
+        public static HandlerDescriptor FromMethodInfo(MethodInfo methodInfo, object? target = null) =>
             new MethodInfoHandlerDescriptor(methodInfo, target);
 
         public static HandlerDescriptor FromDelegate(Delegate @delegate) =>

--- a/src/System.CommandLine/Binding/IMethodDescriptor.cs
+++ b/src/System.CommandLine/Binding/IMethodDescriptor.cs
@@ -7,7 +7,7 @@ namespace System.CommandLine.Binding
 {
     public interface IMethodDescriptor
     {
-        ModelDescriptor Parent { get; }
+        ModelDescriptor? Parent { get; }
 
         IReadOnlyList<ParameterDescriptor> ParameterDescriptors { get; }
     }

--- a/src/System.CommandLine/Binding/IValueDescriptor.cs
+++ b/src/System.CommandLine/Binding/IValueDescriptor.cs
@@ -5,12 +5,12 @@ namespace System.CommandLine.Binding
 {
     public interface IValueDescriptor
     {
-        string ValueName { get; }
+        string? ValueName { get; }
 
         Type ValueType { get; }
 
         bool HasDefaultValue { get; }
 
-        object GetDefaultValue();
+        object? GetDefaultValue();
     }
 }

--- a/src/System.CommandLine/Binding/IValueSource.cs
+++ b/src/System.CommandLine/Binding/IValueSource.cs
@@ -8,6 +8,6 @@ namespace System.CommandLine.Binding
         bool TryGetValue(
             IValueDescriptor valueDescriptor,
             BindingContext? bindingContext,
-            out object boundValue);
+            out object? boundValue);
     }
 }

--- a/src/System.CommandLine/Binding/IValueSource.cs
+++ b/src/System.CommandLine/Binding/IValueSource.cs
@@ -7,7 +7,7 @@ namespace System.CommandLine.Binding
     {
         bool TryGetValue(
             IValueDescriptor valueDescriptor,
-            BindingContext bindingContext,
+            BindingContext? bindingContext,
             out object boundValue);
     }
 }

--- a/src/System.CommandLine/Binding/MethodInfoHandlerDescriptor.cs
+++ b/src/System.CommandLine/Binding/MethodInfoHandlerDescriptor.cs
@@ -11,11 +11,11 @@ namespace System.CommandLine.Binding
     internal class MethodInfoHandlerDescriptor : HandlerDescriptor
     {
         private readonly MethodInfo _handlerMethodInfo;
-        private readonly object _invocationTarget;
+        private readonly object? _invocationTarget;
 
         public MethodInfoHandlerDescriptor(
             MethodInfo handlerMethodInfo,
-            object target = null)
+            object? target = null)
         {
             _handlerMethodInfo = handlerMethodInfo ??
                                  throw new ArgumentNullException(nameof(handlerMethodInfo));

--- a/src/System.CommandLine/Binding/MethodInfoHandlerDescriptor.cs
+++ b/src/System.CommandLine/Binding/MethodInfoHandlerDescriptor.cs
@@ -24,7 +24,7 @@ namespace System.CommandLine.Binding
 
         public override ICommandHandler GetCommandHandler()
         {
-            if (_invocationTarget == null)
+            if (_invocationTarget is null)
             {
                 return new ModelBindingCommandHandler(
                     _handlerMethodInfo,

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -102,7 +102,7 @@ namespace System.CommandLine.Binding
                 new SpecificSymbolValueSource(valueDescriptor);
         }
 
-        public object CreateInstance(BindingContext context)
+        public object? CreateInstance(BindingContext context)
         {
             var values = GetValues(
                 // No binding sources, as were are attempting to bind a value
@@ -187,7 +187,7 @@ namespace System.CommandLine.Binding
         }
 
         private IReadOnlyList<BoundValue> GetValues(
-            IDictionary<IValueDescriptor, IValueSource> bindingSources,
+            IDictionary<IValueDescriptor, IValueSource>? bindingSources,
             BindingContext bindingContext,
             IReadOnlyList<IValueDescriptor> valueDescriptors,
             bool includeMissingValues)
@@ -200,7 +200,7 @@ namespace System.CommandLine.Binding
 
                 var valueSource = GetValueSource(bindingSources, bindingContext, valueDescriptor);
 
-                BoundValue boundValue;
+                BoundValue? boundValue;
                 if (valueSource is null)
                 {
                     // If there is no source to bind from, no value can be bound.
@@ -239,8 +239,8 @@ namespace System.CommandLine.Binding
             return values;
         }
 
-        private IValueSource GetValueSource(
-            IDictionary<IValueDescriptor, IValueSource> bindingSources,
+        private IValueSource? GetValueSource(
+            IDictionary<IValueDescriptor, IValueSource>? bindingSources,
             BindingContext bindingContext,
             IValueDescriptor valueDescriptor)
         {
@@ -269,7 +269,7 @@ namespace System.CommandLine.Binding
             $"{ModelDescriptor.ModelType.Name}";
 
         private bool ShouldPassNullToConstructor(ModelDescriptor modelDescriptor,
-            ConstructorDescriptor ctor = null)
+            ConstructorDescriptor? ctor = null)
         {
             if (!(ctor is null))
             {
@@ -288,11 +288,11 @@ namespace System.CommandLine.Binding
                 ValueType = modelType;
             }
 
-            public string ValueName => null;
+            public string? ValueName => null;
 
             public bool HasDefaultValue => false;
 
-            public object GetDefaultValue() => null;
+            public object? GetDefaultValue() => null;
 
             public override string ToString() => $"{ValueType}";
         }

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -128,7 +129,7 @@ namespace System.CommandLine.Binding
 
         private bool TryDefaultConstructorAndPropertiesStrategy(
             BindingContext context,
-            out object instance)
+            [NotNullWhen(true)]out object? instance)
         {
             var constructorDescriptors =
                 ModelDescriptor
@@ -148,7 +149,7 @@ namespace System.CommandLine.Binding
                     continue;
                 }
 
-                // Found invocable constructor, invoke and return
+                // Found invokable constructor, invoke and return
                 var values = boundConstructorArguments.Select(v => v.Value).ToArray();
 
                 try

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -129,7 +129,7 @@ namespace System.CommandLine.Binding
 
         private bool TryDefaultConstructorAndPropertiesStrategy(
             BindingContext context,
-            [NotNullWhen(true)]out object? instance)
+            [NotNullWhen(true)] out object? instance)
         {
             var constructorDescriptors =
                 ModelDescriptor

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -251,7 +251,7 @@ namespace System.CommandLine.Binding
                 return valueSource;
             }
 
-            if (bindingContext.TryGetValueSource(valueDescriptor, out valueSource))
+            if (bindingContext.TryGetValueSource(valueDescriptor, out valueSource!))
             {
                 return valueSource;
             }

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Binding
     {
         public ModelBinder(Type modelType) : this(new AnonymousValueDescriptor(modelType))
         {
-            if (modelType == null)
+            if (modelType is null)
             {
                 throw new ArgumentNullException(nameof(modelType));
             }
@@ -215,7 +215,7 @@ namespace System.CommandLine.Binding
                     boundValue = BoundValue.DefaultForValueDescriptor(valueDescriptor);
                 }
 
-                if (boundValue == null)
+                if (boundValue is null)
                 {
                     if (includeMissingValues)
                     {

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -246,12 +246,12 @@ namespace System.CommandLine.Binding
             IValueDescriptor valueDescriptor)
         {
             if (!(bindingSources is null) &&
-                bindingSources.TryGetValue(valueDescriptor, out var valueSource))
+                bindingSources.TryGetValue(valueDescriptor, out IValueSource? valueSource))
             {
                 return valueSource;
             }
 
-            if (bindingContext.TryGetValueSource(valueDescriptor, out valueSource!))
+            if (bindingContext.TryGetValueSource(valueDescriptor, out valueSource))
             {
                 return valueSource;
             }

--- a/src/System.CommandLine/Binding/ModelBinder{T}.cs
+++ b/src/System.CommandLine/Binding/ModelBinder{T}.cs
@@ -24,7 +24,7 @@ namespace System.CommandLine.Binding
 
         public void BindMemberFromValue<TValue>(
             Expression<Func<TModel, TValue>> property,
-            Func<BindingContext, TValue> getValue)
+            Func<BindingContext?, TValue> getValue)
         {
             var (propertyType, propertyName) = property.MemberTypeAndName();
             var propertyDescriptor = FindModelPropertyDescriptor(

--- a/src/System.CommandLine/Binding/ModelDescriptor.cs
+++ b/src/System.CommandLine/Binding/ModelDescriptor.cs
@@ -17,8 +17,8 @@ namespace System.CommandLine.Binding
 
         private static readonly ConcurrentDictionary<Type, ModelDescriptor> _modelDescriptors = new ConcurrentDictionary<Type, ModelDescriptor>();
 
-        private List<PropertyDescriptor> _propertyDescriptors;
-        private List<ConstructorDescriptor> _constructorDescriptors;
+        private List<PropertyDescriptor>? _propertyDescriptors;
+        private List<ConstructorDescriptor>? _constructorDescriptors;
 
         protected ModelDescriptor(Type modelType)
         {

--- a/src/System.CommandLine/Binding/ParameterDescriptor.cs
+++ b/src/System.CommandLine/Binding/ParameterDescriptor.cs
@@ -30,7 +30,7 @@ namespace System.CommandLine.Binding
         {
             get
             {
-                if (_allowsNull == null)
+                if (_allowsNull is null)
                 {
                     if (_parameterInfo.ParameterType.IsNullable())
                     {
@@ -38,7 +38,7 @@ namespace System.CommandLine.Binding
                     }
 
                     if (_parameterInfo.HasDefaultValue &&
-                        _parameterInfo.DefaultValue == null)
+                        _parameterInfo.DefaultValue is null)
                     {
                         _allowsNull = true;
                     }

--- a/src/System.CommandLine/Binding/ParameterDescriptor.cs
+++ b/src/System.CommandLine/Binding/ParameterDescriptor.cs
@@ -48,7 +48,7 @@ namespace System.CommandLine.Binding
             }
         }
 
-        public object GetDefaultValue() =>
+        public object? GetDefaultValue() =>
             _parameterInfo.DefaultValue is DBNull
                 ? ValueType.GetDefaultValueForType()
                 : _parameterInfo.DefaultValue;

--- a/src/System.CommandLine/Binding/ParseResultMatchingValueSource.cs
+++ b/src/System.CommandLine/Binding/ParseResultMatchingValueSource.cs
@@ -9,12 +9,12 @@ namespace System.CommandLine.Binding
     {
         public bool TryGetValue(
             IValueDescriptor valueDescriptor,
-            BindingContext bindingContext,
-            out object boundValue)
+            BindingContext? bindingContext,
+            out object? boundValue)
         {
             if (!string.IsNullOrEmpty(valueDescriptor.ValueName))
             {
-                var commandResult = bindingContext.ParseResult.CommandResult;
+                CommandResult? commandResult = bindingContext?.ParseResult.CommandResult;
 
                 while (commandResult != null)
                 {

--- a/src/System.CommandLine/Binding/PropertyDescriptor.cs
+++ b/src/System.CommandLine/Binding/PropertyDescriptor.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine.Binding
             PropertyInfo propertyInfo,
             ModelDescriptor parent)
         {
-            Parent = parent;
+            Parent = parent ?? throw new ArgumentNullException(nameof(parent));
             _propertyInfo = propertyInfo;
         }
 
@@ -21,9 +21,7 @@ namespace System.CommandLine.Binding
 
         public ModelDescriptor Parent { get; }
 
-        internal string Path => Parent != null
-                                    ? Parent + "." + ValueName
-                                    : ValueName;
+        internal string Path => Parent + "." + ValueName;
 
         public Type ValueType => _propertyInfo.PropertyType;
 

--- a/src/System.CommandLine/Binding/PropertyDescriptor.cs
+++ b/src/System.CommandLine/Binding/PropertyDescriptor.cs
@@ -29,7 +29,7 @@ namespace System.CommandLine.Binding
 
         public bool HasDefaultValue => false;
 
-        public object GetDefaultValue() => ValueType.GetDefaultValueForType();
+        public object? GetDefaultValue() => ValueType.GetDefaultValueForType();
 
         public void SetValue(object? instance, object? value)
         {

--- a/src/System.CommandLine/Binding/PropertyDescriptor.cs
+++ b/src/System.CommandLine/Binding/PropertyDescriptor.cs
@@ -31,7 +31,7 @@ namespace System.CommandLine.Binding
 
         public object GetDefaultValue() => ValueType.GetDefaultValueForType();
 
-        public void SetValue(object instance, object value)
+        public void SetValue(object? instance, object? value)
         {
             _propertyInfo.SetValue(instance, value);
         }

--- a/src/System.CommandLine/Binding/ServiceProviderValueSource.cs
+++ b/src/System.CommandLine/Binding/ServiceProviderValueSource.cs
@@ -7,10 +7,10 @@ namespace System.CommandLine.Binding
     {
         public bool TryGetValue(
             IValueDescriptor valueDescriptor,
-            BindingContext bindingContext,
-            out object boundValue)
+            BindingContext? bindingContext,
+            out object? boundValue)
         {
-            boundValue = bindingContext.ServiceProvider.GetService(valueDescriptor.ValueType);
+            boundValue = bindingContext?.ServiceProvider.GetService(valueDescriptor.ValueType);
             return true;
         }
     }

--- a/src/System.CommandLine/Binding/SpecificSymbolValueSource.cs
+++ b/src/System.CommandLine/Binding/SpecificSymbolValueSource.cs
@@ -16,14 +16,14 @@ namespace System.CommandLine.Binding
         public IValueDescriptor ValueDescriptor { get; }
 
         public bool TryGetValue(IValueDescriptor valueDescriptor,
-            BindingContext bindingContext,
-            out object boundValue)
+            BindingContext? bindingContext,
+            out object? boundValue)
         {
             var specificDescriptor = ValueDescriptor;
             switch (specificDescriptor)
             {
                 case IOption option:
-                    var optionResult = bindingContext.ParseResult.FindResultFor(option);
+                    var optionResult = bindingContext?.ParseResult.FindResultFor(option);
                     if (!(optionResult is null))
                     {
                         boundValue = optionResult.GetValueOrDefault();
@@ -31,8 +31,8 @@ namespace System.CommandLine.Binding
                     }
                     break;
                 case IArgument argument:
-                    var argumentResult = bindingContext.ParseResult.FindResultFor(argument);
-                    if (!(argument is null))
+                    var argumentResult = bindingContext?.ParseResult.FindResultFor(argument);
+                    if (!(argumentResult is null))
                     {
                         boundValue = argumentResult.GetValueOrDefault();
                         return true;

--- a/src/System.CommandLine/Binding/SuccessfulArgumentConversionResult.cs
+++ b/src/System.CommandLine/Binding/SuccessfulArgumentConversionResult.cs
@@ -5,11 +5,11 @@ namespace System.CommandLine.Binding
 {
     internal class SuccessfulArgumentConversionResult : ArgumentConversionResult
     {
-        internal SuccessfulArgumentConversionResult(IArgument argument, object value) : base(argument)
+        internal SuccessfulArgumentConversionResult(IArgument argument, object? value) : base(argument)
         {
             Value = value;
         }
 
-        public object Value { get; }
+        public object? Value { get; }
     }
 }

--- a/src/System.CommandLine/Binding/TryConvertArgument.cs
+++ b/src/System.CommandLine/Binding/TryConvertArgument.cs
@@ -7,5 +7,5 @@ namespace System.CommandLine.Binding
 {
     internal delegate bool TryConvertArgument(
         ArgumentResult argumentResult,
-        out object value);
+        out object? value);
 }

--- a/src/System.CommandLine/Binding/TypeDefaultValueSource.cs
+++ b/src/System.CommandLine/Binding/TypeDefaultValueSource.cs
@@ -5,7 +5,7 @@ namespace System.CommandLine.Binding
 {
     internal class TypeDefaultValueSource : IValueSource
     {
-        public static IValueSource Instance = new TypeDefaultValueSource();
+        public static readonly IValueSource Instance = new TypeDefaultValueSource();
 
         private TypeDefaultValueSource()
         {
@@ -13,8 +13,8 @@ namespace System.CommandLine.Binding
 
         public bool TryGetValue(
             IValueDescriptor valueDescriptor,
-            BindingContext bindingContext,
-            out object boundValue)
+            BindingContext? bindingContext,
+            out object? boundValue)
         {
             boundValue = valueDescriptor.ValueType.GetDefaultValueForType();
             return true;

--- a/src/System.CommandLine/Binding/ValueDescriptorDefaultValueSource.cs
+++ b/src/System.CommandLine/Binding/ValueDescriptorDefaultValueSource.cs
@@ -5,13 +5,13 @@ namespace System.CommandLine.Binding
 {
     internal class ValueDescriptorDefaultValueSource : IValueSource
     {
-        public static IValueSource Instance = new ValueDescriptorDefaultValueSource();
+        public static readonly IValueSource Instance = new ValueDescriptorDefaultValueSource();
 
         private ValueDescriptorDefaultValueSource()
         {
         }
 
-        public bool TryGetValue(IValueDescriptor valueDescriptor, BindingContext bindingContext, out object boundValue)
+        public bool TryGetValue(IValueDescriptor valueDescriptor, BindingContext? bindingContext, out object? boundValue)
         {
             boundValue = valueDescriptor.GetDefaultValue();
             return true;

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine.Builder
     {
         private readonly List<(InvocationMiddleware middleware, int order)> _middlewareList = new List<(InvocationMiddleware middleware, int order)>();
 
-        public CommandLineBuilder(Command rootCommand = null)
+        public CommandLineBuilder(Command? rootCommand = null)
             : base(rootCommand ?? new RootCommand())
         {
         }
@@ -25,11 +25,11 @@ namespace System.CommandLine.Builder
 
         public ResponseFileHandling ResponseFileHandling { get; set; }
 
-        internal Func<BindingContext, IHelpBuilder> HelpBuilderFactory { get; set; }
+        internal Func<BindingContext, IHelpBuilder>? HelpBuilderFactory { get; set; }
 
-        internal Option HelpOption { get; set; }
+        internal Option? HelpOption { get; set; }
 
-        internal ValidationMessages ValidationMessages { get; set; }
+        internal ValidationMessages? ValidationMessages { get; set; }
 
         public Parser Build()
         {
@@ -42,7 +42,7 @@ namespace System.CommandLine.Builder
                     enableDirectives: EnableDirectives,
                     validationMessages: ValidationMessages,
                     responseFileHandling: ResponseFileHandling,
-                    middlewarePipeline: _middlewareList?.OrderBy(m => m.order)
+                    middlewarePipeline: _middlewareList.OrderBy(m => m.order)
                                                        .Select(m => m.middleware)
                                                        .ToArray(),
                     helpBuilderFactory: HelpBuilderFactory));

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace System.CommandLine.Builder
             new Lazy<string>(() => {
                 var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
                 var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-                if (assemblyVersionAttribute == null)
+                if (assemblyVersionAttribute is null)
                 {
                     return assembly.GetName().Version.ToString();
                 }
@@ -284,7 +284,7 @@ namespace System.CommandLine.Builder
             this CommandLineBuilder builder,
             Option helpOption)
         {
-            if (builder.HelpOption == null)
+            if (builder.HelpOption is null)
             {
                 builder.HelpOption = helpOption; 
                 builder.Command.TryAddGlobalOption(helpOption);
@@ -304,7 +304,7 @@ namespace System.CommandLine.Builder
         public static TBuilder UseHelpBuilder<TBuilder>(this TBuilder builder, Func<BindingContext, IHelpBuilder> getHelpBuilder)
             where TBuilder : CommandLineBuilder
         {
-            if (builder == null)
+            if (builder is null)
             {
                 throw new ArgumentNullException(nameof(builder));
             }

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -79,14 +79,14 @@ namespace System.CommandLine.Builder
             builder.AddMiddleware(async (context, next) =>
             {
                 bool cancellationHandlingAdded = false;
-                ManualResetEventSlim blockProcessExit = null;
-                ConsoleCancelEventHandler consoleHandler = null;
-                EventHandler processExitHandler = null;
+                ManualResetEventSlim? blockProcessExit = null;
+                ConsoleCancelEventHandler? consoleHandler = null;
+                EventHandler? processExitHandler = null;
 
                 context.CancellationHandlingAdded += (CancellationTokenSource cts) =>
                 {
-                    cancellationHandlingAdded = true;
                     blockProcessExit = new ManualResetEventSlim(initialState: false);
+                    cancellationHandlingAdded = true;
                     consoleHandler = (_, args) =>
                     {
                         cts.Cancel();
@@ -119,7 +119,7 @@ namespace System.CommandLine.Builder
                     {
                         Console.CancelKeyPress -= consoleHandler;
                         AppDomain.CurrentDomain.ProcessExit -= processExitHandler;
-                        blockProcessExit.Set();
+                        blockProcessExit!.Set();
                     }
                 }
             }, MiddlewareOrderInternal.Startup);

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -245,7 +245,7 @@ namespace System.CommandLine.Builder
 
         public static CommandLineBuilder UseExceptionHandler(
             this CommandLineBuilder builder,
-            Action<Exception, InvocationContext> onException = null)
+            Action<Exception, InvocationContext>? onException = null)
         {
             builder.AddMiddleware(async (context, next) =>
             {

--- a/src/System.CommandLine/Collections/AliasedSet.cs
+++ b/src/System.CommandLine/Collections/AliasedSet.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace System.CommandLine.Collections
 {
@@ -12,9 +11,9 @@ namespace System.CommandLine.Collections
     {
         protected IList<T> Items { get; } = new List<T>();
 
-        public T this[string alias] => GetByAlias(alias);
+        public T? this[string alias] => GetByAlias(alias);
 
-        public T GetByAlias(string alias)
+        public T? GetByAlias(string alias)
         {
             for (var i = 0; i < Items.Count; i++)
             {

--- a/src/System.CommandLine/Collections/ISymbolSet.cs
+++ b/src/System.CommandLine/Collections/ISymbolSet.cs
@@ -7,6 +7,6 @@ namespace System.CommandLine.Collections
 {
     public interface ISymbolSet : IReadOnlyCollection<ISymbol>
     {
-        ISymbol GetByAlias(string alias);
+        ISymbol? GetByAlias(string alias);
     }
 }

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.CommandLine.Collections
 {
@@ -18,7 +19,7 @@ namespace System.CommandLine.Collections
 
         internal bool IsAnyAliasInUse(
             ISymbol item,
-            out string aliasAlreadyInUse)
+            [MaybeNullWhen(false)]out string aliasAlreadyInUse)
         {
             var itemRawAliases = GetRawAliases(item);
 
@@ -53,7 +54,7 @@ namespace System.CommandLine.Collections
 
         internal void ThrowIfAnyAliasIsInUse(ISymbol item)
         {
-            string rawAliasAlreadyInUse;
+            string? rawAliasAlreadyInUse;
 
             switch (item)
             {

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -19,7 +19,7 @@ namespace System.CommandLine.Collections
 
         internal bool IsAnyAliasInUse(
             ISymbol item,
-            [MaybeNullWhen(false)]out string aliasAlreadyInUse)
+            [MaybeNullWhen(false)] out string aliasAlreadyInUse)
         {
             var itemRawAliases = GetRawAliases(item);
 
@@ -39,7 +39,7 @@ namespace System.CommandLine.Collections
                 }
             }
 
-            aliasAlreadyInUse = null;
+            aliasAlreadyInUse = null!;
             return false;
 
             static IReadOnlyList<string> GetRawAliases(ISymbol symbol)

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine
     {
         private readonly SymbolSet _globalOptions = new SymbolSet();
 
-        public Command(string name, string description = null) : base(new[] { name }, description)
+        public Command(string name, string? description = null) : base(new[] { name }, description)
         {
         }
 
@@ -72,7 +72,7 @@ namespace System.CommandLine
 
         public bool TreatUnmatchedTokensAsErrors { get; set; } = true;
 
-        public ICommandHandler Handler { get; set; }
+        public ICommandHandler? Handler { get; set; }
 
         public IEnumerator<Symbol> GetEnumerator() => Children.OfType<Symbol>().GetEnumerator();
 
@@ -82,6 +82,6 @@ namespace System.CommandLine
 
         IEnumerable<IOption> ICommand.Options => Options;
 
-        internal Parser ImplicitParser { get; set; }
+        internal Parser? ImplicitParser { get; set; }
     }
 }

--- a/src/System.CommandLine/CommandExtensions.cs
+++ b/src/System.CommandLine/CommandExtensions.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine
         public static int Invoke(
             this Command command,
             string[] args,
-            IConsole console = null)
+            IConsole? console = null)
         {
             return GetInvocationPipeline(command, args).Invoke(console);
         }
@@ -23,13 +23,13 @@ namespace System.CommandLine
         public static int Invoke(
             this Command command,
             string commandLine,
-            IConsole console = null) =>
+            IConsole? console = null) =>
             command.Invoke(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console);
 
         public static async Task<int> InvokeAsync(
             this Command command,
             string[] args,
-            IConsole console = null)
+            IConsole? console = null)
         {
             return await GetInvocationPipeline(command, args).InvokeAsync(console);
         }
@@ -37,7 +37,7 @@ namespace System.CommandLine
         public static Task<int> InvokeAsync(
             this Command command,
             string commandLine,
-            IConsole console = null) =>
+            IConsole? console = null) =>
             command.InvokeAsync(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console);
 
         private static InvocationPipeline GetInvocationPipeline(Command command, string[] args)
@@ -60,7 +60,7 @@ namespace System.CommandLine
         public static ParseResult Parse(
             this Command command,
             string commandLine,
-            IReadOnlyCollection<char> delimiters = null) =>
+            IReadOnlyCollection<char>? delimiters = null) =>
             new Parser(command).Parse(commandLine);
     }
 }

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -13,8 +13,8 @@ namespace System.CommandLine
 {
     public class CommandLineConfiguration
     {
-        private IReadOnlyCollection<InvocationMiddleware>? _middlewarePipeline;
-        private Func<BindingContext, IHelpBuilder>? _helpBuilderFactory;
+        private IReadOnlyCollection<InvocationMiddleware> _middlewarePipeline;
+        private Func<BindingContext, IHelpBuilder> _helpBuilderFactory;
         private readonly SymbolSet _symbols = new SymbolSet();
 
         public CommandLineConfiguration(
@@ -87,8 +87,8 @@ namespace System.CommandLine
             EnableDirectives = enableDirectives;
             ValidationMessages = validationMessages ?? ValidationMessages.Instance;
             ResponseFileHandling = responseFileHandling;
-            _middlewarePipeline = middlewarePipeline;
-            _helpBuilderFactory = helpBuilderFactory;
+            _middlewarePipeline = middlewarePipeline ?? new List<InvocationMiddleware>();
+            _helpBuilderFactory = helpBuilderFactory ?? (context => new HelpBuilder(context.Console));
         }
 
         private void AddGlobalOptionsToChildren(Command parentCommand)
@@ -118,11 +118,9 @@ namespace System.CommandLine
 
         public ValidationMessages ValidationMessages { get; }
 
-        internal Func<BindingContext, IHelpBuilder> HelpBuilderFactory =>
-            _helpBuilderFactory ??= context => new HelpBuilder(context.Console);
+        internal Func<BindingContext, IHelpBuilder> HelpBuilderFactory => _helpBuilderFactory;
 
-        internal IReadOnlyCollection<InvocationMiddleware> Middleware =>
-            _middlewarePipeline ??= new List<InvocationMiddleware>();
+        internal IReadOnlyCollection<InvocationMiddleware> Middleware => _middlewarePipeline;
 
         public ICommand RootCommand { get; }
 

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -27,7 +27,7 @@ namespace System.CommandLine
             IReadOnlyCollection<InvocationMiddleware>? middlewarePipeline = null,
             Func<BindingContext, IHelpBuilder>? helpBuilderFactory = null)
         {
-            if (symbols == null)
+            if (symbols is null)
             {
                 throw new ArgumentNullException(nameof(symbols));
             }
@@ -65,7 +65,7 @@ namespace System.CommandLine
                                      .OfType<RootCommand>()
                                      .FirstOrDefault();
 
-                if (rootCommand == null)
+                if (rootCommand is null)
                 {
                     rootCommand = new RootCommand();
 

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -13,19 +13,19 @@ namespace System.CommandLine
 {
     public class CommandLineConfiguration
     {
-        private IReadOnlyCollection<InvocationMiddleware> _middlewarePipeline;
-        private Func<BindingContext, IHelpBuilder> _helpBuilderFactory;
+        private IReadOnlyCollection<InvocationMiddleware>? _middlewarePipeline;
+        private Func<BindingContext, IHelpBuilder>? _helpBuilderFactory;
         private readonly SymbolSet _symbols = new SymbolSet();
 
         public CommandLineConfiguration(
             IReadOnlyCollection<Symbol> symbols,
-            IReadOnlyCollection<char> argumentDelimiters = null,
+            IReadOnlyCollection<char>? argumentDelimiters = null,
             bool enablePosixBundling = true,
             bool enableDirectives = true,
-            ValidationMessages validationMessages = null,
+            ValidationMessages? validationMessages = null,
             ResponseFileHandling responseFileHandling = ResponseFileHandling.ParseArgsAsLineSeparated,
-            IReadOnlyCollection<InvocationMiddleware> middlewarePipeline = null,
-            Func<BindingContext, IHelpBuilder> helpBuilderFactory = null)
+            IReadOnlyCollection<InvocationMiddleware>? middlewarePipeline = null,
+            Func<BindingContext, IHelpBuilder>? helpBuilderFactory = null)
         {
             if (symbols == null)
             {
@@ -98,7 +98,7 @@ namespace System.CommandLine
                 {
                     if (child is Command childCommand)
                     {
-                        if (!childCommand.Children.IsAnyAliasInUse(globalOption, out var inUse))
+                        if (!childCommand.Children.IsAnyAliasInUse(globalOption, out _))
                         {
                             childCommand.AddOption(globalOption);
                         }
@@ -106,9 +106,7 @@ namespace System.CommandLine
                 }
             }
         }
-
-        public IReadOnlyCollection<string> Prefixes { get; }
-
+        
         public ISymbolSet Symbols => _symbols;
 
         public IReadOnlyCollection<char> ArgumentDelimiters { get; }

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -61,21 +61,22 @@ namespace System.CommandLine
             else
             {
                 // reuse existing auto-generated root command, if one is present, to prevent repeated mutations
-                rootCommand = symbols.SelectMany(s => s.Parents)
-                                     .OfType<RootCommand>()
-                                     .FirstOrDefault();
+                RootCommand? parentRootCommand = 
+                    symbols.SelectMany(s => s.Parents)
+                           .OfType<RootCommand>()
+                           .FirstOrDefault();
 
-                if (rootCommand is null)
+                if (parentRootCommand is null)
                 {
-                    rootCommand = new RootCommand();
+                    parentRootCommand = new RootCommand();
 
                     foreach (var symbol in symbols)
                     {
-                        rootCommand.Add(symbol);
+                        parentRootCommand.Add(symbol);
                     }
                 }
 
-                RootCommand = rootCommand;
+                RootCommand = rootCommand = parentRootCommand;
             }
 
             _symbols.Add(RootCommand);

--- a/src/System.CommandLine/DirectiveCollection.cs
+++ b/src/System.CommandLine/DirectiveCollection.cs
@@ -32,7 +32,7 @@ namespace System.CommandLine
             return _directives.ContainsKey(name);
         }
 
-        public bool TryGetValues(string name,  [NotNullWhen(true)]out IEnumerable<string>? values)
+        public bool TryGetValues(string name,  [NotNullWhen(true)] out IEnumerable<string>? values)
         {
             if (_directives.TryGetValue(name, out var v))
             {

--- a/src/System.CommandLine/DirectiveCollection.cs
+++ b/src/System.CommandLine/DirectiveCollection.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace System.CommandLine
@@ -11,7 +12,7 @@ namespace System.CommandLine
     {
         private readonly Dictionary<string, List<string>> _directives = new Dictionary<string, List<string>>();
 
-        public void Add(string name, string value)
+        public void Add(string name, string? value)
         {
             if (_directives.TryGetValue(name, out var values))
             {
@@ -35,7 +36,7 @@ namespace System.CommandLine
             return _directives.ContainsKey(name);
         }
 
-        public bool TryGetValues(string name, out IEnumerable<string> values)
+        public bool TryGetValues(string name,  [NotNullWhen(true)]out IEnumerable<string>? values)
         {
             if (_directives.TryGetValue(name, out var v))
             {

--- a/src/System.CommandLine/DirectiveCollection.cs
+++ b/src/System.CommandLine/DirectiveCollection.cs
@@ -14,20 +14,16 @@ namespace System.CommandLine
 
         public void Add(string name, string? value)
         {
-            if (_directives.TryGetValue(name, out var values))
+            if (!_directives.TryGetValue(name, out var values))
+            {
+                values = new List<string>();
+
+                _directives.Add(name, values);
+            }
+
+            if (value != null)
             {
                 values.Add(value);
-            }
-            else
-            {
-                var list = new List<string>();
-
-                if (value != null)
-                {
-                    list.Add(value);
-                }
-
-                _directives.Add(name, list);
             }
         }
 

--- a/src/System.CommandLine/EnumerableExtensions.cs
+++ b/src/System.CommandLine/EnumerableExtensions.cs
@@ -33,10 +33,12 @@ namespace System.CommandLine
         }
 
         internal static IEnumerable<T> RecurseWhileNotNull<T>(
-            this T source,
-            Func<T, T> next)
+            this T? source,
+            Func<T, T?> next)
             where T : class
         {
+            if (source is null) yield break;
+
             yield return source;
 
             while ((source = next(source)) != null)

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -594,7 +594,7 @@ namespace System.CommandLine.Help
 
             public string Invocation { get; }
 
-            public string? Description { get; }
+            public string Description { get; }
 
             protected bool Equals(HelpItem other) => 
                 (Invocation, Description) == (other.Invocation, other.Description);

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -161,9 +161,9 @@ namespace System.CommandLine.Help
         /// </summary>
         /// <param name="heading">Heading text content to write to the console</param>
         /// <exception cref="ArgumentNullException"></exception>
-        private void AppendHeading(string heading)
+        private void AppendHeading(string? heading)
         {
-            if (heading == null)
+            if (heading is null)
             {
                 throw new ArgumentNullException(nameof(heading));
             }
@@ -178,7 +178,7 @@ namespace System.CommandLine.Help
         /// <exception cref="ArgumentNullException"></exception>
         private void AppendDescription(string description)
         {
-            if (description == null)
+            if (description is null)
             {
                 throw new ArgumentNullException(nameof(description));
             }
@@ -586,7 +586,7 @@ namespace System.CommandLine.Help
 
         protected class HelpItem
         {
-            public HelpItem(string invocation, string description = null)
+            public HelpItem(string invocation, string? description = null)
             {
                 Invocation = invocation;
                 Description = description ?? "";
@@ -594,7 +594,7 @@ namespace System.CommandLine.Help
 
             public string Invocation { get; }
 
-            public string Description { get; }
+            public string? Description { get; }
 
             protected bool Equals(HelpItem other) => 
                 (Invocation, Description) == (other.Invocation, other.Description);
@@ -609,7 +609,7 @@ namespace System.CommandLine.Help
             public static void Write(
                 HelpBuilder builder,
                 string title,
-                string description = null)
+                string? description = null)
             {
                 if (!ShouldWrite(description, null))
                 {
@@ -626,9 +626,9 @@ namespace System.CommandLine.Help
             public static void Write(
                 HelpBuilder builder,
                 string title,
-                IReadOnlyCollection<ISymbol> usageItems = null,
-                Func<ISymbol, IEnumerable<HelpItem>> formatter = null,
-                string description = null)
+                IReadOnlyCollection<ISymbol>? usageItems = null,
+                Func<ISymbol, IEnumerable<HelpItem>>? formatter = null,
+                string? description = null)
             {
                 if (!ShouldWrite(description, usageItems))
                 {
@@ -643,7 +643,7 @@ namespace System.CommandLine.Help
                 builder.AppendBlankLine();
             }
 
-            private static bool ShouldWrite(string description, IReadOnlyCollection<ISymbol> usageItems)
+            private static bool ShouldWrite(string? description, IReadOnlyCollection<ISymbol>? usageItems)
             {
                 if (!string.IsNullOrWhiteSpace(description))
                 {
@@ -653,7 +653,7 @@ namespace System.CommandLine.Help
                 return usageItems?.Any() == true;
             }
 
-            private static void AppendHeading(HelpBuilder builder, string title = null)
+            private static void AppendHeading(HelpBuilder builder, string? title = null)
             {
                 if (string.IsNullOrWhiteSpace(title))
                 {
@@ -663,7 +663,7 @@ namespace System.CommandLine.Help
                 builder.AppendHeading(title);
             }
 
-            private static void AddDescription(HelpBuilder builder, string description = null)
+            private static void AddDescription(HelpBuilder builder, string? description = null)
             {
                 if (string.IsNullOrWhiteSpace(description))
                 {
@@ -675,8 +675,8 @@ namespace System.CommandLine.Help
 
             private static void AddInvocation(
                 HelpBuilder builder,
-                IReadOnlyCollection<ISymbol> symbols,
-                Func<ISymbol, IEnumerable<HelpItem>> formatter)
+                IReadOnlyCollection<ISymbol>? symbols,
+                Func<ISymbol, IEnumerable<HelpItem>>? formatter)
             {
                 var helpItems = symbols
                     .SelectMany(formatter)

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -57,7 +57,7 @@ namespace System.CommandLine.Help
         /// <inheritdoc />
         public virtual void Write(ICommand command)
         {
-            if (command == null)
+            if (command is null)
             {
                 throw new ArgumentNullException(nameof(command));
             }
@@ -205,7 +205,7 @@ namespace System.CommandLine.Help
         /// </param>
         protected void AppendHelpItem(HelpItem helpItem, int maxInvocationWidth)
         {
-            if (helpItem == null)
+            if (helpItem is null)
             {
                 throw new ArgumentNullException(nameof(helpItem));
             }
@@ -562,9 +562,9 @@ namespace System.CommandLine.Help
             HelpSection.Write(this, AdditionalArguments.Title, AdditionalArguments.Description);
         }
 
-        private bool ShouldDisplayArgumentHelp(ICommand command)
+        private bool ShouldDisplayArgumentHelp(ICommand? command)
         {
-            if (command == null)
+            if (command is null)
             {
                 return false;
             }

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -670,7 +670,7 @@ namespace System.CommandLine.Help
                     return;
                 }
 
-                builder.AppendDescription(description);
+                builder.AppendDescription(description!);
             }
 
             private static void AddInvocation(

--- a/src/System.CommandLine/IDirectiveCollection.cs
+++ b/src/System.CommandLine/IDirectiveCollection.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.CommandLine
 {
@@ -9,6 +10,6 @@ namespace System.CommandLine
     {
         bool Contains(string name);
 
-        bool TryGetValues(string name, out IEnumerable<string> values);
+        bool TryGetValues(string name,  [NotNullWhen(true)] out IEnumerable<string>? values);
     }
 }

--- a/src/System.CommandLine/IO/StandardStreamWriter.cs
+++ b/src/System.CommandLine/IO/StandardStreamWriter.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.IO
     {
         public static IStandardStreamWriter Create(TextWriter writer)
         {
-            if (writer == null)
+            if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
             }
@@ -19,7 +19,7 @@ namespace System.CommandLine.IO
 
         public static void WriteLine(this IStandardStreamWriter writer)
         {
-            if (writer == null)
+            if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
             }
@@ -29,7 +29,7 @@ namespace System.CommandLine.IO
 
         public static void WriteLine(this IStandardStreamWriter writer, string value)
         {
-            if (writer == null)
+            if (writer is null)
             {
                 throw new ArgumentNullException(nameof(writer));
             }

--- a/src/System.CommandLine/ISymbol.cs
+++ b/src/System.CommandLine/ISymbol.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine
     {
         string Name { get; }
 
-        string Description { get; }
+        string? Description { get; }
 
         IReadOnlyList<string> Aliases { get; }
 

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Invocation
         public static ICommandHandler Create(Delegate @delegate) =>
             HandlerDescriptor.FromDelegate(@delegate).GetCommandHandler();
 
-        public static ICommandHandler Create(MethodInfo method, object target = null) =>
+        public static ICommandHandler Create(MethodInfo method, object? target = null) =>
             HandlerDescriptor.FromMethodInfo(method, target).GetCommandHandler();
 
         public static ICommandHandler Create(Action action) =>

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -9,14 +9,14 @@ namespace System.CommandLine.Invocation
 {
     public sealed class InvocationContext : IDisposable
     {
-        private CancellationTokenSource _cts;
-        private Action<CancellationTokenSource> _cancellationHandlingAddedEvent;
+        private CancellationTokenSource? _cts;
+        private Action<CancellationTokenSource>? _cancellationHandlingAddedEvent;
 
         public BindingContext BindingContext { get; }
 
         public InvocationContext(
             ParseResult parseResult,
-            IConsole console = null)
+            IConsole? console = null)
         {
             BindingContext = new BindingContext(parseResult, console);
             BindingContext.ServiceProvider.AddService(_ => GetCancellationToken());
@@ -35,7 +35,7 @@ namespace System.CommandLine.Invocation
 
         public int ResultCode { get; set; }
 
-        public IInvocationResult InvocationResult { get; set; }
+        public IInvocationResult? InvocationResult { get; set; }
 
         internal event Action<CancellationTokenSource> CancellationHandlingAdded
         {

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -57,7 +57,7 @@ namespace System.CommandLine.Invocation
         /// <returns>Token used by the caller to implement cancellation handling.</returns>
         public CancellationToken GetCancellationToken()
         {
-            if (_cts == null)
+            if (_cts is null)
             {
                 _cts = new CancellationTokenSource();
                 _cancellationHandlingAddedEvent?.Invoke(_cts);

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -17,7 +17,7 @@ namespace System.CommandLine.Invocation
             this.parseResult = parseResult ?? throw new ArgumentNullException(nameof(parseResult));
         }
 
-        public async Task<int> InvokeAsync(IConsole console = null)
+        public async Task<int> InvokeAsync(IConsole? console = null)
         {
             var context = new InvocationContext(parseResult, console);
 
@@ -28,7 +28,7 @@ namespace System.CommandLine.Invocation
             return GetResultCode(context);
         }
 
-        public int Invoke(IConsole console = null)
+        public int Invoke(IConsole? console = null)
         {
             var context = new InvocationContext(parseResult, console);
 

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -11,39 +11,39 @@ namespace System.CommandLine.Invocation
 {
     internal class ModelBindingCommandHandler : ICommandHandler
     {
-        private readonly Delegate _handlerDelegate;
-        private readonly object _invocationTarget;
-        private readonly ModelBinder _invocationTargetBinder;
-        private readonly MethodInfo _handlerMethodInfo;
+        private readonly Delegate? _handlerDelegate;
+        private readonly object? _invocationTarget;
+        private readonly ModelBinder? _invocationTargetBinder;
+        private readonly MethodInfo? _handlerMethodInfo;
         private readonly IReadOnlyList<ParameterDescriptor> _parameterDescriptors;
 
         public ModelBindingCommandHandler(
             MethodInfo handlerMethodInfo,
             IReadOnlyList<ParameterDescriptor> parameterDescriptors)
         {
-            _handlerMethodInfo = handlerMethodInfo;
+            _handlerMethodInfo = handlerMethodInfo ?? throw new ArgumentNullException(nameof(handlerMethodInfo));
             _invocationTargetBinder = _handlerMethodInfo.IsStatic
                                           ? null
                                           : new ModelBinder(_handlerMethodInfo.DeclaringType);
-            _parameterDescriptors = parameterDescriptors;
+            _parameterDescriptors = parameterDescriptors ?? throw new ArgumentNullException(nameof(parameterDescriptors));
         }
 
         public ModelBindingCommandHandler(
             MethodInfo handlerMethodInfo,
             IReadOnlyList<ParameterDescriptor> parameterDescriptors,
-            object invocationTarget)
+            object? invocationTarget)
         {
             _invocationTarget = invocationTarget;
-            _handlerMethodInfo = handlerMethodInfo;
-            _parameterDescriptors = parameterDescriptors;
+            _handlerMethodInfo = handlerMethodInfo ?? throw new ArgumentNullException(nameof(handlerMethodInfo));
+            _parameterDescriptors = parameterDescriptors ?? throw new ArgumentNullException(nameof(parameterDescriptors));
         }
 
         public ModelBindingCommandHandler(
             Delegate handlerDelegate,
             IReadOnlyList<ParameterDescriptor> parameterDescriptors)
         {
-            _handlerDelegate = handlerDelegate;
-            _parameterDescriptors = parameterDescriptors;
+            _handlerDelegate = handlerDelegate ?? throw new ArgumentNullException(nameof(handlerDelegate));
+            _parameterDescriptors = parameterDescriptors ?? throw new ArgumentNullException(nameof(parameterDescriptors));
         }
 
         public async Task<int> InvokeAsync(InvocationContext context)

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Binding;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -65,7 +65,7 @@ namespace System.CommandLine.Invocation
             object result;
             if (_handlerDelegate == null)
             {
-                result = _handlerMethodInfo.Invoke(
+                result = _handlerMethodInfo!.Invoke(
                     invocationTarget,
                     invocationArguments);
             }

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -63,7 +63,7 @@ namespace System.CommandLine.Invocation
                                    _invocationTargetBinder?.CreateInstance(bindingContext);
 
             object result;
-            if (_handlerDelegate == null)
+            if (_handlerDelegate is null)
             {
                 result = _handlerMethodInfo!.Invoke(
                     invocationTarget,

--- a/src/System.CommandLine/Invocation/Process.cs
+++ b/src/System.CommandLine/Invocation/Process.cs
@@ -11,9 +11,9 @@ namespace System.CommandLine.Invocation
         public static async Task<int> ExecuteAsync(
             string command,
             string args,
-            string workingDir = null,
-            Action<string> stdOut = null,
-            Action<string> stdErr = null,
+            string? workingDir = null,
+            Action<string>? stdOut = null,
+            Action<string>? stdErr = null,
             params (string key, string value)[] environmentVariables)
         {
             var process = StartProcess(command,
@@ -39,9 +39,9 @@ namespace System.CommandLine.Invocation
         public static Diagnostics.Process StartProcess(
             string command,
             string args,
-            string workingDir = null,
-            Action<string> stdOut = null,
-            Action<string> stdErr = null,
+            string? workingDir = null,
+            Action<string>? stdOut = null,
+            Action<string>? stdErr = null,
             params (string key, string value)[] environmentVariables)
         {
             args = args ?? "";

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -57,7 +57,7 @@ namespace System.CommandLine.Invocation
                 .TakeWhile(tuple =>
                 {
                     var (_, distance) = tuple;
-                    if (bestDistance == null)
+                    if (bestDistance is null)
                     {
                         bestDistance = distance;
                     }
@@ -78,12 +78,12 @@ namespace System.CommandLine.Invocation
         private static int GetDistance(string first, string second)
         {
             // Validate parameters
-            if (first == null)
+            if (first is null)
             {
                 throw new ArgumentNullException(nameof(first));
             }
 
-            if (second == null)
+            if (second is null)
             {
                 throw new ArgumentNullException(nameof(second));
             }

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine
 {
     public class Option : Symbol, IOption
     {
-        public Option(string alias, string description = null)
+        public Option(string alias, string? description = null)
             : base(new[]
             {
                 alias
@@ -18,7 +18,7 @@ namespace System.CommandLine
         {
         }
 
-        public Option(string[] aliases, string description = null) : base(aliases, description)
+        public Option(string[] aliases, string? description = null) : base(aliases, description)
         {
         }
 
@@ -52,6 +52,6 @@ namespace System.CommandLine
 
         bool IValueDescriptor.HasDefaultValue => Argument.HasDefaultValue;
 
-        object IValueDescriptor.GetDefaultValue() => Argument.GetDefaultValue();
+        object? IValueDescriptor.GetDefaultValue() => Argument.GetDefaultValue();
     }
 }

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -9,14 +9,14 @@ namespace System.CommandLine
     {
         public Option(
             string alias, 
-            string description = null) : base(alias, description)
+            string? description = null) : base(alias, description)
         {
             Argument = new Argument<T>();
         }
 
         public Option(
             string[] aliases, 
-            string description = null) : base(aliases, description)
+            string? description = null) : base(aliases, description)
         {
             Argument = new Argument<T>();
         }

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine
             string alias,
             ParseArgument<T> parseArgument,
             bool isDefault = false,
-            string description = null) : base(alias, description)
+            string? description = null) : base(alias, description)
         {
             if (parseArgument is null)
             {
@@ -39,7 +39,7 @@ namespace System.CommandLine
             string[] aliases,
             ParseArgument<T> parseArgument,
             bool isDefault = false,
-            string description = null) : base(aliases, description)
+            string? description = null) : base(aliases, description)
         {
             if (parseArgument is null)
             {
@@ -52,7 +52,7 @@ namespace System.CommandLine
         public Option(
             string alias,
             Func<T> getDefaultValue,
-            string description = null) : base(alias, description)
+            string? description = null) : base(alias, description)
         {
             if (getDefaultValue is null)
             {
@@ -65,7 +65,7 @@ namespace System.CommandLine
         public Option(
             string[] aliases,
             Func<T> getDefaultValue,
-            string description = null) : base(aliases, description)
+            string? description = null) : base(aliases, description)
         {
             if (getDefaultValue is null)
             {

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -26,10 +26,9 @@ namespace System.CommandLine.Parsing
 
         internal ParseError? CustomError(Argument argument)
         {
-            string errorMessage = ErrorMessage;
-            if (!string.IsNullOrEmpty(errorMessage))
+            if (!string.IsNullOrEmpty(ErrorMessage))
             {
-                return new ParseError(errorMessage, this);
+                return new ParseError(ErrorMessage, this);
             }
 
             for (var i = 0; i < argument.Validators.Count; i++)
@@ -39,7 +38,7 @@ namespace System.CommandLine.Parsing
 
                 if (!string.IsNullOrWhiteSpace(errorMessage))
                 {
-                    return new ParseError(errorMessage, this);
+                    return new ParseError(errorMessage!, this);
                 }
             }
 

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -61,7 +61,7 @@ namespace System.CommandLine.Parsing
 
             if (argument is Argument arg)
             {
-                if (parentResult.UseDefaultValueFor(argument))
+                if (parentResult!.UseDefaultValueFor(argument))
                 {
                     var argumentResult = new ArgumentResult(arg, Parent);
 

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -28,7 +28,7 @@ namespace System.CommandLine.Parsing
         {
             if (!string.IsNullOrEmpty(ErrorMessage))
             {
-                return new ParseError(ErrorMessage, this);
+                return new ParseError(ErrorMessage!, this);
             }
 
             for (var i = 0; i < argument.Validators.Count; i++)
@@ -77,7 +77,7 @@ namespace System.CommandLine.Parsing
                     {
                         return ArgumentConversionResult.Failure(
                             argument,
-                            argumentResult.ErrorMessage);
+                            argumentResult.ErrorMessage!);
                     }
                 }
 

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Parsing
 
         internal ArgumentResult(
             IArgument argument,
-            SymbolResult parent) : base(argument, parent)
+            SymbolResult? parent) : base(argument, parent)
         {
             Argument = argument;
         }
@@ -24,11 +24,12 @@ namespace System.CommandLine.Parsing
 
         public override string ToString() => $"{GetType().Name} {Argument.Name}: {string.Join(" ", Tokens.Select(t => $"<{t.Value}>"))}";
 
-        internal ParseError CustomError(Argument argument)
+        internal ParseError? CustomError(Argument argument)
         {
-            if (!string.IsNullOrEmpty(ErrorMessage))
+            string errorMessage = ErrorMessage;
+            if (!string.IsNullOrEmpty(errorMessage))
             {
-                return new ParseError(ErrorMessage, this);
+                return new ParseError(errorMessage, this);
             }
 
             for (var i = 0; i < argument.Validators.Count; i++)

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -8,7 +8,7 @@ namespace System.CommandLine.Parsing
 {
     public class ArgumentResult : SymbolResult
     {
-        private ArgumentConversionResult _conversionResult;
+        private ArgumentConversionResult? _conversionResult;
 
         internal ArgumentResult(
             IArgument argument,

--- a/src/System.CommandLine/Parsing/ArgumentResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResultExtensions.cs
@@ -8,10 +8,10 @@ namespace System.CommandLine.Parsing
 {
     public static class ArgumentResultExtensions
     {
-        public static object? GetValueOrDefault(this ArgumentResult argumentResult) => 
+        public static object? GetValueOrDefault(this ArgumentResult argumentResult) =>
             argumentResult.GetValueOrDefault<object?>();
 
-        [return:MaybeNull]
+        [return: MaybeNull]
         public static T GetValueOrDefault<T>(this ArgumentResult argumentResult) =>
             argumentResult.GetArgumentConversionResult()
                           .ConvertIfNeeded(argumentResult, typeof(T))

--- a/src/System.CommandLine/Parsing/ArgumentResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResultExtensions.cs
@@ -2,14 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Binding;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.CommandLine.Parsing
 {
     public static class ArgumentResultExtensions
     {
-        public static object GetValueOrDefault(this ArgumentResult argumentResult) => 
-            argumentResult.GetValueOrDefault<object>();
+        public static object? GetValueOrDefault(this ArgumentResult argumentResult) => 
+            argumentResult.GetValueOrDefault<object?>();
 
+        [return:MaybeNull]
         public static T GetValueOrDefault<T>(this ArgumentResult argumentResult) =>
             argumentResult.GetArgumentConversionResult()
                           .ConvertIfNeeded(argumentResult, typeof(T))

--- a/src/System.CommandLine/Parsing/CommandLineStringSplitter.cs
+++ b/src/System.CommandLine/Parsing/CommandLineStringSplitter.cs
@@ -95,7 +95,7 @@ namespace System.CommandLine.Parsing
 
             string CurrentToken()
             {
-                if (skipQuoteAtIndex == null)
+                if (skipQuoteAtIndex is null)
                 {
                     return memory.Slice(
                                      startTokenIndex,

--- a/src/System.CommandLine/Parsing/CommandNode.cs
+++ b/src/System.CommandLine/Parsing/CommandNode.cs
@@ -8,7 +8,7 @@ namespace System.CommandLine.Parsing
         public CommandNode(
             Token token,
             ICommand command,
-            CommandNode parent) : base(token, parent)
+            CommandNode? parent) : base(token, parent)
         {
             if (token.Type != TokenType.Command)
             {

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -9,12 +9,12 @@ namespace System.CommandLine.Parsing
 {
     public class CommandResult : SymbolResult
     {
-        private ArgumentConversionResultSet _results;
+        private ArgumentConversionResultSet? _results;
 
         internal CommandResult(
             ICommand command,
-            Token token,
-            CommandResult parent = null) :
+            Token? token,
+            CommandResult? parent = null) :
             base(command ?? throw new ArgumentNullException(nameof(command)),
                  parent)
         {

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -71,7 +71,7 @@ namespace System.CommandLine.Parsing
             return ValueForOption<object?>(alias);
         }
 
-        [return:MaybeNull]
+        [return: MaybeNull]
         public T ValueForOption<T>(string alias)
         {
             if (string.IsNullOrWhiteSpace(alias))

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Binding;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace System.CommandLine.Parsing
@@ -13,7 +14,7 @@ namespace System.CommandLine.Parsing
 
         internal CommandResult(
             ICommand command,
-            Token? token,
+            Token token,
             CommandResult? parent = null) :
             base(command ?? throw new ArgumentNullException(nameof(command)),
                  parent)
@@ -25,9 +26,9 @@ namespace System.CommandLine.Parsing
 
         public ICommand Command { get; }
 
-        public OptionResult this[string alias] => OptionResult(alias);
+        public OptionResult? this[string alias] => OptionResult(alias);
 
-        public OptionResult OptionResult(string alias)
+        public OptionResult? OptionResult(string alias)
         {
             return Children[alias] as OptionResult;
         }
@@ -35,11 +36,11 @@ namespace System.CommandLine.Parsing
         public Token Token { get; }
 
 
-        internal virtual RootCommandResult Root => (Parent as CommandResult)?.Root;
+        internal virtual RootCommandResult? Root => (Parent as CommandResult)?.Root;
 
         internal bool TryGetValueForArgument(
             IValueDescriptor valueDescriptor,
-            out object value)
+            [NotNullWhen(true)]out object? value)
         {
             foreach (var argument in Command.Arguments)
             {
@@ -54,7 +55,7 @@ namespace System.CommandLine.Parsing
             return false;
         }
 
-        public object ValueForOption(string alias)
+        public object? ValueForOption(string alias)
         {
             if (Children[alias] is OptionResult optionResult)
             {
@@ -64,9 +65,10 @@ namespace System.CommandLine.Parsing
                 }
             }
 
-            return ValueForOption<object>(alias);
+            return ValueForOption<object?>(alias);
         }
 
+        [return:MaybeNull]
         public T ValueForOption<T>(string alias)
         {
             if (string.IsNullOrWhiteSpace(alias))

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -93,7 +93,7 @@ namespace System.CommandLine.Parsing
         {
             get
             {
-                if (_results == null)
+                if (_results is null)
                 {
                     var results = Children
                                   .OfType<ArgumentResult>()

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -40,14 +40,17 @@ namespace System.CommandLine.Parsing
 
         internal bool TryGetValueForArgument(
             IValueDescriptor valueDescriptor,
-            [NotNullWhen(true)]out object? value)
+            out object? value)
         {
-            foreach (var argument in Command.Arguments)
+            if (valueDescriptor.ValueName is string valueName)
             {
-                if (valueDescriptor.ValueName.IsMatch(argument.Name))
+                foreach (var argument in Command.Arguments)
                 {
-                    value = ArgumentConversionResults[argument.Name].GetValueOrDefault();
-                    return true;
+                    if (valueName.IsMatch(argument.Name))
+                    {
+                        value = ArgumentConversionResults[argument.Name]?.GetValueOrDefault();
+                        return true;
+                    }
                 }
             }
 

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -85,7 +85,7 @@ namespace System.CommandLine.Parsing
             }
             else
             {
-                return default;
+                return default!;
             }
         }
 

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Parsing
             return commandResult.GetArgumentValueOrDefault<object?>(argumentName);
         }
 
-        [return:MaybeNull]
+        [return: MaybeNull]
         public static T GetArgumentValueOrDefault<T>(
             this CommandResult commandResult,
             string argumentName)

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -1,19 +1,21 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Binding;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace System.CommandLine.Parsing
 {
     public static class CommandResultExtensions
     {
-        public static object GetArgumentValueOrDefault(
+        public static object? GetArgumentValueOrDefault(
             this CommandResult commandResult,
             string argumentName)
         {
-            return commandResult.GetArgumentValueOrDefault<object>(argumentName);
+            return commandResult.GetArgumentValueOrDefault<object?>(argumentName);
         }
 
+        [return:MaybeNull]
         public static T GetArgumentValueOrDefault<T>(
             this CommandResult commandResult,
             string argumentName)
@@ -32,7 +34,7 @@ namespace System.CommandLine.Parsing
         {
             var children = commandResult
                            .Children
-                           .Where(o => valueDescriptor.ValueName.IsMatch(o.Symbol))
+                           .Where(o => valueDescriptor.ValueName?.IsMatch(o.Symbol) == true)
                            .ToArray();
 
             SymbolResult? symbolResult = null;

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -28,14 +28,14 @@ namespace System.CommandLine.Parsing
         internal static bool TryGetValueForOption(
             this CommandResult commandResult,
             IValueDescriptor valueDescriptor,
-            out object value)
+            out object? value)
         {
             var children = commandResult
                            .Children
                            .Where(o => valueDescriptor.ValueName.IsMatch(o.Symbol))
                            .ToArray();
 
-            SymbolResult symbolResult = null;
+            SymbolResult? symbolResult = null;
 
             if (children.Length > 1)
             {

--- a/src/System.CommandLine/Parsing/DirectiveNode.cs
+++ b/src/System.CommandLine/Parsing/DirectiveNode.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
             Token token,
             RootCommandNode parent,
             string name,
-            string value) : base(token, parent)
+            string? value) : base(token, parent)
         {
             if (token.Type != TokenType.Directive)
             {
@@ -22,6 +22,6 @@ namespace System.CommandLine.Parsing
 
         public string Name { get; }
 
-        public string Value { get; }
+        public string? Value { get; }
     }
 }

--- a/src/System.CommandLine/Parsing/ImplicitToken.cs
+++ b/src/System.CommandLine/Parsing/ImplicitToken.cs
@@ -5,11 +5,11 @@ namespace System.CommandLine.Parsing
 {
     internal class ImplicitToken : Token
     {
-        public ImplicitToken(object value, TokenType type) : base(value?.ToString(), type)
+        public ImplicitToken(object? value, TokenType type) : base(value?.ToString(), type)
         {
             ActualValue = value;
         }
 
-        public object ActualValue { get; }
+        public object? ActualValue { get; }
     }
 }

--- a/src/System.CommandLine/Parsing/NonterminalSyntaxNode.cs
+++ b/src/System.CommandLine/Parsing/NonterminalSyntaxNode.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
     {
         private readonly List<SyntaxNode> _children = new List<SyntaxNode>();
 
-        protected NonterminalSyntaxNode(Token token, SyntaxNode parent) : base(token, parent)
+        protected NonterminalSyntaxNode(Token token, SyntaxNode? parent) : base(token, parent)
         {
         }
 

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -46,7 +46,7 @@ namespace System.CommandLine.Parsing
         {
             get
             {
-                if (_argumentConversionResult == null)
+                if (_argumentConversionResult is null)
                 {
                     var results = Children
                                   .OfType<ArgumentResult>()

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -8,12 +8,12 @@ namespace System.CommandLine.Parsing
 {
     public class OptionResult : SymbolResult
     {
-        private ArgumentConversionResult _argumentConversionResult;
+        private ArgumentConversionResult? _argumentConversionResult;
 
         internal OptionResult(
             IOption option,
-            Token token = null,
-            CommandResult parent = null) :
+            Token? token = null,
+            CommandResult? parent = null) :
             base(option ?? throw new ArgumentNullException(nameof(option)),
                  parent)
         {
@@ -25,7 +25,7 @@ namespace System.CommandLine.Parsing
 
         public bool IsImplicit => Token is ImplicitToken || Token is null;
 
-        public Token Token { get; }
+        public Token? Token { get; }
 
         private protected override int RemainingArgumentCapacity
         {

--- a/src/System.CommandLine/Parsing/OptionResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/OptionResultExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Binding;
-using System.Linq;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.CommandLine.Parsing
 {
@@ -21,11 +21,12 @@ namespace System.CommandLine.Parsing
                                .ConvertIfNeeded(optionResult, type);
         }
 
-        public static object GetValueOrDefault(this OptionResult optionResult)
+        public static object? GetValueOrDefault(this OptionResult optionResult)
         {
-            return optionResult.GetValueOrDefault<object>();
+            return optionResult.GetValueOrDefault<object?>();
         }
 
+        [return:MaybeNull]
         public static T GetValueOrDefault<T>(this OptionResult optionResult)
         {
             return optionResult.ConvertIfNeeded(typeof(T))

--- a/src/System.CommandLine/Parsing/OptionResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/OptionResultExtensions.cs
@@ -26,7 +26,7 @@ namespace System.CommandLine.Parsing
             return optionResult.GetValueOrDefault<object?>();
         }
 
-        [return:MaybeNull]
+        [return: MaybeNull]
         public static T GetValueOrDefault<T>(this OptionResult optionResult)
         {
             return optionResult.ConvertIfNeeded(typeof(T))

--- a/src/System.CommandLine/Parsing/OptionResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/OptionResultExtensions.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Parsing
             this OptionResult optionResult,
             Type type)
         {
-            if (optionResult == null)
+            if (optionResult is null)
             {
                 throw new ArgumentNullException(nameof(optionResult));
             }

--- a/src/System.CommandLine/Parsing/ParseError.cs
+++ b/src/System.CommandLine/Parsing/ParseError.cs
@@ -7,7 +7,7 @@ namespace System.CommandLine.Parsing
     {
         internal ParseError(
             string message, 
-            SymbolResult symbolResult = null)
+            SymbolResult? symbolResult = null)
         {
             if (string.IsNullOrWhiteSpace(message))
             {
@@ -20,7 +20,7 @@ namespace System.CommandLine.Parsing
 
         public string Message { get; }
 
-        public SymbolResult SymbolResult { get; }
+        public SymbolResult? SymbolResult { get; }
 
         public override string ToString() => Message;
     }

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -95,7 +95,7 @@ namespace System.CommandLine.Parsing
                                     .Children
                                     .GetByAlias(CurrentToken.Value) as ICommand;
 
-            if (command == null)
+            if (command is null)
             {
                 return null;
             }
@@ -145,7 +145,7 @@ namespace System.CommandLine.Parsing
                                       .Arguments
                                       .FirstOrDefault(a => !IsFull(a));
 
-            if (argument == null)
+            if (argument is null)
             {
                 return null;
             }

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -26,7 +26,7 @@ namespace System.CommandLine.Parsing
 
         public List<ParseError> Errors { get; } = new List<ParseError>();
 
-        public RootCommandNode RootCommandNode { get; private set; }
+        public RootCommandNode? RootCommandNode { get; private set; }
 
         public List<Token> UnmatchedTokens { get; } = new List<Token>();
 
@@ -84,7 +84,7 @@ namespace System.CommandLine.Parsing
             return rootCommandNode;
         }
 
-        private CommandNode ParseSubcommand(CommandNode parentNode)
+        private CommandNode? ParseSubcommand(CommandNode parentNode)
         {
             if (CurrentToken.Type != TokenType.Command)
             {
@@ -119,10 +119,10 @@ namespace System.CommandLine.Parsing
                 }
 
                 var child = ParseSubcommand(parent) ??
-                            (SyntaxNode)ParseOption(parent) ??
+                            (SyntaxNode?)ParseOption(parent) ??
                             ParseCommandArgument(parent);
 
-                if (child == null)
+                if (child is null)
                 {
                     UnmatchedTokens.Add(CurrentToken);
                     Advance();
@@ -134,7 +134,7 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        private CommandArgumentNode ParseCommandArgument(CommandNode commandNode)
+        private CommandArgumentNode? ParseCommandArgument(CommandNode commandNode)
         {
             if (CurrentToken.Type != TokenType.Argument)
             {
@@ -162,14 +162,14 @@ namespace System.CommandLine.Parsing
             return argumentNode;
         }
 
-        private OptionNode ParseOption(CommandNode parent)
+        private OptionNode? ParseOption(CommandNode parent)
         {
             if (CurrentToken.Type != TokenType.Option)
             {
                 return null;
             }
 
-            OptionNode optionNode = null;
+            OptionNode? optionNode = null;
 
             if (parent.Command.Children.GetByAlias(CurrentToken.Value) is IOption option)
             {

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -19,8 +19,8 @@ namespace System.CommandLine.Parsing
             TokenizeResult tokenizeResult,
             IReadOnlyCollection<string> unparsedTokens,
             IReadOnlyCollection<string> unmatchedTokens,
-            List<ParseError> errors = null,
-            string rawInput = null)
+            List<ParseError>? errors = null,
+            string? rawInput = null)
         {
             Parser = parser;
             _rootCommandResult = rootCommandResult;
@@ -59,7 +59,7 @@ namespace System.CommandLine.Parsing
 
         public IReadOnlyCollection<string> UnmatchedTokens { get; }
 
-        internal string RawInput { get; }
+        internal string? RawInput { get; }
 
         public IReadOnlyCollection<string> UnparsedTokens { get; }
 
@@ -85,17 +85,17 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        public SymbolResult this[string alias] => CommandResult.Children[alias];
+        public SymbolResult? this[string alias] => CommandResult.Children[alias];
 
         public override string ToString() => $"{nameof(ParseResult)}: {this.Diagram()}";
 
-        public ArgumentResult FindResultFor(IArgument argument) =>
+        public ArgumentResult? FindResultFor(IArgument argument) =>
             _rootCommandResult.FindResultFor(argument);
             
-        public CommandResult FindResultFor(ICommand command) =>
+        public CommandResult? FindResultFor(ICommand command) =>
             _rootCommandResult.FindResultFor(command);
 
-        public OptionResult FindResultFor(IOption option) =>
+        public OptionResult? FindResultFor(IOption option) =>
             _rootCommandResult.FindResultFor(option);
     }
 }

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -81,7 +81,7 @@ namespace System.CommandLine.Parsing
             }
             else
             {
-                return default;
+                return default!;
             }
         }
 

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -64,13 +64,11 @@ namespace System.CommandLine.Parsing
 
         public IReadOnlyCollection<string> UnparsedTokens { get; }
 
-        public object? ValueForOption(
-            string alias) =>
+        public object? ValueForOption(string alias) =>
             ValueForOption<object?>(alias);
 
-        [return:MaybeNull]
-        public T ValueForOption<T>(
-            string alias)
+        [return: MaybeNull]
+        public T ValueForOption<T>(string alias)
         {
             if (string.IsNullOrWhiteSpace(alias))
             {
@@ -93,7 +91,7 @@ namespace System.CommandLine.Parsing
 
         public ArgumentResult? FindResultFor(IArgument argument) =>
             _rootCommandResult.FindResultFor(argument);
-            
+
         public CommandResult? FindResultFor(ICommand command) =>
             _rootCommandResult.FindResultFor(command);
 

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace System.CommandLine.Parsing
@@ -63,10 +64,11 @@ namespace System.CommandLine.Parsing
 
         public IReadOnlyCollection<string> UnparsedTokens { get; }
 
-        public object ValueForOption(
+        public object? ValueForOption(
             string alias) =>
-            ValueForOption<object>(alias);
+            ValueForOption<object?>(alias);
 
+        [return:MaybeNull]
         public T ValueForOption<T>(
             string alias)
         {

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -31,7 +31,7 @@ namespace System.CommandLine.Parsing
             var lastToken = source.Tokens.LastOrDefault(t => t.Type != TokenType.Directive);
 
             string? textToMatch = null;
-            var rawInput = source.RawInput;
+            string? rawInput = source.RawInput;
 
             if (rawInput != null)
             {
@@ -59,12 +59,12 @@ namespace System.CommandLine.Parsing
                 if (source.UnmatchedTokens.Any() ||
                     lastToken?.Type == TokenType.Argument)
                 {
-                    return textToMatch;
+                    return textToMatch ?? "";
                 }
             }
             else 
             {
-                var textBeforeCursor = rawInput.Substring(0, position.Value);
+                var textBeforeCursor = rawInput.Substring(0, position!.Value);
 
                 var textAfterCursor = rawInput.Substring(position.Value);
 
@@ -206,7 +206,7 @@ namespace System.CommandLine.Parsing
             return parseResult.CommandResult.Children.Contains(alias);
         }
 
-        public static IEnumerable<string> GetSuggestions(
+        public static IEnumerable<string?> GetSuggestions(
             this ParseResult parseResult,
             int? position = null)
         {
@@ -219,13 +219,13 @@ namespace System.CommandLine.Parsing
                     ? currentSuggestionSource.GetSuggestions(textToMatch)
                     : Array.Empty<string>();
 
-            IEnumerable<string> siblingSuggestions;
+            IEnumerable<string?> siblingSuggestions;
             var parentSymbol = currentSymbolResult.Parent?.Symbol;
 
             if (parentSymbol == null ||
                 !currentSymbolResult.IsArgumentLimitReached)
             {
-                siblingSuggestions = Array.Empty<string>();
+                siblingSuggestions = Array.Empty<string?>();
             }
             else
             {

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -28,7 +28,7 @@ namespace System.CommandLine.Parsing
             this ParseResult source,
             int? position = null)
         {
-            var lastToken = source.Tokens.LastOrDefault(t => t.Type != TokenType.Directive);
+            Token? lastToken = source.Tokens.LastOrDefault(t => t.Type != TokenType.Directive);
 
             string? textToMatch = null;
             string? rawInput = source.RawInput;
@@ -186,7 +186,7 @@ namespace System.CommandLine.Parsing
             this ParseResult parseResult,
             IOption option)
         {
-            if (parseResult == null)
+            if (parseResult is null)
             {
                 throw new ArgumentNullException(nameof(parseResult));
             }
@@ -198,7 +198,7 @@ namespace System.CommandLine.Parsing
             this ParseResult parseResult,
             string alias)
         {
-            if (parseResult == null)
+            if (parseResult is null)
             {
                 throw new ArgumentNullException(nameof(parseResult));
             }
@@ -222,7 +222,7 @@ namespace System.CommandLine.Parsing
             IEnumerable<string?> siblingSuggestions;
             var parentSymbol = currentSymbolResult.Parent?.Symbol;
 
-            if (parentSymbol == null ||
+            if (parentSymbol is null ||
                 !currentSymbolResult.IsArgumentLimitReached)
             {
                 siblingSuggestions = Array.Empty<string?>();

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -16,12 +16,12 @@ namespace System.CommandLine.Parsing
     {
         public static async Task<int> InvokeAsync(
             this ParseResult parseResult,
-            IConsole console = null) =>
+            IConsole? console = null) =>
             await new InvocationPipeline(parseResult).InvokeAsync(console);
 
         public static int Invoke(
             this ParseResult parseResult,
-            IConsole console = null) =>
+            IConsole? console = null) =>
             new InvocationPipeline(parseResult).Invoke(console);
 
         public static string TextToMatch(
@@ -30,7 +30,7 @@ namespace System.CommandLine.Parsing
         {
             var lastToken = source.Tokens.LastOrDefault(t => t.Type != TokenType.Directive);
 
-            string textToMatch = null;
+            string? textToMatch = null;
             var rawInput = source.RawInput;
 
             if (rawInput != null)

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -64,7 +64,7 @@ namespace System.CommandLine.Parsing
             }
             else 
             {
-                var textBeforeCursor = rawInput.Substring(0, position!.Value);
+                var textBeforeCursor = rawInput!.Substring(0, position!.Value);
 
                 var textAfterCursor = rawInput.Substring(position.Value);
 

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -12,15 +12,15 @@ namespace System.CommandLine.Parsing
     {
         private readonly Parser _parser;
         private readonly TokenizeResult _tokenizeResult;
-        private readonly string _rawInput;
+        private readonly string? _rawInput;
 
         private readonly DirectiveCollection _directives = new DirectiveCollection();
         private readonly List<string> _unparsedTokens;
         private readonly List<string> _unmatchedTokens;
         private readonly List<ParseError> _errors;
 
-        private RootCommandResult _rootCommandResult;
-        private CommandResult _innermostCommandResult;
+        private RootCommandResult? _rootCommandResult;
+        private CommandResult? _innermostCommandResult;
 
         public ParseResultVisitor(
             Parser parser,
@@ -28,7 +28,7 @@ namespace System.CommandLine.Parsing
             IReadOnlyCollection<Token> unparsedTokens,
             IReadOnlyCollection<Token> unmatchedTokens,
             IReadOnlyCollection<ParseError> parseErrors,
-            string rawInput)
+            string? rawInput)
         {
             _parser = parser;
             _tokenizeResult = tokenizeResult;
@@ -124,9 +124,9 @@ namespace System.CommandLine.Parsing
             var argument = argumentNode.Argument;
 
             var argumentResult =
-                (ArgumentResult)optionResult.Children.ResultFor(argument);
+                (ArgumentResult?)optionResult.Children.ResultFor(argument);
 
-            if (argumentResult == null)
+            if (argumentResult is null)
             {
                 argumentResult =
                     new ArgumentResult(
@@ -198,7 +198,7 @@ namespace System.CommandLine.Parsing
             {
                 if (option is Option o &&
                     o.Required && 
-                    _rootCommandResult.FindResultFor(o) == null)
+                    _rootCommandResult.FindResultFor(o) is null)
                 {
                     _errors.Add(
                         new ParseError($"Option '{o.RawAliases.First()}' is required.",
@@ -320,7 +320,7 @@ namespace System.CommandLine.Parsing
                 {
                     var symbolResult = _rootCommandResult.FindResultFor(symbol);
 
-                    if (symbolResult == null)
+                    if (symbolResult is null)
                     {
                         switch (symbol)
                         {

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -68,7 +68,7 @@ namespace System.CommandLine.Parsing
                 commandNode.Token,
                 _innermostCommandResult);
 
-            _innermostCommandResult
+            _innermostCommandResult!
                 .Children
                 .Add(commandResult);
 
@@ -81,7 +81,7 @@ namespace System.CommandLine.Parsing
             var commandResult = _innermostCommandResult;
 
             var argumentResult =
-                commandResult.Children
+                commandResult!.Children
                              .OfType<ArgumentResult>()
                              .SingleOrDefault(r => r.Symbol == argumentNode.Argument);
 
@@ -101,7 +101,7 @@ namespace System.CommandLine.Parsing
 
         protected override void VisitOptionNode(OptionNode optionNode)
         {
-            if (_innermostCommandResult.Children.ResultFor(optionNode.Option) == null)
+            if (_innermostCommandResult!.Children.ResultFor(optionNode.Option) == null)
             {
                 var optionResult = new OptionResult(
                     optionNode.Option,
@@ -119,12 +119,12 @@ namespace System.CommandLine.Parsing
         {
             var option = argumentNode.ParentOptionNode.Option;
 
-            var optionResult = _innermostCommandResult.Children.ResultFor(option);
+            var optionResult = _innermostCommandResult!.Children.ResultFor(option);
 
             var argument = argumentNode.Argument;
 
             var argumentResult =
-                (ArgumentResult?)optionResult.Children.ResultFor(argument);
+                (ArgumentResult?)optionResult!.Children.ResultFor(argument);
 
             if (argumentResult is null)
             {
@@ -157,7 +157,7 @@ namespace System.CommandLine.Parsing
 
             ValidateCommandResult();
 
-            foreach (var result in _innermostCommandResult.Children.ToArray())
+            foreach (var result in _innermostCommandResult!.Children.ToArray())
             {
                 switch (result)
                 {
@@ -178,7 +178,7 @@ namespace System.CommandLine.Parsing
 
         private void ValidateCommandResult()
         {
-            if (_innermostCommandResult.Command is Command command)
+            if (_innermostCommandResult!.Command is Command command)
             {
                 foreach (var validator in command.Validators)
                 {
@@ -198,7 +198,7 @@ namespace System.CommandLine.Parsing
             {
                 if (option is Option o &&
                     o.Required && 
-                    _rootCommandResult.FindResultFor(o) is null)
+                    _rootCommandResult!.FindResultFor(o) is null)
                 {
                     _errors.Add(
                         new ParseError($"Option '{o.RawAliases.First()}' is required.",
@@ -219,14 +219,14 @@ namespace System.CommandLine.Parsing
                 if (arityFailure != null)
                 {
                     _errors.Add(
-                        new ParseError(arityFailure.ErrorMessage, _innermostCommandResult));
+                        new ParseError(arityFailure.ErrorMessage!, _innermostCommandResult));
                 }
             }
         }
 
         private void ValidateCommandHandler()
         {
-            if (!(_innermostCommandResult.Command is Command cmd) || 
+            if (!(_innermostCommandResult!.Command is Command cmd) || 
                 cmd.Handler != null)
             {
                 return;
@@ -261,7 +261,7 @@ namespace System.CommandLine.Parsing
             if (arityFailure != null)
             {
                 _errors.Add(
-                    new ParseError(arityFailure.ErrorMessage, optionResult));
+                    new ParseError(arityFailure.ErrorMessage!, optionResult));
             }
 
             if (optionResult.Option is Option option)
@@ -290,7 +290,7 @@ namespace System.CommandLine.Parsing
             if (argumentResult.Argument is Argument argument)
             {
                 var parseError =
-                    argumentResult.Parent.UnrecognizedArgumentError(argument) ??
+                    argumentResult.Parent?.UnrecognizedArgumentError(argument) ??
                     argumentResult.CustomError(argument);
 
                 if (parseError != null)
@@ -304,21 +304,21 @@ namespace System.CommandLine.Parsing
             {
                 _errors.Add(
                     new ParseError(
-                        failed.ErrorMessage,
+                        failed.ErrorMessage!,
                         argumentResult));
             }
         }
 
         private void PopulateDefaultValues()
         {
-            var commandResults = _innermostCommandResult
+            var commandResults = _innermostCommandResult!
                 .RecurseWhileNotNull(c => c.Parent as CommandResult);
 
             foreach (var commandResult in commandResults)
             {
                 foreach (var symbol in commandResult.Command.Children)
                 {
-                    var symbolResult = _rootCommandResult.FindResultFor(symbol);
+                    var symbolResult = _rootCommandResult!.FindResultFor(symbol);
 
                     if (symbolResult is null)
                     {
@@ -367,8 +367,8 @@ namespace System.CommandLine.Parsing
         public ParseResult Result =>
             new ParseResult(
                 _parser,
-                _rootCommandResult,
-                _innermostCommandResult,
+                _rootCommandResult ?? throw new InvalidOperationException(),
+                _innermostCommandResult ?? throw new InvalidOperationException(),
                 _directives,
                 _tokenizeResult,
                 _unparsedTokens,

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -370,8 +370,8 @@ namespace System.CommandLine.Parsing
         public ParseResult Result =>
             new ParseResult(
                 _parser,
-                _rootCommandResult ?? throw new InvalidOperationException(),
-                _innermostCommandResult ?? throw new InvalidOperationException(),
+                _rootCommandResult ?? throw new InvalidOperationException("No root command was found"),
+                _innermostCommandResult ?? throw new InvalidOperationException("No command was found"),
                 _directives,
                 _tokenizeResult,
                 _unparsedTokens,

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.CommandLine.Binding;
 using System.CommandLine.Help;
+using System.Diagnostics;
 using System.Linq;
 
 namespace System.CommandLine.Parsing
@@ -68,6 +69,8 @@ namespace System.CommandLine.Parsing
                 commandNode.Token,
                 _innermostCommandResult);
 
+            Debug.Assert(_innermostCommandResult != null);
+
             _innermostCommandResult!
                 .Children
                 .Add(commandResult);
@@ -85,7 +88,7 @@ namespace System.CommandLine.Parsing
                              .OfType<ArgumentResult>()
                              .SingleOrDefault(r => r.Symbol == argumentNode.Argument);
 
-            if (argumentResult == null)
+            if (argumentResult is null)
             {
                 argumentResult =
                     new ArgumentResult(
@@ -101,7 +104,7 @@ namespace System.CommandLine.Parsing
 
         protected override void VisitOptionNode(OptionNode optionNode)
         {
-            if (_innermostCommandResult!.Children.ResultFor(optionNode.Option) == null)
+            if (_innermostCommandResult!.Children.ResultFor(optionNode.Option) is null)
             {
                 var optionResult = new OptionResult(
                     optionNode.Option,

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -187,7 +187,7 @@ namespace System.CommandLine.Parsing
                     if (!string.IsNullOrWhiteSpace(errorMessage))
                     {
                         _errors.Add(
-                            new ParseError(errorMessage, _innermostCommandResult));
+                            new ParseError(errorMessage!, _innermostCommandResult));
                     }
                 }
             }
@@ -272,7 +272,7 @@ namespace System.CommandLine.Parsing
 
                     if (!string.IsNullOrWhiteSpace(message))
                     {
-                        _errors.Add(new ParseError(message, optionResult));
+                        _errors.Add(new ParseError(message!, optionResult));
                     }
                 }
             }

--- a/src/System.CommandLine/Parsing/Parser.cs
+++ b/src/System.CommandLine/Parsing/Parser.cs
@@ -42,7 +42,7 @@ namespace System.CommandLine.Parsing
                 operation.Errors,
                 rawInput);
 
-            visitor.Visit(operation.RootCommandNode);
+            visitor.Visit(operation.RootCommandNode!);
 
             return visitor.Result;
         }

--- a/src/System.CommandLine/Parsing/Parser.cs
+++ b/src/System.CommandLine/Parsing/Parser.cs
@@ -24,7 +24,7 @@ namespace System.CommandLine.Parsing
 
         public ParseResult Parse(
             IReadOnlyList<string> arguments,
-            string rawInput = null)
+            string? rawInput = null)
         {
             var tokenizeResult = arguments.Tokenize(Configuration);
 

--- a/src/System.CommandLine/Parsing/ParserExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParserExtensions.cs
@@ -11,25 +11,25 @@ namespace System.CommandLine.Parsing
         public static int Invoke(
             this Parser parser,
             string commandLine,
-            IConsole console = null) =>
+            IConsole? console = null) =>
             parser.Invoke(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console);
 
         public static int Invoke(
             this Parser parser,
             string[] args,
-            IConsole console = null) =>
+            IConsole? console = null) =>
             parser.Parse(args).Invoke(console);
 
         public static Task<int> InvokeAsync(
             this Parser parser,
             string commandLine,
-            IConsole console = null) =>
+            IConsole? console = null) =>
             parser.InvokeAsync(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console);
 
         public static async Task<int> InvokeAsync(
             this Parser parser,
             string[] args,
-            IConsole console = null) =>
+            IConsole? console = null) =>
             await parser.Parse(args).InvokeAsync(console);
 
         public static ParseResult Parse(

--- a/src/System.CommandLine/Parsing/RootCommandResult.cs
+++ b/src/System.CommandLine/Parsing/RootCommandResult.cs
@@ -7,9 +7,9 @@ namespace System.CommandLine.Parsing
 {
     internal class RootCommandResult : CommandResult
     {
-        private Dictionary<IArgument, ArgumentResult> _allArgumentResults;
-        private Dictionary<ICommand, CommandResult> _allCommandResults;
-        private Dictionary<IOption, OptionResult> _allOptionResults;
+        private Dictionary<IArgument, ArgumentResult>? _allArgumentResults;
+        private Dictionary<ICommand, CommandResult>? _allCommandResults;
+        private Dictionary<IOption, OptionResult>? _allOptionResults;
 
         public RootCommandResult(
             ICommand command,
@@ -47,34 +47,34 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        public ArgumentResult FindResultFor(IArgument argument)
+        public ArgumentResult? FindResultFor(IArgument argument)
         {
             EnsureResultMapsAreInitialized();
 
-            _allArgumentResults.TryGetValue(argument, out var result);
+            _allArgumentResults!.TryGetValue(argument, out var result);
 
             return result;
         }
 
-        public CommandResult FindResultFor(ICommand command)
+        public CommandResult? FindResultFor(ICommand command)
         {
             EnsureResultMapsAreInitialized();
 
-            _allCommandResults.TryGetValue(command, out var result);
+            _allCommandResults!.TryGetValue(command, out var result);
 
             return result;
         }
 
-        public OptionResult FindResultFor(IOption option)
+        public OptionResult? FindResultFor(IOption option)
         {
             EnsureResultMapsAreInitialized();
 
-            _allOptionResults.TryGetValue(option, out var result);
+            _allOptionResults!.TryGetValue(option, out var result);
 
             return result;
         }
 
-        public SymbolResult FindResultFor(ISymbol symbol)
+        public SymbolResult? FindResultFor(ISymbol symbol)
         {
             switch (symbol)
             {

--- a/src/System.CommandLine/Parsing/RootCommandResult.cs
+++ b/src/System.CommandLine/Parsing/RootCommandResult.cs
@@ -84,26 +84,28 @@ namespace System.CommandLine.Parsing
                     return FindResultFor(command);
                 case IOption option:
                     return FindResultFor(option);
-                default: 
+                default:
                     throw new ArgumentException($"Unsupported symbol type: {symbol.GetType()}");
             }
         }
 
         internal void AddToSymbolMap(SymbolResult result)
         {
-             switch (result)
+            EnsureResultMapsAreInitialized();
+
+            switch (result)
             {
                 case ArgumentResult argumentResult:
-                    _allArgumentResults.Add(argumentResult.Argument, argumentResult);
+                    _allArgumentResults!.Add(argumentResult.Argument, argumentResult);
                     break;
                 case CommandResult commandResult:
-                    _allCommandResults.Add(commandResult.Command, commandResult);
+                    _allCommandResults!.Add(commandResult.Command, commandResult);
                     break;
                 case OptionResult optionResult:
-                    _allOptionResults.Add(optionResult.Option, optionResult);
+                    _allOptionResults!.Add(optionResult.Option, optionResult);
                     break;
-                
-                default: 
+
+                default:
                     throw new ArgumentException($"Unsupported {nameof(SymbolResult)} type: {result.GetType()}");
             }
         }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -318,9 +318,9 @@ namespace System.CommandLine.Parsing
 
         private static List<string> NormalizeRootCommand(
             CommandLineConfiguration commandLineConfiguration, 
-            IReadOnlyList<string> args)
+            IReadOnlyList<string>? args)
         {
-            if (args == null)
+            if (args is null)
             {
                 args = new List<string>();
             }
@@ -367,7 +367,7 @@ namespace System.CommandLine.Parsing
 
             bool FirstArgMatchesRootCommand()
             {
-                if (potentialRootCommand == null)
+                if (potentialRootCommand is null)
                 {
                     return false;
                 }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -16,12 +16,12 @@ namespace System.CommandLine.Parsing
 
         internal static bool ContainsCaseInsensitive(
             this string source,
-            string value) =>
+            string? value) =>
             source.IndexOfCaseInsensitive(value) >= 0;
 
         internal static int IndexOfCaseInsensitive(
             this string source,
-            string value) =>
+            string? value) =>
             CultureInfo.InvariantCulture
                        .CompareInfo
                        .IndexOf(source,
@@ -176,7 +176,7 @@ namespace System.CommandLine.Parsing
 
             return new TokenizeResult(tokenList, errorList);
 
-            bool CanBeUnbundled(string arg, out IReadOnlyList<string> replacement)
+            bool CanBeUnbundled(string arg, out IEnumerable<string>? replacement)
             {
                 replacement = null;
 

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Collections;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -114,7 +113,7 @@ namespace System.CommandLine.Parsing
                 }
 
                 if (configuration.EnablePosixBundling && 
-                         CanBeUnbundled(arg, out var replacement))
+                    CanBeUnbundled(arg, out IEnumerable<string>? replacement))
                 {
                     argList.InsertRange(i + 1, replacement);
                     argList.RemoveAt(i);
@@ -167,7 +166,7 @@ namespace System.CommandLine.Parsing
                             symbolSet = configuration.Symbols;
                         }
 
-                        currentCommand = (ICommand) symbolSet.GetByAlias(arg);
+                        currentCommand = (ICommand) symbolSet.GetByAlias(arg)!;
                         knownTokens = currentCommand.ValidTokens();
                         knownTokensStrings = new HashSet<string>(knownTokens.Select(t => t.Value));
                         tokenList.Add(Command(arg));
@@ -195,7 +194,7 @@ namespace System.CommandLine.Parsing
                 return prefix == "-" && 
                        TryUnbundle(alias, out replacement);
 
-                Token TokenForOptionAlias(char c) =>
+                Token? TokenForOptionAlias(char c) =>
                     argumentDelimiters.Contains(c) 
                     ? null
                     : knownTokens.FirstOrDefault(t => 
@@ -339,7 +338,8 @@ namespace System.CommandLine.Parsing
                     // possible exception for illegal characters in path on .NET Framework
                 }
 
-                if (commandLineConfiguration.RootCommand.HasRawAlias(potentialRootCommand))
+                if (potentialRootCommand != null &&
+                    commandLineConfiguration.RootCommand.HasRawAlias(potentialRootCommand))
                 {
                     return args.ToList();
                 }
@@ -406,7 +406,7 @@ namespace System.CommandLine.Parsing
             int i = 0;
             bool addDash = false;
 
-            // handles beginning of string, breaks onfirst letter or digit. addDash might be better named "canAddDash"
+            // handles beginning of string, breaks on first letter or digit. addDash might be better named "canAddDash"
             for (; i < value.Length; i++)
             {
                 char ch = value[i];

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -41,7 +42,7 @@ namespace System.CommandLine.Parsing
             return rawAlias;
         }
 
-        internal static (string prefix, string alias) SplitPrefix(this string rawAlias)
+        internal static (string? prefix, string alias) SplitPrefix(this string rawAlias)
         {
             foreach (var prefix in _optionPrefixStrings)
             {
@@ -61,7 +62,7 @@ namespace System.CommandLine.Parsing
             var tokenList = new List<Token>();
             var errorList = new List<TokenizeError>();
 
-            ICommand currentCommand = null;
+            ICommand? currentCommand = null;
             var foundEndOfArguments = false;
             var foundEndOfDirectives = !configuration.EnableDirectives;
             var argList = NormalizeRootCommand(configuration, args);
@@ -213,7 +214,7 @@ namespace System.CommandLine.Parsing
                     }
                 }
                 
-                bool TryUnbundle(string arg, out IReadOnlyList<string> replacement)
+                bool TryUnbundle(string arg, out IEnumerable<string>? replacement)
                 {
                     if (arg == string.Empty)
                     {
@@ -226,7 +227,7 @@ namespace System.CommandLine.Parsing
                     for (var i = 0; i < arg.Length; i++)
                     {
                         var token = TokenForOptionAlias(arg[i]);
-                        if (token == null)
+                        if (token is null)
                         {
                             if (lastTokenHasArgument)
                             {
@@ -325,7 +326,7 @@ namespace System.CommandLine.Parsing
                 args = new List<string>();
             }
 
-            string potentialRootCommand = null;
+            string? potentialRootCommand = null;
 
             if (args.Count > 0)
             {
@@ -385,7 +386,7 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        private static string GetResponseFileReference(this string arg) =>
+        private static string? GetResponseFileReference(this string arg) =>
             arg.StartsWith("@") && arg.Length > 1
                 ? arg.Substring(1)
                 : null;

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine.Parsing
 
         private protected SymbolResult(
             ISymbol symbol, 
-            SymbolResult parent)
+            SymbolResult? parent)
         {
             Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
 
@@ -25,7 +25,7 @@ namespace System.CommandLine.Parsing
 
         public SymbolResultSet Children { get; } = new SymbolResultSet();
 
-        public SymbolResult Parent { get; }
+        public SymbolResult? Parent { get; }
 
         public ISymbol Symbol { get; }
 

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
     public abstract class SymbolResult
     {
         private protected readonly List<Token> _tokens = new List<Token>();
-        private ValidationMessages _validationMessages;
+        private ValidationMessages? _validationMessages;
         private readonly Dictionary<IArgument, ArgumentResult> _defaultArgumentValues = new Dictionary<IArgument, ArgumentResult>();
 
         private protected SymbolResult(
@@ -21,7 +21,7 @@ namespace System.CommandLine.Parsing
             Parent = parent;
         }
 
-        public string ErrorMessage { get; set; }
+        public string? ErrorMessage { get; set; }
 
         public SymbolResultSet Children { get; } = new SymbolResultSet();
 
@@ -89,7 +89,7 @@ namespace System.CommandLine.Parsing
 
         public override string ToString() => $"{GetType().Name}: {this.Token()}";
 
-        internal ParseError UnrecognizedArgumentError(Argument argument)
+        internal ParseError? UnrecognizedArgumentError(Argument argument)
         {
             if (argument.AllowedValues?.Count > 0 &&
                 Tokens.Count > 0)

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -44,9 +44,9 @@ namespace System.CommandLine.Parsing
         {
             get
             {
-                if (_validationMessages == null)
+                if (_validationMessages is null)
                 {
-                    if (Parent == null)
+                    if (Parent is null)
                     {
                         _validationMessages = ValidationMessages.Instance;
                     }

--- a/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Parsing
     {
         internal static IEnumerable<SymbolResult> AllSymbolResults(this SymbolResult symbolResult)
         {
-            if (symbolResult == null)
+            if (symbolResult is null)
             {
                 throw new ArgumentNullException(nameof(symbolResult));
             }

--- a/src/System.CommandLine/Parsing/SymbolResultSet.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultSet.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
 {
     public class SymbolResultSet : AliasedSet<SymbolResult>
     {
-        internal SymbolResult ResultFor(ISymbol symbol) =>
+        internal SymbolResult? ResultFor(ISymbol symbol) =>
             Items.SingleOrDefault(i => i.Symbol == symbol);
 
         protected override IReadOnlyList<string> GetAliases(SymbolResult item) =>

--- a/src/System.CommandLine/Parsing/SyntaxNode.cs
+++ b/src/System.CommandLine/Parsing/SyntaxNode.cs
@@ -7,13 +7,13 @@ namespace System.CommandLine.Parsing
     {
         protected SyntaxNode(
             Token token,
-            SyntaxNode parent)
+            SyntaxNode? parent)
         {
             Token = token;
             Parent = parent;
         }
 
-        public SyntaxNode Parent { get; }
+        public SyntaxNode? Parent { get; }
 
         public Token Token { get; }
 

--- a/src/System.CommandLine/Parsing/Token.cs
+++ b/src/System.CommandLine/Parsing/Token.cs
@@ -7,7 +7,7 @@ namespace System.CommandLine.Parsing
 {
     public class Token
     {
-        public Token(string value, TokenType type)
+        public Token(string? value, TokenType type)
         {
             Value = value ?? "";
             Type = type;

--- a/src/System.CommandLine/Parsing/ValidateSymbol.cs
+++ b/src/System.CommandLine/Parsing/ValidateSymbol.cs
@@ -3,6 +3,6 @@
 
 namespace System.CommandLine.Parsing
 {
-    public delegate string ValidateSymbol<in T>(T symbolResult) 
+    public delegate string? ValidateSymbol<in T>(T symbolResult) 
         where T : SymbolResult;
 }

--- a/src/System.CommandLine/Platform.cs
+++ b/src/System.CommandLine/Platform.cs
@@ -8,7 +8,7 @@
         {
             get
             {
-                if (_isConsoleRedirectionCheckSupported == null)
+                if (_isConsoleRedirectionCheckSupported is null)
                 {
                     try
                     {

--- a/src/System.CommandLine/Suggestions/AnonymousSuggestionSource.cs
+++ b/src/System.CommandLine/Suggestions/AnonymousSuggestionSource.cs
@@ -7,16 +7,16 @@ namespace System.CommandLine.Suggestions
 {
     internal class AnonymousSuggestionSource : ISuggestionSource
     {
-        private readonly Suggest suggest;
+        private readonly Suggest _suggest;
 
         public AnonymousSuggestionSource(Suggest suggest)
         {
-            this.suggest = suggest;
+            _suggest = suggest ?? throw new ArgumentNullException(nameof(suggest));
         }
 
-        public IEnumerable<string> GetSuggestions(string textToMatch = null)
+        public IEnumerable<string> GetSuggestions(string? textToMatch = null)
         {
-            return suggest(textToMatch);
+            return _suggest(textToMatch);
         }
     }
 }

--- a/src/System.CommandLine/Suggestions/ISuggestionSource.cs
+++ b/src/System.CommandLine/Suggestions/ISuggestionSource.cs
@@ -7,6 +7,6 @@ namespace System.CommandLine.Suggestions
 {
     public interface ISuggestionSource
     {
-        IEnumerable<string> GetSuggestions(string? textToMatch = null);
+        IEnumerable<string?> GetSuggestions(string? textToMatch = null);
     }
 }

--- a/src/System.CommandLine/Suggestions/ISuggestionSource.cs
+++ b/src/System.CommandLine/Suggestions/ISuggestionSource.cs
@@ -7,6 +7,6 @@ namespace System.CommandLine.Suggestions
 {
     public interface ISuggestionSource
     {
-        IEnumerable<string> GetSuggestions(string textToMatch = null);
+        IEnumerable<string> GetSuggestions(string? textToMatch = null);
     }
 }

--- a/src/System.CommandLine/Suggestions/Suggest.cs
+++ b/src/System.CommandLine/Suggestions/Suggest.cs
@@ -5,5 +5,5 @@ using System.Collections.Generic;
 
 namespace System.CommandLine.Suggestions
 {
-    public delegate IEnumerable<string> Suggest(string textToMatch);
+    public delegate IEnumerable<string> Suggest(string? textToMatch);
 }

--- a/src/System.CommandLine/Suggestions/Suggestions.cs
+++ b/src/System.CommandLine/Suggestions/Suggestions.cs
@@ -9,9 +9,9 @@ namespace System.CommandLine.Suggestions
 {
     internal static class SuggestionExtensions
     {
-        public static IEnumerable<string> Containing(
-            this IEnumerable<string> candidates,
-            string textToMatch) =>
-            candidates.Where(c => c.ContainsCaseInsensitive(textToMatch));
+        public static IEnumerable<string?> Containing(
+            this IEnumerable<string?> candidates,
+            string? textToMatch) =>
+            candidates.Where(c => c?.ContainsCaseInsensitive(textToMatch) == true);
     }
 }

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -95,7 +95,7 @@ namespace System.CommandLine
 
         public SymbolSet Children { get; } = new SymbolSet();
 
-        public void AddAlias(string alias)
+        public void AddAlias(string? alias)
         {
             var unprefixedAlias = alias?.RemovePrefix();
 
@@ -135,7 +135,7 @@ namespace System.CommandLine
 
         public bool IsHidden { get; set; }
 
-        public virtual IEnumerable<string> GetSuggestions(string? textToMatch = null)
+        public virtual IEnumerable<string?> GetSuggestions(string? textToMatch = null)
         {
             var argumentSuggestions =
                 Children

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -78,7 +78,7 @@ namespace System.CommandLine
 
         private protected void AddArgumentInner(Argument argument)
         {
-            if (argument == null)
+            if (argument is null)
             {
                 throw new ArgumentNullException(nameof(argument));
             }

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -147,7 +147,8 @@ namespace System.CommandLine
                        .Concat(argumentSuggestions)
                        .Distinct()
                        .Containing(textToMatch)
-                       .OrderBy(symbol => symbol.IndexOfCaseInsensitive(textToMatch))
+                       .Where(symbol => symbol != null)
+                       .OrderBy(symbol => symbol!.IndexOfCaseInsensitive(textToMatch))
                        .ThenBy(symbol => symbol, StringComparer.OrdinalIgnoreCase);
         }
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -95,7 +95,7 @@ namespace System.CommandLine
 
         public SymbolSet Children { get; } = new SymbolSet();
 
-        public void AddAlias(string? alias)
+        public void AddAlias(string alias)
         {
             var unprefixedAlias = alias?.RemovePrefix();
 
@@ -113,9 +113,9 @@ namespace System.CommandLine
             }
 
             _rawAliases.Add(alias);
-            _aliases.Add(unprefixedAlias);
+            _aliases.Add(unprefixedAlias!);
 
-            if (unprefixedAlias.Length > Name?.Length)
+            if (unprefixedAlias!.Length > Name?.Length)
             {
                 _longestAlias = unprefixedAlias;
             }

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine
         private readonly List<string> _aliases = new List<string>();
         private readonly List<string> _rawAliases = new List<string>();
         private string _longestAlias = "";
-        private string _specifiedName;
+        private string? _specifiedName;
 
         private readonly SymbolSet _parents = new SymbolSet();
 
@@ -23,10 +23,10 @@ namespace System.CommandLine
         }
 
         protected Symbol(
-            IReadOnlyCollection<string> aliases = null,
-            string description = null)
+            IReadOnlyCollection<string>? aliases = null,
+            string? description = null)
         {
-            if (aliases == null)
+            if (aliases is null)
             {
                 throw new ArgumentNullException(nameof(aliases));
             }
@@ -48,7 +48,7 @@ namespace System.CommandLine
 
         public IReadOnlyList<string> RawAliases => _rawAliases;
 
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         public virtual string Name
         {
@@ -104,7 +104,7 @@ namespace System.CommandLine
                 throw new ArgumentException("An alias cannot be null, empty, or consist entirely of whitespace.");
             }
 
-            for (var i = 0; i < alias.Length; i++)
+            for (var i = 0; i < alias!.Length; i++)
             {
                 if (char.IsWhiteSpace(alias[i]))
                 {
@@ -135,7 +135,7 @@ namespace System.CommandLine
 
         public bool IsHidden { get; set; }
 
-        public virtual IEnumerable<string> GetSuggestions(string textToMatch = null)
+        public virtual IEnumerable<string> GetSuggestions(string? textToMatch = null)
         {
             var argumentSuggestions =
                 Children

--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>System.CommandLine</PackageId>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
     <Description>This package includes a powerful command line parser and other tools for building command line applications, including:
@@ -18,6 +18,10 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugType>portable</DebugType>
   </PropertyGroup>
+   
+  <ItemGroup>
+    <Compile Include="..\System.Diagnostics.CodeAnalysis.cs" Link="System.Diagnostics.CodeAnalysis.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />

--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <PackageId>System.CommandLine</PackageId>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>
     <Description>This package includes a powerful command line parser and other tools for building command line applications, including:

--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -5,6 +5,7 @@
     <PackageId>System.CommandLine</PackageId>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
     <Description>This package includes a powerful command line parser and other tools for building command line applications, including:
     
     * Shell-agnostic support for command line completions

--- a/src/System.Diagnostics.CodeAnalysis.cs
+++ b/src/System.Diagnostics.CodeAnalysis.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma warning disable CA1801, CA1822
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class AllowNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+    internal sealed class DisallowNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        public DoesNotReturnIfAttribute(bool parameterValue) { }
+
+        public bool ParameterValue { get { throw null!; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Constructor | AttributeTargets.Event | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
+    internal sealed class ExcludeFromCodeCoverageAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class MaybeNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue) { }
+
+        public bool ReturnValue { get { throw null!; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+    internal sealed class NotNullAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        public NotNullIfNotNullAttribute(string parameterName) { }
+
+        public string ParameterName { get { throw null!; } }
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue) { }
+
+        public bool ReturnValue { get { throw null!; } }
+    }
+}


### PR DESCRIPTION
Starting work on handling C# 8 nullable reference types.

The current work only handles it in the core library. 

Outstanding TODO items:

- [x] Conditionally include nullable reference type attributes to support `net462`
- [x] Confirm upgrade to netstandard2.1 is acceptable. This is not explicitly needed since we will already be including attributes.
- [x] Handle possible `null` setter values on `Argument.ArgumentType`
- [x] `ParseResultVisitor.Result` currently throws `InvalidOperationException`. What should the error messages be for these?
- [x] `ErrorMessage` on `*Result` classes is declared as nullable, because some localization implementation could in theory return a null. Currently explicitly ignoring with null forgiveness operator.