### PR TITLE
rename Option.Required to Option.IsRequired

### DIFF
--- a/samples/HostingPlayground/Program.cs
+++ b/samples/HostingPlayground/Program.cs
@@ -30,7 +30,7 @@ namespace HostingPlayground
         {
             var root = new RootCommand(@"$ dotnet run --name 'Joe'"){
                 new Option<string>("--name"){
-                    Required = true
+                    IsRequired = true
                 }
             };
             root.Handler = CommandHandler.Create<GreeterOptions, IHost>(Run);

--- a/src/System.CommandLine.Tests/ApprovalTests/Help/HelpBuilderTests.Approval.cs
+++ b/src/System.CommandLine.Tests/ApprovalTests/Help/HelpBuilderTests.Approval.cs
@@ -34,7 +34,7 @@ namespace System.CommandLine.Tests.Help
                 },
                 new Option(aliases: new string[] {"--the-root-option-no-arg", "-trna"}) {
                     Description = "the-root-option-no-arg-description",
-                    Required = true
+                    IsRequired = true
                 },
                 new Option<string>(
                     aliases: new string[] {"--the-root-option-no-description-default-arg", "-trondda"}, 
@@ -47,7 +47,7 @@ namespace System.CommandLine.Tests.Help
                     {
                         Description = "the-root-option-arg-no-default-description"
                     },
-                    Required = true
+                    IsRequired = true
                 },
                 new Option(aliases: new string[] {"--the-root-option-default-arg", "-troda"}) {
                     Description = "the-root-option-default-arg-description",
@@ -69,7 +69,7 @@ namespace System.CommandLine.Tests.Help
                     {
                         Description = "the-root-option-arg-description",
                     },
-                    Required = true
+                    IsRequired = true
                 }
             };
             command.Name = "the-root-command";

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -1172,7 +1172,7 @@ namespace System.CommandLine.Tests.Help
             {
                 new Option("--required")
                 {
-                    Required = true
+                    IsRequired = true
                 }
             };
 
@@ -1191,7 +1191,7 @@ namespace System.CommandLine.Tests.Help
             {
                 new Option(new[] {"-r", "--required" })
                 {
-                    Required = true,
+                    IsRequired = true,
                     Argument = new Argument<string>("ARG")
                 }
             };

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -90,7 +90,7 @@ namespace System.CommandLine.Tests
             {
                 new Option("-x")
                 {
-                    Required = true
+                    IsRequired = true
                 }
             };
 
@@ -112,7 +112,7 @@ namespace System.CommandLine.Tests
         {
             var option = new Option<string>("-x")
             {
-                Required = true
+                IsRequired = true
             };
 
             var command = new RootCommand
@@ -136,7 +136,7 @@ namespace System.CommandLine.Tests
 
             var parent = new RootCommand
             {
-                new Option<string>("-x") { Required = true },
+                new Option<string>("-x") { IsRequired = true },
                 child
             };
             parent.Name = "parent";

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Builder;
-using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.CommandLine.Tests.Utility;
 using System.IO;

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -151,7 +151,7 @@ namespace System.CommandLine.Tests
             {
                 new Option<string>("-x")
                 {
-                    Required = true
+                    IsRequired = true
                 },
             };
 

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -499,7 +499,7 @@ namespace System.CommandLine.Help
             }
 
             if (symbol is IOption option &&
-                option.Required)
+                option.IsRequired)
             {
                 invocation += " (REQUIRED)";
             }

--- a/src/System.CommandLine/IOption.cs
+++ b/src/System.CommandLine/IOption.cs
@@ -9,6 +9,6 @@ namespace System.CommandLine
     {
         IArgument Argument { get; }
 
-        bool Required { get; }
+        bool IsRequired { get; }
     }
 }

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -44,7 +44,7 @@ namespace System.CommandLine
 
         IArgument IOption.Argument => Argument;
 
-        public bool Required { get; set; }
+        public bool IsRequired { get; set; }
  
         string IValueDescriptor.ValueName => Name;
 

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -208,7 +208,7 @@ namespace System.CommandLine.Parsing
                                    .Options)
             {
                 if (option is Option o &&
-                    o.Required && 
+                    o.IsRequired && 
                     _rootCommandResult!.FindResultFor(o) is null)
                 {
                     _errors.Add(


### PR DESCRIPTION
This is more consistent with e.g. `Option.IsHidden`.