### PR TITLE
Hosting simplifications when using Dependency Injections

### DIFF
--- a/src/System.CommandLine.Hosting/HostedCommandLineBuilder.cs
+++ b/src/System.CommandLine.Hosting/HostedCommandLineBuilder.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+
+namespace System.CommandLine.Hosting
+{
+    public interface ICommand
+    {
+        Task RunAsync(CancellationToken cancellationToken = default);
+    }
+
+
+    public class HostedCommandLineBuilder : CommandLineBuilder
+    {
+        private readonly List<Action<IServiceCollection>> _serviceConfigurations;
+
+
+        public HostedCommandLineBuilder()
+        {
+            _serviceConfigurations = new List<Action<IServiceCollection>>();
+        }
+
+
+        public IReadOnlyList<Action<IServiceCollection>> ServiceConfigurations => _serviceConfigurations;
+
+
+        public ICommandHandler BuildHandler<TCommand>()
+            where TCommand : class, ICommand
+        {
+            _serviceConfigurations.Add(services => { services.AddSingleton<TCommand>(); });
+
+            return CommandHandler.Create<IHost, CancellationToken>(async (host, cancellationToken) =>
+            {
+                var command = host.Services.GetRequiredService<TCommand>();
+
+                await command.RunAsync(cancellationToken);
+            });
+        }
+    }
+
+
+    public static class CommandLineExtensions
+    {
+        public static IServiceCollection AddCommands(
+            this IServiceCollection services,
+            HostedCommandLineBuilder builder)
+        {
+            foreach (var configureService in builder.ServiceConfigurations)
+            {
+                configureService(services);
+            }
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
This PR is not in a mergable state, but to visualize a simplified handling with dependency injections.

it would allow to write the following code
```csharp
    class SampleProgram
    {
        static async Task<int> Main(string[] args)
        {
            var appBuilder = new HostedCommandLineBuilder()
                             .AddOption(new Option<bool>("--isOption"))
                             .AddOption(new Option<string>("--value"));

            appBuilder.Command.Handler = appBuilder.BuildHandler<SampleCommand>();


            var parser = appBuilder.UseDefaults()
                                   .UseHost(host =>
                                   {
                                       host.ConfigureServices((ctx, services) =>
                                       {
                                           services.AddCommands(appBuilder);
                                           services.AddOptions<SampleOption>()
                                                   .BindCommandLine();
                                       });
                                   })
                                   .Build();

            return await parser.InvokeAsync(args);
        }
    }
```

for completeness
```csharp
    internal class SampleCommand : ICommand
    {
        private readonly ILogger _logger;
        private readonly SampleOption _options;
        private readonly IConsole _console;

        public SampleCommand(ILogger<SampleCommand> logger, IOptions<SampleOption> options, IConsole console)
        {
            _logger = logger;
            _options = options.Value;
            _console = console;
        }

        public async Task RunAsync(CancellationToken cancellationToken = default)
        { /* Execute Command */ }
    }

    internal class SampleOption
    {
        public bool IsOption { get; set; }
        public string Value { get; set; }
    }
```
