### PR TITLE
Add ParseResult.ValueForArgument and ValueForOption

### DIFF
--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -67,13 +67,13 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void By_default_the_argument_type_is_void()
+        public void By_default_the_argument_type_is_string()
         {
             var argument = new Argument();
 
             argument.ArgumentType
-                .Should()
-                .Be(typeof(void));
+                    .Should()
+                    .Be(typeof(string));
         }
 
         public class CustomParsing
@@ -203,8 +203,7 @@ namespace System.CommandLine.Tests
                 var argument = new Argument<int>(result => int.Parse(result.Tokens.Single().Value));
 
                 argument.Parse("123")
-                        .FindResultFor(argument)
-                        .GetValueOrDefault()
+                        .ValueForArgument(argument)
                         .Should()
                         .Be(123);
             }
@@ -215,8 +214,7 @@ namespace System.CommandLine.Tests
                 var argument = new Argument<IEnumerable<int>>(result => result.Tokens.Single().Value.Split(',').Select(int.Parse));
 
                 argument.Parse("1,2,3")
-                        .FindResultFor(argument)
-                        .GetValueOrDefault()
+                        .ValueForArgument(argument)
                         .Should()
                         .BeEquivalentTo(new[] { 1, 2, 3 });
             }
@@ -230,8 +228,7 @@ namespace System.CommandLine.Tests
                 });
 
                 argument.Parse("1 2 3")
-                        .FindResultFor(argument)
-                        .GetValueOrDefault()
+                        .ValueForArgument(argument)
                         .Should()
                         .BeEquivalentTo(new[] { 1, 2, 3 });
             }
@@ -245,8 +242,7 @@ namespace System.CommandLine.Tests
                 };
 
                 argument.Parse("1 2 3")
-                        .FindResultFor(argument)
-                        .GetValueOrDefault()
+                        .ValueForArgument(argument)
                         .Should()
                         .Be(6);
             }

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -266,20 +266,6 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void It_defaults_argument_to_alias_name_when_it_is_not_provided()
-        {
-            var command = new Command("-alias")
-            {
-                new Argument
-                {
-                    Arity = ArgumentArity.ZeroOrOne
-                }
-            };
-
-            command.Arguments.Single().Name.Should().Be("alias");
-        }
-
-        [Fact]
         public void It_retains_argument_name_when_it_is_provided()
         {
             var command = new Command("-alias")

--- a/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
@@ -303,18 +303,16 @@ namespace System.CommandLine.Tests.Invocation
         {
             BindingContext boundContext = default;
 
+            var option = new Option<int>("-x");
             var command = new Command("command")
             {
-                new Option("-x")
-                {
-                    Argument = new Argument<int>()
-                }
+                option
             };
             command.Handler = CommandHandler.Create<BindingContext>(context => { boundContext = context; });
 
             await command.InvokeAsync("command -x 123", _console);
 
-            boundContext.ParseResult.ValueForOption("-x").Should().Be(123);
+            boundContext.ParseResult.ValueForOption(option).Should().Be(123);
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
@@ -117,7 +117,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await result.InvokeAsync(_console);
 
-            _console.Out.ToString().Should().Contain("'een' was not matched. Did you mean 'been'?");
+            _console.Out.ToString().Should().NotContain("the-argument");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
@@ -108,7 +108,7 @@ namespace System.CommandLine.Tests.Invocation
         {
             var parser =
                 new CommandLineBuilder()
-                    .AddArgument(new Argument())
+                    .AddArgument(new Argument("the-argument"))
                     .AddCommand(new Command("been"))
                     .UseTypoCorrections()
                     .Build();

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.CommandLine.Parsing;
 using System.CommandLine.Tests.Utility;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace System.CommandLine.Tests
@@ -147,6 +148,33 @@ namespace System.CommandLine.Tests
                       .GetArgumentValueOrDefault("destination")
                       .Should()
                       .Be("dest.txt");
+            }
+
+            [Fact]
+            public void arity_ambiguities_can_be_differentiated_by_type_convertibility()
+            {
+                var ints = new Argument<int[]>();
+                var strings = new Argument<string[]>();
+
+                var root = new RootCommand
+                {
+                    ints,
+                    strings
+                };
+
+                var result = root.Parse("1 2 3 one", "two");
+
+                var _ = new AssertionScope();
+
+                result.ValueForArgument(ints)
+                      .Should()
+                      .BeEquivalentTo(new[] { 1, 2, 3 },
+                                      options => options.WithStrictOrdering());
+
+                result.ValueForArgument(strings)
+                      .Should()
+                      .BeEquivalentTo(new[] { "one", "two" },
+                                      options => options.WithStrictOrdering());
             }
         }
     }

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1948,14 +1948,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Argument_with_custom_type_converter_can_be_bound()
         {
-            var option = new Option("--value")
-            {
-                Argument = new Argument<ClassWithCustomTypeConverter>()
-            };
+            var option = new Option<ClassWithCustomTypeConverter>("--value");
 
             var parseResult = option.Parse("--value a;b;c");
 
-            var instance = (ClassWithCustomTypeConverter)parseResult.ValueForOption("--value");
+            var instance = parseResult.ValueForOption(option);
 
             instance.Values.Should().BeEquivalentTo("a", "b", "c");
         }

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -7,7 +7,6 @@ using System.CommandLine.Parsing;
 using System.IO;
 using FluentAssertions;
 using System.Linq;
-using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -280,7 +280,7 @@ namespace System.CommandLine.Tests
 
                 result.Errors
                       .Should()
-                      .Contain(e => e.SymbolResult.Symbol.Name == "the-command" &&
+                      .Contain(e => e.SymbolResult.Symbol == command.Arguments.First() &&
                                     e.Message == $"Character not allowed in a path: {invalidCharacter}");
             }   
             
@@ -428,7 +428,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "move" &&
+                      .Contain(e => e.SymbolResult.Symbol == command.Arguments.First() &&
                                     e.Message == $"File or directory does not exist: {path}");
             }
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -38,14 +38,10 @@ namespace System.CommandLine
             {
                 if (_arity is null)
                 {
-                    if (ArgumentType != typeof(void))
-                    {
-                        return ArgumentArity.Default(ArgumentType, this, Parents.FirstOrDefault());
-                    }
-                    else
-                    {
-                        return ArgumentArity.Zero;
-                    }
+                    return ArgumentArity.Default(
+                        ArgumentType, 
+                        this, 
+                        Parents.FirstOrDefault());
                 }
 
                 return _arity;
@@ -57,8 +53,7 @@ namespace System.CommandLine
         {
             get
             {
-                if (_convertArguments == null &&
-                    ArgumentType != typeof(void))
+                if (_convertArguments == null)
                 {
                     if (ArgumentType.CanBeBoundFromScalarValue())
                     {

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -16,13 +16,13 @@ namespace System.CommandLine
         private readonly List<ISuggestionSource> _suggestionSources = new List<ISuggestionSource>();
         private IArgumentArity? _arity;
         private TryConvertArgument? _convertArguments;
-        private Type _argumentType = typeof(void);
+        private Type _argumentType = typeof(string);
 
         public Argument()
         {
         }
 
-        public Argument(string? name) 
+        public Argument(string name) 
         {
             if (!string.IsNullOrWhiteSpace(name))
             {
@@ -223,5 +223,9 @@ namespace System.CommandLine
         string IValueDescriptor.ValueName => Name;
 
         Type IValueDescriptor.ValueType => ArgumentType;
+
+        private protected override void ChooseNameForUnnamedArgument(Argument argument)
+        {
+        }
     }
 }

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -7,7 +7,7 @@ namespace System.CommandLine
 {
     public class Argument<T> : Argument
     {
-        public Argument() : base(null)
+        public Argument()
         {
             ArgumentType = typeof(T);
         }

--- a/src/System.CommandLine/Binding/Binder.cs
+++ b/src/System.CommandLine/Binding/Binder.cs
@@ -15,7 +15,8 @@ namespace System.CommandLine.Binding
                           StringComparison.OrdinalIgnoreCase);
 
         internal static bool IsMatch(this string parameterName, ISymbol symbol) =>
-            parameterName.IsMatch(symbol.Name) || symbol.Aliases.Any(parameterName.IsMatch);
+            parameterName.IsMatch(symbol.Name) || 
+            symbol.HasAlias(parameterName);
 
         internal static bool IsNullable(this Type t)
         {

--- a/src/System.CommandLine/Binding/IValueDescriptor.cs
+++ b/src/System.CommandLine/Binding/IValueDescriptor.cs
@@ -5,7 +5,7 @@ namespace System.CommandLine.Binding
 {
     public interface IValueDescriptor
     {
-        string? ValueName { get; }
+        string ValueName { get; }
 
         Type ValueType { get; }
 

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -289,7 +289,7 @@ namespace System.CommandLine.Binding
                 ValueType = modelType;
             }
 
-            public string? ValueName => null;
+            public string ValueName => "";
 
             public bool HasDefaultValue => false;
 

--- a/src/System.CommandLine/Binding/SpecificSymbolValueSource.cs
+++ b/src/System.CommandLine/Binding/SpecificSymbolValueSource.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Parsing;
-using System.Linq;
 
 namespace System.CommandLine.Binding
 {

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -83,5 +83,10 @@ namespace System.CommandLine
         IEnumerable<IOption> ICommand.Options => Options;
 
         internal Parser? ImplicitParser { get; set; }
+
+        private protected override void ChooseNameForUnnamedArgument(Argument argument)
+        {
+            argument.Name = argument.ArgumentType.Name.ToLower();
+        }
     }
 }

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -53,5 +53,10 @@ namespace System.CommandLine
         bool IValueDescriptor.HasDefaultValue => Argument.HasDefaultValue;
 
         object? IValueDescriptor.GetDefaultValue() => Argument.GetDefaultValue();
+
+        private protected override void ChooseNameForUnnamedArgument(Argument argument)
+        {
+            argument.Name = Aliases[0].ToLower();
+        }
     }
 }

--- a/src/System.CommandLine/Parsing/ArgumentResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResultExtensions.cs
@@ -8,6 +8,7 @@ namespace System.CommandLine.Parsing
 {
     public static class ArgumentResultExtensions
     {
+        [return: MaybeNull]
         public static object? GetValueOrDefault(this ArgumentResult argumentResult) =>
             argumentResult.GetValueOrDefault<object?>();
 

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -35,14 +35,13 @@ namespace System.CommandLine.Parsing
 
         public Token Token { get; }
 
-
         internal virtual RootCommandResult? Root => (Parent as CommandResult)?.Root;
 
         internal bool TryGetValueForArgument(
             IValueDescriptor valueDescriptor,
             out object? value)
         {
-            if (valueDescriptor.ValueName is string valueName)
+            if (valueDescriptor.ValueName is { } valueName)
             {
                 foreach (var argument in Command.Arguments)
                 {

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -88,15 +88,10 @@ namespace System.CommandLine.Parsing
         [return: MaybeNull]
         public T ValueForArgument<T>(Argument<T> argument)
         {
-            var result = FindResultFor(argument);
-
-            if (result is {})
+            if (FindResultFor(argument) is {} result &&
+                result.GetValueOrDefault<T>() is {} t)
             {
-                return result.GetValueOrDefault<T>() switch
-                {
-                    { } t => t,
-                    _ => default!
-                };
+                return t;
             }
 
             return default!;
@@ -105,52 +100,37 @@ namespace System.CommandLine.Parsing
         [return: MaybeNull]
         public T ValueForArgument<T>(Argument argument)
         {
-            var result = FindResultFor(argument);
-
-            if (result is {})
+            if (FindResultFor(argument) is {} result &&
+                result.GetValueOrDefault<T>() is {} t)
             {
-                return result.GetValueOrDefault<T>() switch
-                {
-                    { } t => t,
-                    _ => default
-                };
+                return t;
             }
 
-            return default;
+            return default!;
         }
 
         [return: MaybeNull]
         public T ValueForOption<T>(Option<T> option)
         {
-            var result = FindResultFor(option);
-
-            if (result is {})
+            if (FindResultFor(option) is {} result &&
+                result.GetValueOrDefault<T>() is {} t)
             {
-                return result.GetValueOrDefault<T>() switch
-                {
-                    { } t => t,
-                    _ => default
-                };
+                return t;
             }
 
-            return default;
+            return default!;
         }
 
         [return: MaybeNull]
         public T ValueForOption<T>(Option option)
         {
-            var result = FindResultFor(option);
-
-            if (result is {})
+            if (FindResultFor(option) is {} result &&
+                result.GetValueOrDefault<T>() is {} t)
             {
-                return result.GetValueOrDefault<T>() switch
-                {
-                    { } t => t,
-                    _ => default
-                };
+                return t;
             }
 
-            return default;
+            return default!;
         }
 
         public SymbolResult? this[string alias] => CommandResult.Children[alias];

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -85,6 +85,74 @@ namespace System.CommandLine.Parsing
             }
         }
 
+        [return: MaybeNull]
+        public T ValueForArgument<T>(Argument<T> argument)
+        {
+            var result = FindResultFor(argument);
+
+            if (result is {})
+            {
+                return result.GetValueOrDefault<T>() switch
+                {
+                    { } t => t,
+                    _ => default
+                };
+            }
+
+            return default;
+        }
+
+        [return: MaybeNull]
+        public T ValueForArgument<T>(Argument argument)
+        {
+            var result = FindResultFor(argument);
+
+            if (result is {})
+            {
+                return result.GetValueOrDefault<T>() switch
+                {
+                    { } t => t,
+                    _ => default
+                };
+            }
+
+            return default;
+        }
+
+        [return: MaybeNull]
+        public T ValueForOption<T>(Option<T> option)
+        {
+            var result = FindResultFor(option);
+
+            if (result is {})
+            {
+                return result.GetValueOrDefault<T>() switch
+                {
+                    { } t => t,
+                    _ => default
+                };
+            }
+
+            return default;
+        }
+
+        [return: MaybeNull]
+        public T ValueForOption<T>(Option option)
+        {
+            var result = FindResultFor(option);
+
+            if (result is {})
+            {
+                return result.GetValueOrDefault<T>() switch
+                {
+                    { } t => t,
+                    _ => default
+                };
+            }
+
+            return default;
+        }
+
         public SymbolResult? this[string alias] => CommandResult.Children[alias];
 
         public override string ToString() => $"{nameof(ParseResult)}: {this.Diagram()}";

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -95,11 +95,11 @@ namespace System.CommandLine.Parsing
                 return result.GetValueOrDefault<T>() switch
                 {
                     { } t => t,
-                    _ => default
+                    _ => default!
                 };
             }
 
-            return default;
+            return default!;
         }
 
         [return: MaybeNull]

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -115,8 +115,8 @@ namespace System.CommandLine.Parsing
             {
                 var includeArgumentName =
                     argumentResult.Argument is Argument argument &&
-                    argument.Parents.First() is ICommand command &&
-                    command.Name != argument.Name;
+                    argument.Parents[0] is ICommand command &&
+                    command.Arguments.Count() > 1;
 
                 if (includeArgumentName)
                 {

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -69,8 +69,6 @@ namespace System.CommandLine.Parsing
                 commandNode.Token,
                 _innermostCommandResult);
 
-            Debug.Assert(_innermostCommandResult != null);
-
             _innermostCommandResult!
                 .Children
                 .Add(commandResult);

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -11,6 +11,7 @@ namespace System.CommandLine
 {
     public abstract class Symbol : ISymbol
     {
+        // FIX: (Symbol) HashSets?
         private readonly List<string> _aliases = new List<string>();
         private readonly List<string> _rawAliases = new List<string>();
         private string _longestAlias = "";
@@ -87,11 +88,13 @@ namespace System.CommandLine
 
             if (string.IsNullOrEmpty(argument.Name))
             {
-                argument.Name = _aliases.First().ToLower();
+                ChooseNameForUnnamedArgument(argument);
             }
 
             Children.Add(argument);
         }
+
+        private protected abstract void ChooseNameForUnnamedArgument(Argument argument);
 
         public SymbolSet Children { get; } = new SymbolSet();
 
@@ -123,6 +126,7 @@ namespace System.CommandLine
 
         public bool HasAlias(string alias)
         {
+            // FIX: (HasAlias) as much as possible, use an overload that takes a Token
             if (string.IsNullOrWhiteSpace(alias))
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(alias));

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -11,7 +11,6 @@ namespace System.CommandLine
 {
     public abstract class Symbol : ISymbol
     {
-        // FIX: (Symbol) HashSets?
         private readonly List<string> _aliases = new List<string>();
         private readonly List<string> _rawAliases = new List<string>();
         private string _longestAlias = "";
@@ -126,7 +125,6 @@ namespace System.CommandLine
 
         public bool HasAlias(string alias)
         {
-            // FIX: (HasAlias) as much as possible, use an overload that takes a Token
             if (string.IsNullOrWhiteSpace(alias))
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(alias));


### PR DESCRIPTION
This aims to further simplify looking up values from a `ParseResult`.