### PR TITLE
update suggestion API

### DIFF
--- a/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine.Tests
                 .AddSuggestions("apple", "banana", "cherry");
 
             _vegetableOption = new Option<string>("--vegetable")
-                .AddSuggestions("asparagus", "broccoli", "carrot");
+                .AddSuggestions(_ => new[] { "asparagus", "broccoli", "carrot" });
 
             _eatCommand = new Command("eat")
             {

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -15,6 +15,7 @@ namespace System.CommandLine
         private IArgumentArity? _arity;
         private TryConvertArgument? _convertArguments;
         private Type _argumentType = typeof(string);
+        private List<ISuggestionSource>? _suggestions = null;
 
         public Argument()
         {
@@ -102,15 +103,13 @@ namespace System.CommandLine
             set => _convertArguments = value;
         }
 
-
-        private List<ISuggestionSource>? _suggestions = null;
         public List<ISuggestionSource> Suggestions
         { 
             get
             {
                 if (_suggestions is null)
                 {
-                    _suggestions = new List<ISuggestionSource>()
+                    _suggestions = new List<ISuggestionSource>
                     {
                         SuggestionSource.ForType(ArgumentType)
                     };

--- a/src/System.CommandLine/ArgumentExtensions.cs
+++ b/src/System.CommandLine/ArgumentExtensions.cs
@@ -3,14 +3,34 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Parsing;
+using System.CommandLine.Suggestions;
 using System.Linq;
 using System.IO;
-using System.CommandLine.Suggestions;
 
 namespace System.CommandLine
 {
     public static class ArgumentExtensions
     {
+        public static TArgument AddSuggestions<TArgument>(
+            this TArgument argument,
+            params string[] values)
+            where TArgument : Argument
+        {
+            argument.Suggestions.Add(values);
+
+            return argument;
+        }
+
+        public static TArgument AddSuggestions<TArgument>(
+            this TArgument argument,
+            SuggestDelegate suggest)
+            where TArgument : Argument
+        {
+            argument.Suggestions.Add(suggest);
+
+            return argument;
+        }
+
         public static TArgument FromAmong<TArgument>(
             this TArgument argument,
             params string[] values)

--- a/src/System.CommandLine/OptionExtensions.cs
+++ b/src/System.CommandLine/OptionExtensions.cs
@@ -32,9 +32,9 @@ namespace System.CommandLine
             return option;
         }
 
-        public static TOption AddSuggestion<TOption>(
+        public static TOption AddSuggestions<TOption>(
             this TOption option,
-            Suggest suggest)
+            SuggestDelegate suggest)
             where TOption : Option 
         {
             option.Argument.Suggestions.Add(suggest);

--- a/src/System.CommandLine/SuggestionSourceExtensions.cs
+++ b/src/System.CommandLine/SuggestionSourceExtensions.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine
     {
         public static void Add(
             this List<ISuggestionSource> suggestionSources,
-            Suggest suggest)
+            SuggestDelegate suggest)
         {
             if (suggestionSources is null)
             {

--- a/src/System.CommandLine/Suggestions/AnonymousSuggestionSource.cs
+++ b/src/System.CommandLine/Suggestions/AnonymousSuggestionSource.cs
@@ -7,9 +7,9 @@ namespace System.CommandLine.Suggestions
 {
     internal class AnonymousSuggestionSource : ISuggestionSource
     {
-        private readonly Suggest _suggest;
+        private readonly SuggestDelegate _suggest;
 
-        public AnonymousSuggestionSource(Suggest suggest)
+        public AnonymousSuggestionSource(SuggestDelegate suggest)
         {
             _suggest = suggest ?? throw new ArgumentNullException(nameof(suggest));
         }

--- a/src/System.CommandLine/Suggestions/SuggestDelegate.cs
+++ b/src/System.CommandLine/Suggestions/SuggestDelegate.cs
@@ -5,5 +5,5 @@ using System.Collections.Generic;
 
 namespace System.CommandLine.Suggestions
 {
-    public delegate IEnumerable<string> Suggest(string? textToMatch);
+    public delegate IEnumerable<string> SuggestDelegate(string? textToMatch);
 }


### PR DESCRIPTION
This makes a couple of small changes:

* Renames `Suggest` -> `SuggestDelegate`
* Adds  `AddSuggestions` extension methods to `Argument` for parity with `Option` extensions
* Renames `AddSuggestion` to `AddSuggestions`