### PR TITLE
Add GenericHost playground sample 

### DIFF
--- a/System.CommandLine.sln
+++ b/System.CommandLine.sln
@@ -56,6 +56,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.CommandLine.Hosting"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.CommandLine.Hosting.Tests", "src\System.CommandLine.Hosting.Tests\System.CommandLine.Hosting.Tests.csproj", "{39483140-BC26-4CAD-BBAE-3DC76C2F16CF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HostingPlayground", "samples\HostingPlayground\HostingPlayground.csproj", "{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -222,6 +224,18 @@ Global
 		{39483140-BC26-4CAD-BBAE-3DC76C2F16CF}.Release|x64.Build.0 = Release|Any CPU
 		{39483140-BC26-4CAD-BBAE-3DC76C2F16CF}.Release|x86.ActiveCfg = Release|Any CPU
 		{39483140-BC26-4CAD-BBAE-3DC76C2F16CF}.Release|x86.Build.0 = Release|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Debug|x64.Build.0 = Debug|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Release|x64.ActiveCfg = Release|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Release|x64.Build.0 = Release|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -240,6 +254,7 @@ Global
 		{C39B0705-993E-43DB-B66A-A37A587F0BF7} = {E5B1EC71-0FC4-4FAA-9C65-32D5016FBC45}
 		{644C4B4A-4A32-4307-9F71-C3BF901FFB66} = {E5B1EC71-0FC4-4FAA-9C65-32D5016FBC45}
 		{39483140-BC26-4CAD-BBAE-3DC76C2F16CF} = {E5B1EC71-0FC4-4FAA-9C65-32D5016FBC45}
+		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906} = {6749FB3E-39DE-4321-A39E-525278E9408D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5C159F93-800B-49E7-9905-EE09F8B8434A}

--- a/samples/HostingPlayground/Greeter.cs
+++ b/samples/HostingPlayground/Greeter.cs
@@ -1,0 +1,7 @@
+namespace HostingPlayground
+{
+    public class Greeter : IGreeter
+    {
+
+    }
+}

--- a/samples/HostingPlayground/GreeterOptions.cs
+++ b/samples/HostingPlayground/GreeterOptions.cs
@@ -1,0 +1,12 @@
+namespace HostingPlayground
+{
+    public class GreeterOptions
+    {
+        public string Name { get; set; }
+
+        public GreeterOptions(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/samples/HostingPlayground/GreeterOptions.cs
+++ b/samples/HostingPlayground/GreeterOptions.cs
@@ -2,7 +2,7 @@ namespace HostingPlayground
 {
     public class GreeterOptions
     {
-        public string Name { get; set; }
+        public string Name { get; }
 
         public GreeterOptions(string name)
         {

--- a/samples/HostingPlayground/HostingPlayground.csproj
+++ b/samples/HostingPlayground/HostingPlayground.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   

--- a/samples/HostingPlayground/HostingPlayground.csproj
+++ b/samples/HostingPlayground/HostingPlayground.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.CommandLine.Hosting\System.CommandLine.Hosting.csproj" />
+    <ProjectReference Include="..\..\src\System.CommandLine\System.CommandLine.csproj" />
+  </ItemGroup>
+
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="microsoft.extensions.hosting" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
+  </ItemGroup>
+
+</Project>

--- a/samples/HostingPlayground/HostingPlaygroundLogEvents.cs
+++ b/samples/HostingPlayground/HostingPlaygroundLogEvents.cs
@@ -1,0 +1,7 @@
+namespace HostingPlayground
+{
+    public class HostingPlaygroundLogEvents
+    {
+        public const int GreetEvent = 1000;
+    }
+}

--- a/samples/HostingPlayground/IGreeter.cs
+++ b/samples/HostingPlayground/IGreeter.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace HostingPlayground
+{
+    interface IGreeter
+    {
+        void Greet(string name) => Console.WriteLine($"Hello, {name ?? "anonymous"}");
+    }
+}

--- a/samples/HostingPlayground/Program.cs
+++ b/samples/HostingPlayground/Program.cs
@@ -1,0 +1,52 @@
+﻿using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Hosting;
+using System.CommandLine.Invocation;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.CommandLine.Parsing;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using static HostingPlayground.HostingPlaygroundLogEvents;
+
+namespace HostingPlayground
+{
+    class Program
+    {
+        static async Task Main(string[] args) => await BuildCommandLine()
+            .UseHost(_ => Host.CreateDefaultBuilder(),
+                host =>
+                {
+                    host.ConfigureServices(services =>
+                    {
+                        services.AddSingleton<IGreeter, Greeter>();
+                    });
+                })
+            .UseDefaults()
+            .Build()
+            .InvokeAsync(args);
+
+        private static CommandLineBuilder BuildCommandLine()
+        {
+            var root = new RootCommand(@"$ dotnet run --name 'Joe'"){
+                new Option<string>("--name"){
+                    Required = true
+                }
+            };
+            root.Handler = CommandHandler.Create<GreeterOptions, IHost>(Run);
+            return new CommandLineBuilder(root);
+        }
+
+        private static void Run(GreeterOptions options, IHost host)
+        {
+            var serviceProvider = host.Services;
+            var greeter = serviceProvider.GetRequiredService<IGreeter>();
+            var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger(typeof(Program));
+
+            var name = options.Name;
+            logger.LogInformation(GreetEvent, "Greeting was requested for: {name}", name);
+            greeter.Greet(name);
+        }
+    }
+}

--- a/samples/HostingPlayground/appsettings.json
+++ b/samples/HostingPlayground/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
Looking through PRs I found that quite a lot of folks ask for documentation and samples on how to use `System.CommandLine.Hosting`. Also, I think it useful to have a playground for _Hosting_ since it allows people to play with it and share user feedback. Therefore this PR.

Fixes: #482
Relates: #671, #826, #440