### PR TITLE
Configurable command builder

### DIFF
--- a/src/System.CommandLine.Tests/Builder/ConfigurableBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Builder/ConfigurableBuilderTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Builder;
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests.Builder
+{
+    public class ConfigurableBuilderTests
+    {
+        [Fact]
+        public void When_a_ConfigurableCommandLineBuider_is_created_it_has_a_null_Command()
+        {
+            var builder = new ConfigurableCommandLineBuilder();
+            builder.Command.Should().BeNull();
+        }
+
+        [Fact]
+        public void ConfigurableCommandLineBuider_Command_can_be_set()
+        {
+            var builder = new ConfigurableCommandLineBuilder();
+            builder.SetCommand(new Command("Bob"));
+            builder.Command.Should().NotBeNull()
+                .And.BeEmpty("Bob");
+
+        }
+
+        [Fact]
+        public void ConfigurableCommandLineBuider_Command_should_throw_if_Command_already_set()
+        {
+            var builder = new ConfigurableCommandLineBuilder();
+            builder.SetCommand(new Command("Bob"));
+            Action create = () => builder.SetCommand(new Command("Joe"));
+
+            create.Should()
+                      .Throw<InvalidOperationException>()
+                      .Which
+                      .Message
+                      .Should()
+                      .Be("Command has already been set.");
+        }
+    }
+}

--- a/src/System.CommandLine/Builder/CommandBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandBuilder.cs
@@ -8,14 +8,26 @@ namespace System.CommandLine.Builder
 {
     public class CommandBuilder
     {
-        public CommandBuilder(Command command) 
+        public CommandBuilder(Command command)
         {
             Command = command;
         }
 
-        public Command Command { get; }
+        private protected CommandBuilder()
+        { }
+
+        public Command? Command { get; private set; }
 
         public IEnumerable<Option> Options => Command.Children.OfType<Option>();
+
+        private protected void SetCommandInternal(Command command)
+        {
+            if (!(Command is null))
+            {
+                throw new InvalidOperationException("Command has already been set.");
+            }
+            Command = command;
+        }
 
         internal void AddCommand(Command command) => Command.AddCommand(command);
 

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -19,6 +19,10 @@ namespace System.CommandLine.Builder
         {
         }
 
+        private protected CommandLineBuilder()
+            : base()
+        { }
+
         public bool EnableDirectives { get; set; } = true;
 
         public bool EnablePosixBundling { get; set; } = true;

--- a/src/System.CommandLine/Builder/ConfigurableCommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/ConfigurableCommandLineBuilder.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine.Builder
+{
+    public class ConfigurableCommandLineBuilder : CommandLineBuilder
+    {
+        public void SetCommand(Command command)
+        {
+            SetCommandInternal(command);
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes #924 

As described in issue #924 use of host builders (see #919) is blocked because the Command is added to the CommandLineBuilder prior to configuration. 

There are several ways to fix this. I chose this approach because: 

* Changing the behavior of RootCommand would be huge and breaking. Not passing anything to this gives you a pleasant default based on your executable and defaults. It's common to build on this.

* I wanted to make it as hard as possible to set the command. In almost all cases, it should be set at builder instantiation as happens today. 

* I wanted the configurable builder pattern to be usable beyond the current host to other hosting scenarios (other host interfaces). 

I am not happy with the name, but thought it was at least immensely clear. 
