### PR TITLE
Fix output mode will always be PlainText.

### DIFF
--- a/src/System.CommandLine.Rendering/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine.Rendering/CommandLineBuilderExtensions.cs
@@ -58,7 +58,7 @@ namespace System.CommandLine.Rendering
                 return mode;
             }
 
-            return context.Console.DetectOutputMode();
+            return Rendering.OutputMode.Auto;
         }
     }
 }


### PR DESCRIPTION
Maybe something larger is out of order, but at the very least even `RenderingPlayground` will stick to `PlainText` unless configured with `[output:ansi]`.

With this change, `OutputMode` will remain `Auto` until the first time something is rendered, [here](https://github.com/dotnet/command-line-api/blob/469b7423fa709682c6988513270f14328b9771f9/src/System.CommandLine.Rendering/ConsoleRenderer.cs#L81) at which time the detection will properly determine `Ansi` is OK.

Without this, [UseAnsiTerminalWhenAvailable](https://github.com/dotnet/command-line-api/blob/469b7423fa709682c6988513270f14328b9771f9/src/System.CommandLine.Rendering/CommandLineBuilderExtensions.cs#L13) will have `context.Console` be a `SystemConsole` which is not an `ITerminal` hence will yield `PlainText` from [`DetectOutputMode`](https://github.com/dotnet/command-line-api/blob/469b7423fa709682c6988513270f14328b9771f9/src/System.CommandLine.Rendering/ConsoleExtensions.cs#L33).