### PR TITLE
Add optional case insensitive parsing

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -54,6 +54,17 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void Option_aliases_are_case_insensitive()
+        {
+            var option = new Option(new[] { "-o" })
+            {
+               IsCaseInsensitive = true
+            };
+
+            option.HasAlias("O").Should().BeTrue();
+        }
+
+        [Fact]
         public void HasAlias_accepts_prefixed_short_value()
         {
             var option = new Option(new[] { "-o", "--option" });

--- a/src/System.CommandLine/Collections/AliasedSet.cs
+++ b/src/System.CommandLine/Collections/AliasedSet.cs
@@ -18,9 +18,10 @@ namespace System.CommandLine.Collections
             for (var i = 0; i < Items.Count; i++)
             {
                 var item = Items[i];
+                var caseInsensitive = IsCaseInsensitive(item);
 
-                if (Contains(GetAliases(item), alias) || 
-                    Contains(GetRawAliases(item), alias))
+                if (Contains(GetAliases(item), alias, caseInsensitive) || 
+                    Contains(GetRawAliases(item), alias, caseInsensitive))
                 {
                     return item;
                 }
@@ -31,11 +32,13 @@ namespace System.CommandLine.Collections
 
         private protected bool Contains(
             IReadOnlyList<string> aliases,
-            string alias)
+            string alias,
+            bool caseInsensitive = false)
         {
             for (var i = 0; i < aliases.Count; i++)
             {
-                if (string.Equals(aliases[i], alias))
+                if (string.Equals(aliases[i], alias,
+                    caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                 {
                     return true;
                 }
@@ -63,6 +66,8 @@ namespace System.CommandLine.Collections
         protected abstract IReadOnlyList<string> GetAliases(T item);
 
         protected abstract IReadOnlyList<string> GetRawAliases(T item);
+
+        protected virtual bool IsCaseInsensitive(T item) => false;
 
         public bool Contains(string alias) => GetByAlias(alias) != null;
 

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -81,5 +81,7 @@ namespace System.CommandLine.Collections
             item.Aliases;
 
         protected override IReadOnlyList<string> GetRawAliases(ISymbol item) => item.RawAliases;
+
+        protected override bool IsCaseInsensitive(ISymbol item) => item.IsCaseInsensitive;
     }
 }

--- a/src/System.CommandLine/ISymbol.cs
+++ b/src/System.CommandLine/ISymbol.cs
@@ -23,6 +23,8 @@ namespace System.CommandLine
 
         bool IsHidden { get; }
 
+        bool IsCaseInsensitive { get; }
+
         ISymbolSet Children { get; }
 
         ISymbolSet Parents { get; }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -167,9 +167,16 @@ namespace System.CommandLine.Parsing
 
                         currentCommand = (ICommand) symbolSet.GetByAlias(arg)!;
 
-                        knownTokens = currentCommand.ValidTokens();
+                        if (currentCommand != null)
+                        {
+                            knownTokens = currentCommand.ValidTokens();
 
-                        tokenList.Add(Command(arg));
+                            tokenList.Add(Command(arg));
+                        }
+                        else
+                        {
+                            tokenList.Add(Argument(arg));
+                        }
                     }
                 }
             }
@@ -562,7 +569,7 @@ namespace System.CommandLine.Parsing
 
         private static Dictionary<string, Token> ValidTokens(this ICommand command)
         {
-            var tokens = new Dictionary<string, Token>();
+            var tokens = new Dictionary<string, Token>(StringComparer.OrdinalIgnoreCase);
 
             for (var commandAliasIndex = 0; commandAliasIndex < command.RawAliases.Count; commandAliasIndex++)
             {

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -50,6 +50,8 @@ namespace System.CommandLine
 
         public string? Description { get; set; }
 
+        public bool IsCaseInsensitive { get; set; } = false;
+
         public virtual string Name
         {
             get => _specifiedName ?? _longestAlias;
@@ -130,7 +132,8 @@ namespace System.CommandLine
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(alias));
             }
 
-            return _aliases.Contains(alias.RemovePrefix());
+            return _aliases.Contains(alias.RemovePrefix(),
+                                     IsCaseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
         }
 
         public bool HasRawAlias(string alias) => _rawAliases.Contains(alias);


### PR DESCRIPTION
This change adds IsCaseInsensitive property to ISymbol to provide the capability to declearing individual case command and option which is case insensitive. By default, it is case sensitive.

Closes #133