### PR TITLE
Updating ArgumentArity.ZeroOrMore and OneOrMore to have int.MaxValue as the maximum number

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -73,11 +73,11 @@ namespace System.CommandLine.DragonFruit.Tests
         [InlineData(nameof(Method_having_string_argument), 1, 1)]
         [InlineData(nameof(Method_having_string_argument_with_null_default_value), 0, 1)]
         [InlineData(nameof(Method_having_string_argument_with_non_null_default_value), 0, 1)]
-        [InlineData(nameof(Method_having_string_array_arguments), 0, byte.MaxValue)]
-        [InlineData(nameof(Method_having_string_array_arguments_with_default_value), 0, byte.MaxValue)]
+        [InlineData(nameof(Method_having_string_array_arguments), 0, int.MaxValue)]
+        [InlineData(nameof(Method_having_string_array_arguments_with_default_value), 0, int.MaxValue)]
         [InlineData(nameof(Method_having_FileInfo_argument), 1, 1)]
         [InlineData(nameof(Method_having_FileInfo_argument_with_default_value), 0, 1)]
-        [InlineData(nameof(Method_having_FileInfo_array_args), 0, byte.MaxValue)]
+        [InlineData(nameof(Method_having_FileInfo_array_args), 0, int.MaxValue)]
         public void Parameters_named_arguments_generate_command_arguments_having_the_correct_arity(
             string methodName,
             int minNumberOfValues,

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -85,9 +85,9 @@ namespace System.CommandLine
 
         public static IArgumentArity ExactlyOne => new ArgumentArity(1, 1);
 
-        public static IArgumentArity ZeroOrMore => new ArgumentArity(0, byte.MaxValue);
+        public static IArgumentArity ZeroOrMore => new ArgumentArity(0, int.MaxValue);
 
-        public static IArgumentArity OneOrMore => new ArgumentArity(1, byte.MaxValue);
+        public static IArgumentArity OneOrMore => new ArgumentArity(1, int.MaxValue);
 
         internal static IArgumentArity Default(Type type, Argument argument, ISymbol parent)
         {


### PR DESCRIPTION
This resolves https://github.com/dotnet/command-line-api/issues/863