### PR TITLE
Add Environment Variable directive parsing

### DIFF
--- a/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -82,6 +83,101 @@ namespace System.CommandLine.Tests
                 .Build();
 
             await parser.InvokeAsync(new[] { $"[env:{variable}=    {value}     ]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Sets_environment_variable_value_containing_equals_sign()
+        {
+            bool asserted = false;
+            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            const string value = "This is = a test containing equals";
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseEnvironmentVariableDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { $"[env:{variable}={value}]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Ignores_environment_directive_without_equals_sign()
+        {
+            bool asserted = false;
+            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Null(Environment.GetEnvironmentVariable(variable));
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseEnvironmentVariableDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { $"[env:{variable}]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Ignores_environment_directive_with_empty_variable_name()
+        {
+            bool asserted = false;
+            string value = $"This is a test, random: {randomizer.Next()}";
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    var env = Environment.GetEnvironmentVariables();
+                    Assert.DoesNotContain(value, env.Values.Cast<string>().ToArray());
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseEnvironmentVariableDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { $"[env:={value}]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Ignores_environment_directive_with_whitespace_variable_name()
+        {
+            bool asserted = false;
+            string value = $"This is a test, random: {randomizer.Next()}";
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    var env = Environment.GetEnvironmentVariables();
+                    Assert.DoesNotContain(value, env.Values.Cast<string>().ToArray());
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseEnvironmentVariableDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { $"[env:    ={value}]" });
 
             Assert.True(asserted);
         }

--- a/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public class EnvironmentVariableDirectiveTests
+    {
+        private static readonly Random randomizer = new Random(Seed: 456476756);
+
+        [Fact]
+        public static async Task Sets_environment_variable_to_value()
+        {
+            bool asserted = false;
+            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            const string value = "This is a test";
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseEnvironmentVariableDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { $"[env:{variable}={value}]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Trims_environment_variable_name()
+        {
+            bool asserted = false;
+            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            const string value = "This is a test";
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseEnvironmentVariableDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { $"[env:     {variable}    ={value}]" });
+
+            Assert.True(asserted);
+        }
+
+        [Fact]
+        public static async Task Trims_environment_variable_value()
+        {
+            bool asserted = false;
+            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            const string value = "This is a test";
+            var rootCommand = new RootCommand
+            {
+                Handler = CommandHandler.Create(() =>
+                {
+                    asserted = true;
+                    Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+                })
+            };
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseEnvironmentVariableDirective()
+                .Build();
+
+            await parser.InvokeAsync(new[] { $"[env:{variable}=    {value}     ]" });
+
+            Assert.True(asserted);
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
@@ -13,12 +13,13 @@ namespace System.CommandLine.Tests
     public class EnvironmentVariableDirectiveTests
     {
         private static readonly Random randomizer = new Random(Seed: 456476756);
+        private readonly string test_variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
 
         [Fact]
-        public static async Task Sets_environment_variable_to_value()
+        public async Task Sets_environment_variable_to_value()
         {
             bool asserted = false;
-            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            string variable = test_variable;
             const string value = "This is a test";
             var rootCommand = new RootCommand
             {
@@ -39,10 +40,10 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public static async Task Trims_environment_variable_name()
+        public async Task Trims_environment_variable_name()
         {
             bool asserted = false;
-            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            string variable = test_variable;
             const string value = "This is a test";
             var rootCommand = new RootCommand
             {
@@ -63,10 +64,10 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public static async Task Trims_environment_variable_value()
+        public async Task Trims_environment_variable_value()
         {
             bool asserted = false;
-            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            string variable = test_variable;
             const string value = "This is a test";
             var rootCommand = new RootCommand
             {
@@ -87,10 +88,10 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public static async Task Sets_environment_variable_value_containing_equals_sign()
+        public async Task Sets_environment_variable_value_containing_equals_sign()
         {
             bool asserted = false;
-            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            string variable = test_variable;
             const string value = "This is = a test containing equals";
             var rootCommand = new RootCommand
             {
@@ -111,10 +112,10 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public static async Task Ignores_environment_directive_without_equals_sign()
+        public async Task Ignores_environment_directive_without_equals_sign()
         {
             bool asserted = false;
-            string variable = $"TEST_ENVIRONMENT_VARIABLE{randomizer.Next()}";
+            string variable = test_variable;
             var rootCommand = new RootCommand
             {
                 Handler = CommandHandler.Create(() =>

--- a/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using FluentAssertions;
+
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -26,7 +25,7 @@ namespace System.CommandLine.Tests
                 Handler = CommandHandler.Create(() =>
                 {
                     asserted = true;
-                    Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+                    Environment.GetEnvironmentVariable(variable).Should().Be(value);
                 })
             };
 
@@ -36,7 +35,7 @@ namespace System.CommandLine.Tests
 
             await parser.InvokeAsync(new[] { $"[env:{variable}={value}]" });
 
-            Assert.True(asserted);
+            asserted.Should().BeTrue();
         }
 
         [Fact]
@@ -50,7 +49,7 @@ namespace System.CommandLine.Tests
                 Handler = CommandHandler.Create(() =>
                 {
                     asserted = true;
-                    Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+                    Environment.GetEnvironmentVariable(variable).Should().Be(value);
                 })
             };
 
@@ -60,7 +59,7 @@ namespace System.CommandLine.Tests
 
             await parser.InvokeAsync(new[] { $"[env:     {variable}    ={value}]" });
 
-            Assert.True(asserted);
+            asserted.Should().BeTrue();
         }
 
         [Fact]
@@ -74,7 +73,7 @@ namespace System.CommandLine.Tests
                 Handler = CommandHandler.Create(() =>
                 {
                     asserted = true;
-                    Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+                    Environment.GetEnvironmentVariable(variable).Should().Be(value);
                 })
             };
 
@@ -84,7 +83,7 @@ namespace System.CommandLine.Tests
 
             await parser.InvokeAsync(new[] { $"[env:{variable}=    {value}     ]" });
 
-            Assert.True(asserted);
+            asserted.Should().BeTrue();
         }
 
         [Fact]
@@ -98,7 +97,7 @@ namespace System.CommandLine.Tests
                 Handler = CommandHandler.Create(() =>
                 {
                     asserted = true;
-                    Assert.Equal(value, Environment.GetEnvironmentVariable(variable));
+                    Environment.GetEnvironmentVariable(variable).Should().Be(value);
                 })
             };
 
@@ -108,7 +107,7 @@ namespace System.CommandLine.Tests
 
             await parser.InvokeAsync(new[] { $"[env:{variable}={value}]" });
 
-            Assert.True(asserted);
+            asserted.Should().BeTrue();
         }
 
         [Fact]
@@ -121,7 +120,7 @@ namespace System.CommandLine.Tests
                 Handler = CommandHandler.Create(() =>
                 {
                     asserted = true;
-                    Assert.Null(Environment.GetEnvironmentVariable(variable));
+                    Environment.GetEnvironmentVariable(variable).Should().BeNull();
                 })
             };
 
@@ -131,7 +130,7 @@ namespace System.CommandLine.Tests
 
             await parser.InvokeAsync(new[] { $"[env:{variable}]" });
 
-            Assert.True(asserted);
+            asserted.Should().BeTrue();
         }
 
         [Fact]
@@ -145,7 +144,7 @@ namespace System.CommandLine.Tests
                 {
                     asserted = true;
                     var env = Environment.GetEnvironmentVariables();
-                    Assert.DoesNotContain(value, env.Values.Cast<string>().ToArray());
+                    env.Values.Cast<string>().Should().NotContain(value);
                 })
             };
 
@@ -155,7 +154,7 @@ namespace System.CommandLine.Tests
 
             await parser.InvokeAsync(new[] { $"[env:={value}]" });
 
-            Assert.True(asserted);
+            asserted.Should().BeTrue();
         }
 
         [Fact]
@@ -169,7 +168,7 @@ namespace System.CommandLine.Tests
                 {
                     asserted = true;
                     var env = Environment.GetEnvironmentVariables();
-                    Assert.DoesNotContain(value, env.Values.Cast<string>().ToArray());
+                    env.Values.Cast<string>().Should().NotContain(value);
                 })
             };
 
@@ -179,7 +178,7 @@ namespace System.CommandLine.Tests
 
             await parser.InvokeAsync(new[] { $"[env:    ={value}]" });
 
-            Assert.True(asserted);
+            asserted.Should().BeTrue();
         }
     }
 }

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -240,7 +240,9 @@ namespace System.CommandLine.Builder
                         var components = envDirective.Split(new[] { '=' }, count: 2);
                         var variable = components.Length > 0 ? components[0].Trim() : string.Empty;
                         if (string.IsNullOrEmpty(variable) || components.Length < 2)
+                        {
                             continue;
+                        }
                         var value = components[1].Trim();
                         SetEnvironmentVariable(variable, value);
                     }

--- a/src/System.CommandLine/Invocation/MiddlewareOrder.cs
+++ b/src/System.CommandLine/Invocation/MiddlewareOrder.cs
@@ -15,6 +15,7 @@ namespace System.CommandLine.Invocation
     {
         Startup = -4000,
         ExceptionHandler = -3000,
+        EnvironmentVariableDirective = -2600,
         ConfigureConsole = -2500,
         RegisterWithDotnetSuggest = -2400,
         DebugDirective = -2300,


### PR DESCRIPTION
# TL;DR

* Adds a new extension method `UseEnvironmentVariableDirective()` to `CommandLineBuilder` enabling to control process-level environment variables for the invocation pipeline from command-line directives.  
   The new directive is: `env`.

# Details

As part of the discussion in #951 the need for an environment variable directive could be benefitial for invocations as well.

This PR adds a parser that intercepts the `env` directive and extracts a `=` separated key-value-pair from the directive value.

## Added to `UseDefaults()`

Since the ability to easily control process-level environment variables is quite useful, I propose that we should add the environment variable directive to the `UseDefaults()` extension method on `CommandLineBuilder`.

This directive is especially useful in shells (most notably on Windows) where specifying variables during process invocation is not possible without modifying the environment variables of the hosting shell.

# Behaviour

The value specified in the `env` directive is expected to contain a `=` separated key-value-pair. 

1. The value of the directive is split into two parts at the first ocurrence of `=`.  
    The first component is considered to be the environment variable to set, the second component is the new value for the variable.
2. Both the variable name and the value are trimmed, stripping leading and trailing whitespace.
3. `System.Envrionment.SetEnvironmentVariable(string variable, string value)` is invoked, setting the variable at process-level, overriding the existing value (if any).

## Invalid Directives

An `env`-directive is ignored if:

* The value of the directive (the text following the `:` in the directive argument) is an empty or white-space only string.
* The value of the directive does not contain at least one `=` character.
* The string preceeding the first `=` in the directive value is an empty or white-space only string.

## Limitations

This directive cannot modify the behaviour of the .NET Runtime that is controlled by environment variables. When the `env`-directive is parsed, the .NET Runtime Host has already booted the runtime and envaluated the environment variables at process launch.

Environment variables that are controlled by the .NET Generic Host can be affected by this directive, provided that the Generic Host is started **after** the invocation pipeline has parsed `env`-directives, or after the pipeline has finished.

## Invocation Pipeline precedence

The middle to parse the `env`-directives is added immediately following the `ExceptionHandler` middleware to ensure that environment variables are parsed as early in the pipeline as possible. `Envrionment.SetEnvironmentVariable` might throw an exception for weird combinatinations for variable names, and these exception should be handled and printed properly using the exception-handling middleware (if present in the pipeline).