### PR TITLE
Fix typo for ReverseOff

### DIFF
--- a/src/System.CommandLine.Rendering/Ansi.cs
+++ b/src/System.CommandLine.Rendering/Ansi.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine.Rendering
             public static AnsiControlCode BoldOn { get; } = $"{Esc}[1m";
             public static AnsiControlCode HiddenOn { get; } = $"{Esc}[8m";
             public static AnsiControlCode ReverseOn { get; } = $"{Esc}[7m";
-            public static AnsiControlCode ReversOff { get; } = $"{Esc}[27m";
+            public static AnsiControlCode ReverseOff { get; } = $"{Esc}[27m";
             public static AnsiControlCode StandoutOff { get; } = $"{Esc}[23m";
             public static AnsiControlCode StandoutOn { get; } = $"{Esc}[3m";
             public static AnsiControlCode UnderlinedOff { get; } = $"{Esc}[24m";

--- a/src/System.CommandLine.Rendering/AnsiRenderingSpanVisitor.cs
+++ b/src/System.CommandLine.Rendering/AnsiRenderingSpanVisitor.cs
@@ -135,7 +135,7 @@ namespace System.CommandLine.Rendering
                 [nameof(StyleSpan.BoldOn)] = Ansi.Text.BoldOn,
                 [nameof(StyleSpan.HiddenOn)] = Ansi.Text.HiddenOn,
                 [nameof(StyleSpan.ReverseOn)] = Ansi.Text.ReverseOn,
-                [nameof(StyleSpan.ReversOff)] = Ansi.Text.ReversOff,
+                [nameof(StyleSpan.ReverseOff)] = Ansi.Text.ReverseOff,
                 [nameof(StyleSpan.StandoutOff)] = Ansi.Text.StandoutOff,
                 [nameof(StyleSpan.StandoutOn)] = Ansi.Text.StandoutOn,
                 [nameof(StyleSpan.UnderlinedOff)] = Ansi.Text.UnderlinedOff,

--- a/src/System.CommandLine.Rendering/StyleSpan.cs
+++ b/src/System.CommandLine.Rendering/StyleSpan.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine.Rendering
         public static StyleSpan BoldOn() => new StyleSpan(nameof(BoldOn), Ansi.Text.BoldOn);
         public static StyleSpan HiddenOn() => new StyleSpan(nameof(HiddenOn), Ansi.Text.HiddenOn);
         public static StyleSpan ReverseOn() => new StyleSpan(nameof(ReverseOn), Ansi.Text.ReverseOn);
-        public static StyleSpan ReversOff() => new StyleSpan(nameof(ReversOff), Ansi.Text.ReversOff);
+        public static StyleSpan ReverseOff() => new StyleSpan(nameof(ReverseOff), Ansi.Text.ReverseOff);
         public static StyleSpan StandoutOff() => new StyleSpan(nameof(StandoutOff), Ansi.Text.StandoutOff);
         public static StyleSpan StandoutOn() => new StyleSpan(nameof(StandoutOn), Ansi.Text.StandoutOn);
         public static StyleSpan UnderlinedOff() => new StyleSpan(nameof(UnderlinedOff), Ansi.Text.UnderlinedOff);


### PR DESCRIPTION
Replace all occurrences of `ReversOff` with `ReverseOff`