### PR TITLE
Add StyleSpan.AttributesOff for ESC[0m

### DIFF
--- a/src/System.CommandLine.Rendering.Tests/TextSpanTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/TextSpanTests.cs
@@ -113,13 +113,13 @@ namespace System.CommandLine.Rendering.Tests
 
             var formatter = new TextSpanFormatter();
 
-            var span = formatter.ParseToSpan($"{Ansi.Color.Foreground.LightGray}hello{Ansi.Color.Off}");
+            var span = formatter.ParseToSpan($"{Ansi.Color.Foreground.LightGray}hello{Ansi.Text.AttributesOff}");
 
             writer.Write(span.ToString(OutputMode.Ansi));
 
             writer.ToString()
                   .Should()
-                  .Be($"{Ansi.Color.Foreground.LightGray.EscapeSequence}hello{Ansi.Color.Off.EscapeSequence}");
+                  .Be($"{Ansi.Color.Foreground.LightGray.EscapeSequence}hello{Ansi.Text.AttributesOff.EscapeSequence}");
         }
     }
 }

--- a/src/System.CommandLine.Rendering/Ansi.cs
+++ b/src/System.CommandLine.Rendering/Ansi.cs
@@ -11,6 +11,7 @@ namespace System.CommandLine.Rendering
         [DebuggerStepThrough]
         public static class Text
         {
+            public static AnsiControlCode AttributesOff { get; } = $"{Esc}[0m";
             public static AnsiControlCode BlinkOff { get; } = $"{Esc}[25m";
             public static AnsiControlCode BlinkOn { get; } = $"{Esc}[5m";
             public static AnsiControlCode BoldOff { get; } = $"{Esc}[22m";
@@ -27,8 +28,6 @@ namespace System.CommandLine.Rendering
         [DebuggerStepThrough]
         public static class Color
         {
-            public static AnsiControlCode Off { get; } = $"{Esc}[0m";
-
             [DebuggerStepThrough]
             public class Background
             {

--- a/src/System.CommandLine.Rendering/AnsiRenderingSpanVisitor.cs
+++ b/src/System.CommandLine.Rendering/AnsiRenderingSpanVisitor.cs
@@ -128,6 +128,7 @@ namespace System.CommandLine.Rendering
         private static readonly Dictionary<string, AnsiControlCode> _styleControlCodeMappings =
             new Dictionary<string, AnsiControlCode>
             {
+                [nameof(StyleSpan.AttributesOff)] = Ansi.Text.AttributesOff,
                 [nameof(StyleSpan.BlinkOff)] = Ansi.Text.BlinkOff,
                 [nameof(StyleSpan.BlinkOn)] = Ansi.Text.BlinkOn,
                 [nameof(StyleSpan.BoldOff)] = Ansi.Text.BoldOff,

--- a/src/System.CommandLine.Rendering/StyleSpan.cs
+++ b/src/System.CommandLine.Rendering/StyleSpan.cs
@@ -9,6 +9,7 @@ namespace System.CommandLine.Rendering
         {
         }
 
+        public static StyleSpan AttributesOff() => new StyleSpan(nameof(AttributesOff), Ansi.Text.AttributesOff);
         public static StyleSpan BlinkOff() => new StyleSpan(nameof(BlinkOff), Ansi.Text.BlinkOn);
         public static StyleSpan BlinkOn() => new StyleSpan(nameof(BlinkOn), Ansi.Text.BlinkOff);
         public static StyleSpan BoldOff() => new StyleSpan(nameof(BoldOff), Ansi.Text.BoldOff);


### PR DESCRIPTION
It seems the the code already has a member for the `Color` class called `Off` that emits `ESC[0m`, however, this ANSI escape sequence isn't just for turning off color, but all attributes (underline, blink, bold, etc...).   So it seems to make more sense to have it as `StyleSpan.AttributesOff()`

Fix https://github.com/dotnet/command-line-api/issues/884
