### PR TITLE
Add overload to ContainerSpan.Add() to accept a string which becomes a ContentSpan

### DIFF
--- a/src/System.CommandLine.Rendering.Tests/ContainerSpanTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/ContainerSpanTests.cs
@@ -17,5 +17,14 @@ namespace System.CommandLine.Rendering.Tests
 
             span.ContentLength.Should().Be("content with child".Length);
         }
+
+        [Fact]
+        public void Container_span_supports_add_string_method()
+        {
+            var span = new ContainerSpan(new ContentSpan("content"));
+            span.Add(" with string");
+
+            span.ContentLength.Should().Be("content with string".Length);
+        }
     }
 }

--- a/src/System.CommandLine.Rendering/ContainerSpan.cs
+++ b/src/System.CommandLine.Rendering/ContainerSpan.cs
@@ -72,5 +72,17 @@ namespace System.CommandLine.Rendering
 
             RecalculateChildPositions();
         }
+
+        public void Add(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            _children.Add(new ContentSpan(text));
+
+            RecalculateChildPositions();
+        }
     }
 }


### PR DESCRIPTION
Note that if the string is empty or null, the method just ignores it rather than throwing an exception.

Fix https://github.com/dotnet/command-line-api/issues/907