### PR TITLE
Add Culture directive parsing

### DIFF
--- a/src/System.CommandLine.Tests/CultureDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/CultureDirectiveTests.cs
@@ -1,0 +1,153 @@
+﻿using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Globalization;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public class CultureDirectiveTests
+    {
+        [Fact]
+        public static async Task Sets_CurrentCulture_to_directive_culture()
+        {
+            bool asserted = false;
+            // Make sure we're invariant to begin with
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal("de-DE", CultureInfo.CurrentCulture.Name);
+                })
+            };
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseCultureDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { "[culture:de-DE]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Sets_CurrentCulture_to_last_directive_culture()
+        {
+            bool asserted = false;
+            // Make sure we're invariant to begin with
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal("nb-NO", CultureInfo.CurrentCulture.Name);
+                })
+            };
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseCultureDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { "[culture:de-DE]", "[culture:nb-NO]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Sets_CurrentUICulture_to_directive_culture()
+        {
+            bool asserted = false;
+            // Make sure we're invariant to begin with
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal("de-DE", CultureInfo.CurrentUICulture.Name);
+                })
+            };
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseCultureDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { "[uiculture:de-DE]" });
+         
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Sets_CurrentUICulture_to_last_directive_culture()
+        {
+            bool asserted = false;
+            // Make sure we're invariant to begin with
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal("nb-NO", CultureInfo.CurrentUICulture.Name);
+                })
+            };
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseCultureDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { "[uiculture:de-DE]", "[uiculture:nb-NO]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Sets_CurrentCulture_to_invariant_culture()
+        {
+            bool asserted = false;
+            // Make sure we're not invariant to begin with
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal(CultureInfo.InvariantCulture, CultureInfo.CurrentCulture);
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseCultureDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { "[invariantculture]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Sets_CurrentUICulture_to_invariant_culture()
+        {
+            bool asserted = false;
+            // Make sure we're not invariant to begin with
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal(CultureInfo.InvariantCulture, CultureInfo.CurrentUICulture);
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseCultureDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { "[invariantuiculture]" });
+
+            Assert.True(asserted);
+        }
+    }
+}

--- a/src/System.CommandLine/Invocation/MiddlewareOrder.cs
+++ b/src/System.CommandLine/Invocation/MiddlewareOrder.cs
@@ -15,6 +15,7 @@ namespace System.CommandLine.Invocation
     {
         Startup = -4000,
         ExceptionHandler = -3000,
+        CultureDirective = -2600,
         ConfigureConsole = -2500,
         RegisterWithDotnetSuggest = -2400,
         DebugDirective = -2300,


### PR DESCRIPTION
# TL;DR

* Adds a new extension method `UseCultureDirective()` to `CommandLineBuilder` enabling to control `CurrentCulture` and `CurrentUICulture` for the invocation pipeline from command-line directives.

# Details

This introduces the following four culture directives:

* `culture`  
   The directive value specifies a new value for static `CultureInfo.CurrentCulture`. The value must be a culture name recognised by the CLR.  
   Expample: `[culture:de-DE]` will set `CultureInfo.CurrentCulture` to the German culture that is specific to Germany.
* `uiculture`  
   The directive value specifies a new value for static `CultureInfo.CurrentUICulture`. The value must be a culture name recognised by the CLR.  
   Expample: `[uiculture:de-DE]` will set `CultureInfo.CurrentUICulture` to the German culture that is specific to Germany.
* `invariantculture`  
   If present in the parse result directives `CultureInfo.CurrentCulture` is set to `CultureInfo.InvariantCulture`.
* `invariantuiculture`  
   If present in the parse result directives `CultureInfo.CurrentUICulture` is set to `CultureInfo.InvariantCulture`.