### PR TITLE
Use the ordinal ignore case string comparer for ordering option aliases

### DIFF
--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -335,8 +335,8 @@ namespace System.CommandLine.Help
             var rawAliases = symbol
                              .RawAliases
                              .Select(r => r.SplitPrefix())
-                             .OrderBy(r => r.prefix)
-                             .ThenBy(r => r.alias)
+                             .OrderBy(r => r.prefix, StringComparer.OrdinalIgnoreCase)
+                             .ThenBy(r => r.alias, StringComparer.OrdinalIgnoreCase)
                              .GroupBy(t => t.alias)
                              .Select(t => t.First())
                              .Select(t => $"{t.prefix}{t.alias}");


### PR DESCRIPTION
Fixes #894. I've specified the ordinal ignore case string comparer, since it seems to be the norm in this project to order case insensitively. Let me know if it should actually be `StringComparer.Ordinal`.