### PR TITLE
Update Generic Host projects for .NET Standard 2.1 / .NET Core 3.0

### DIFF
--- a/samples/HostingPlayground/HostingPlayground.csproj
+++ b/samples/HostingPlayground/HostingPlayground.csproj
@@ -7,17 +7,9 @@
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
-  
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.CommandLine.Hosting\System.CommandLine.Hosting.csproj" />
     <ProjectReference Include="..\..\src\System.CommandLine\System.CommandLine.csproj" />
-  </ItemGroup>
-
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
-    <PackageReference Include="microsoft.extensions.hosting" Version="3.1.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/System.CommandLine.Hosting.Tests/System.CommandLine.Hosting.Tests.csproj
+++ b/src/System.CommandLine.Hosting.Tests/System.CommandLine.Hosting.Tests.csproj
@@ -15,6 +15,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.2.0" />
   </ItemGroup>
 

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -39,16 +39,15 @@ namespace System.CommandLine.Hosting
                 hostBuilder.UseInvocationLifetime(invocation);
                 configureHost?.Invoke(hostBuilder);
 
-                using (var host = hostBuilder.Build())
-                {
-                    invocation.BindingContext.AddService(typeof(IHost), _ => host);
+                using var host = hostBuilder.Build();
 
-                    await host.StartAsync();
+                invocation.BindingContext.AddService(typeof(IHost), _ => host);
 
-                    await next(invocation);
+                await host.StartAsync();
 
-                    await host.StopAsync();
-                }
+                await next(invocation);
+
+                await host.StopAsync();
             });
 
         public static CommandLineBuilder UseHost(this CommandLineBuilder builder,

--- a/src/System.CommandLine.Hosting/InvocationLifetime.cs
+++ b/src/System.CommandLine.Hosting/InvocationLifetime.cs
@@ -7,6 +7,11 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
+#if NETSTANDARD2_0
+using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
+using IHostApplicationLifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
+#endif
+
 namespace System.CommandLine.Hosting
 {
     public class InvocationLifetime : IHostLifetime
@@ -18,8 +23,8 @@ namespace System.CommandLine.Hosting
 
         public InvocationLifetime(
             IOptions<InvocationLifetimeOptions> options,
-            IHostingEnvironment environment,
-            IApplicationLifetime applicationLifetime,
+            IHostEnvironment environment,
+            IHostApplicationLifetime applicationLifetime,
             InvocationContext context = null,
             ILoggerFactory loggerFactory = null)
         {
@@ -40,8 +45,8 @@ namespace System.CommandLine.Hosting
 
         public InvocationLifetimeOptions Options { get; }
         private ILogger Logger { get; }
-        public IHostingEnvironment Environment { get; }
-        public IApplicationLifetime ApplicationLifetime { get; }
+        public IHostEnvironment Environment { get; }
+        public IHostApplicationLifetime ApplicationLifetime { get; }
 
         public Task WaitForStartAsync(CancellationToken cancellationToken)
         {

--- a/src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj
+++ b/src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Description>This package provides support for using System.CommandLine with Microsoft.Extensions.Hosting.</Description>
   </PropertyGroup>
@@ -11,8 +11,11 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.1'">
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There were some breaking changes that need to be addressed for the Generic Host infrastructure for .NET Core 3.0.

However, the previous Generic Host implementation will still continue to work for .NET Standard 2.0 projects. Therefore, the System.CommandLine.Hosting package will now be multi-targeting .NET Standard 2.0 and 2.1. .NET Core Apps targeting 3.0 or later will automatically resolve to use the .NET Standard 2.1 variant of the package.

## Details

* `Microsoft.Extensions.Hosting.IHostingEnvironment` has been replaced by  
   `Microsoft.Extensions.Hosting.IHostEnvironment`
* `Microsoft.Extensions.Hosting.IApplicationLifetime` has been replaced by  
   `Microsoft.Extensions.Hosting.IHostApplicationLifetime`

The replacing types listed above are fully compatible with the old types. Since the Generic Host heavily relies on DI the difference in types in the Constructor signature will most likely not affect any consumers of our API, since nobody really was expected to new the `InvocationLifetime` class manually anyways.