### PR TITLE
Global options fixes

### DIFF
--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -321,53 +321,6 @@ namespace System.CommandLine.Tests
                 .Be("Alias '--same' is already in use.");
         }
 
-        [Fact]
-        public void Global_options_may_be_added_with_aliases_that_conflict_with_local_options()
-        {
-            var command = new Command("the-command")
-            {
-                new Option("--same")
-            };
-
-            command
-                .Invoking(c => c.AddGlobalOption(new Option("--same")))
-                .Should()
-                .NotThrow<ArgumentException>();
-        }
-
-        [Fact]
-        public void Global_options_may_not_have_aliases_conflicting_with_other_global_option_aliases()
-        {
-            var command = new Command("the-command");
-
-            command.AddGlobalOption(new Option("--same"));
-
-            command
-                .Invoking(c => c.AddGlobalOption(new Option("--same")))
-                .Should()
-                .Throw<ArgumentException>()
-                .Which
-                .Message
-                .Should()
-                .Be("Alias '--same' is already in use.");
-        }
-
-        [Fact]
-        public void When_local_options_are_added_then_they_must_differ_from_global_options_by_name()
-        {
-            var command = new Command("the-command");
-            command.AddGlobalOption(new Option("--same"));
-
-            command
-                .Invoking(c => c.Add(new Option("--same")))
-                .Should()
-                .Throw<ArgumentException>()
-                .And
-                .Message
-                .Should()
-                .Be("Alias '--same' is already in use.");
-        }
-
         protected override Symbol CreateSymbol(string name) => new Command(name);
     }
 }

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public class GlobalOptionTests
+    {
+        [Fact]
+        public void Global_options_may_be_added_with_aliases_that_conflict_with_local_options()
+        {
+            var command = new Command("the-command")
+            {
+                new Option("--same")
+            };
+
+            command
+                .Invoking(c => c.AddGlobalOption(new Option("--same")))
+                .Should()
+                .NotThrow<ArgumentException>();
+        }
+
+        [Fact]
+        public void Global_options_may_not_have_aliases_conflicting_with_other_global_option_aliases()
+        {
+            var command = new Command("the-command");
+
+            command.AddGlobalOption(new Option("--same"));
+
+            command
+                .Invoking(c => c.AddGlobalOption(new Option("--same")))
+                .Should()
+                .Throw<ArgumentException>()
+                .Which
+                .Message
+                .Should()
+                .Be("Alias '--same' is already in use.");
+        }
+
+        [Fact]
+        public void When_local_options_are_added_then_they_must_differ_from_global_options_by_name()
+        {
+            var command = new Command("the-command");
+
+            command.AddGlobalOption(new Option("--same"));
+
+            command
+                .Invoking(c => c.Add(new Option("--same")))
+                .Should()
+                .Throw<ArgumentException>()
+                .And
+                .Message
+                .Should()
+                .Be("Alias '--same' is already in use.");
+        }
+
+        [Fact]
+        public void Global_options_appear_in_options_list()
+        {
+            var root = new Command("parent");
+
+            var option = new Option<int>("--global");
+
+            root.AddGlobalOption(option);
+
+            var child = new Command("child");
+
+            root.AddCommand(child);
+
+            root.Options.Should().Contain(option);
+        }
+
+        [Fact]
+        public void Global_options_appear_in_child_command_options_list()
+        {
+            var root = new Command("parent");
+
+            var option = new Option<int>("--global");
+
+            root.AddGlobalOption(option);
+
+            var child = new Command("child");
+
+            root.AddCommand(child);
+
+            child.Options.Should().Contain(option);
+        }
+
+        [Fact]
+        public void Subcommands_added_after_a_global_option_is_added_to_parent_will_recognize_the_global_option()
+        {
+            var root = new Command("parent");
+
+            var option = new Option<int>("--global");
+
+            root.AddGlobalOption(option);
+
+            var child = new Command("child");
+
+            root.AddCommand(child);
+
+            root.Parse("child --global 123").ValueForOption(option).Should().Be(123);
+
+            child.Parse("--global 123").ValueForOption(option).Should().Be(123);
+        }
+    }
+}

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -18,9 +18,14 @@ namespace System.CommandLine
         {
         }
 
-        public IEnumerable<Argument> Arguments => Children.OfType<Argument>();
-        
-        public IEnumerable<Option> Options => Children.OfType<Option>();
+        public IEnumerable<Argument> Arguments => 
+            Children.OfType<Argument>();
+
+        public IEnumerable<Option> Options =>
+            Children.OfType<Option>()
+                    .Concat(Parents
+                            .OfType<Command>()
+                            .SelectMany(c => c.GlobalOptions));
 
         public IEnumerable<Option> GlobalOptions => _globalOptions.OfType<Option>();
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -11,7 +11,6 @@ namespace System.CommandLine
 {
     public abstract class Symbol : ISymbol
     {
-        // FIX: (Symbol) HashSets?
         private readonly List<string> _aliases = new List<string>();
         private readonly List<string> _rawAliases = new List<string>();
         private string _longestAlias = "";
@@ -126,7 +125,6 @@ namespace System.CommandLine
 
         public bool HasAlias(string alias)
         {
-            // FIX: (HasAlias) as much as possible, use an overload that takes a Token
             if (string.IsNullOrWhiteSpace(alias))
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(alias));

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -11,6 +11,7 @@ namespace System.CommandLine
 {
     public abstract class Symbol : ISymbol
     {
+        // FIX: (Symbol) HashSets?
         private readonly List<string> _aliases = new List<string>();
         private readonly List<string> _rawAliases = new List<string>();
         private string _longestAlias = "";
@@ -125,6 +126,7 @@ namespace System.CommandLine
 
         public bool HasAlias(string alias)
         {
+            // FIX: (HasAlias) as much as possible, use an overload that takes a Token
             if (string.IsNullOrWhiteSpace(alias))
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(alias));


### PR DESCRIPTION
This fixes an issue where adding a global option before a child command would result in that option not being available on the child command.