### PR TITLE
Improved lookups

### DIFF
--- a/samples/HostingPlayground/HostingPlayground.csproj
+++ b/samples/HostingPlayground/HostingPlayground.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8</LangVersion>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -355,16 +355,13 @@ namespace System.CommandLine.Tests
                 var argument = new Argument<int>(_ => 789, true);
                 argument.SetDefaultValue(123);
 
-                var result =  argument.Parse("");
+                var result = argument.Parse("");
 
-                var argumentResult = result.FindResultFor(argument);
-
-                argumentResult
-                    .GetValueOrDefault<int>()
-                    .Should()
-                    .Be(123);
+                result.ValueForArgument(argument)
+                      .Should()
+                      .Be(123);
             }
-            
+
             [Fact]
             public void Multiple_command_arguments_can_have_custom_parse_delegates()
             {

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -297,6 +297,41 @@ namespace System.CommandLine.Tests
                     .Should()
                     .Be(command);
             }
+            
+            [Theory]
+            [InlineData("-x value-x -y value-y")]
+            [InlineData("-y value-y -x value-x")]
+            public void Symbol_can_be_found_without_explicitly_traversing_result_tree(string commandLine)
+            {
+                SymbolResult resultForOptionX = null;
+                var optionX = new Option<string>(
+                    "-x",
+                    parseArgument: _ => string.Empty);
+                
+                var optionY = new Option<string>(
+                    "-y",
+                    parseArgument: argResult =>
+                    {
+                        resultForOptionX = argResult.FindResultFor(optionX);
+                        return string.Empty;
+                    });
+            
+                var command = new Command("the-command")
+                {
+                    optionX,
+                    optionY,
+                };
+            
+                command.Parse(commandLine);
+
+                resultForOptionX
+                    .Should()
+                    .BeOfType<OptionResult>()
+                    .Which
+                    .Option
+                    .Should()
+                    .BeSameAs(optionX);
+            }
 
             [Fact]
             public void Command_ArgumentResult_Parent_is_set_correctly_when_token_is_implicit()

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -30,16 +30,15 @@ namespace System.CommandLine
         public int MaximumNumberOfValues { get; set; }
 
         internal static FailedArgumentConversionArityResult? Validate(
-            SymbolResult? symbolResult,
+            SymbolResult symbolResult,
             IArgument argument,
             int minimumNumberOfValues,
             int maximumNumberOfValues)
         {
             var argumentResult = symbolResult switch
             {
-                CommandResult commandResult => commandResult.Root?.FindResultFor(argument),
-                OptionResult optionResult => optionResult.Children.ResultFor(argument),
-                _ => symbolResult
+                ArgumentResult a => a,
+                _ => symbolResult.Root!.FindResultFor(argument)
             };
 
             var tokenCount = argumentResult?.Tokens.Count ?? 0;

--- a/src/System.CommandLine/Binding/ArgumentConversionResultSet.cs
+++ b/src/System.CommandLine/Binding/ArgumentConversionResultSet.cs
@@ -8,12 +8,12 @@ namespace System.CommandLine.Binding
 {
     internal class ArgumentConversionResultSet : AliasedSet<ArgumentConversionResult>
     {
-        protected override IReadOnlyList<string> GetAliases(ArgumentConversionResult item)
+        protected override IReadOnlyCollection<string> GetAliases(ArgumentConversionResult item)
         {
             return new[] { item.Argument.Name };
         }
 
-        protected override IReadOnlyList<string> GetRawAliases(ArgumentConversionResult item)
+        protected override IReadOnlyCollection<string> GetRawAliases(ArgumentConversionResult item)
         {
             return new[] { item.Argument.Name };
         }

--- a/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
+++ b/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine.Binding
             {
                 // TODO: (FailedArgumentTypeConversionResult) localize
 
-                var firstParent = a.Parents.First();
+                var firstParent = a.Parents[0];
 
                 var symbolType =
                     firstParent switch {
@@ -34,7 +34,7 @@ namespace System.CommandLine.Binding
                         _ => null
                         };
 
-                var alias = firstParent.RawAliases[0];
+                var alias = firstParent.RawAliases.First();
 
                 return $"Cannot parse argument '{value}' for {symbolType} '{alias}' as expected type {type}.";
             }

--- a/src/System.CommandLine/ISymbol.cs
+++ b/src/System.CommandLine/ISymbol.cs
@@ -13,9 +13,9 @@ namespace System.CommandLine
 
         string? Description { get; }
 
-        IReadOnlyList<string> Aliases { get; }
+        IReadOnlyCollection<string> Aliases { get; }
 
-        IReadOnlyList<string> RawAliases { get; }
+        IReadOnlyCollection<string> RawAliases { get; }
 
         bool HasAlias(string alias);
 

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -56,7 +56,7 @@ namespace System.CommandLine
 
         private protected override void ChooseNameForUnnamedArgument(Argument argument)
         {
-            argument.Name = Aliases[0].ToLower();
+            argument.Name = Name.ToLower();
         }
     }
 }

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -51,6 +51,7 @@ namespace System.CommandLine.Parsing
             var parentResult = Parent;
 
             if (ShouldCheckArity() &&
+                parentResult is {} &&
                 ArgumentArity.Validate(parentResult,
                                        argument,
                                        argument.Arity.MinimumNumberOfValues,

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -51,7 +51,7 @@ namespace System.CommandLine.Parsing
             var parentResult = Parent;
 
             if (ShouldCheckArity() &&
-                parentResult is {} &&
+                parentResult is { } &&
                 ArgumentArity.Validate(parentResult,
                                        argument,
                                        argument.Arity.MinimumNumberOfValues,

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -35,8 +35,6 @@ namespace System.CommandLine.Parsing
 
         public Token Token { get; }
 
-        internal virtual RootCommandResult? Root => (Parent as CommandResult)?.Root;
-
         internal bool TryGetValueForArgument(
             IValueDescriptor valueDescriptor,
             out object? value)

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -325,7 +325,7 @@ namespace System.CommandLine.Parsing
             {
                 foreach (var symbol in commandResult.Command.Children)
                 {
-                    var symbolResult = _rootCommandResult!.FindResultFor(symbol);
+                    var symbolResult = _rootCommandResult!.FindResultForSymbol(symbol);
 
                     if (symbolResult is null)
                     {

--- a/src/System.CommandLine/Parsing/RootCommandResult.cs
+++ b/src/System.CommandLine/Parsing/RootCommandResult.cs
@@ -47,7 +47,7 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        public ArgumentResult? FindResultFor(IArgument argument)
+        public override ArgumentResult? FindResultFor(IArgument argument)
         {
             EnsureResultMapsAreInitialized();
 
@@ -56,7 +56,7 @@ namespace System.CommandLine.Parsing
             return result;
         }
 
-        public CommandResult? FindResultFor(ICommand command)
+        public override CommandResult? FindResultFor(ICommand command)
         {
             EnsureResultMapsAreInitialized();
 
@@ -65,7 +65,7 @@ namespace System.CommandLine.Parsing
             return result;
         }
 
-        public OptionResult? FindResultFor(IOption option)
+        public override OptionResult? FindResultFor(IOption option)
         {
             EnsureResultMapsAreInitialized();
 
@@ -74,7 +74,7 @@ namespace System.CommandLine.Parsing
             return result;
         }
 
-        public SymbolResult? FindResultFor(ISymbol symbol)
+        public SymbolResult? FindResultForSymbol(ISymbol symbol)
         {
             switch (symbol)
             {

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -566,7 +566,8 @@ namespace System.CommandLine.Parsing
 
             for (var commandAliasIndex = 0; commandAliasIndex < command.RawAliases.Count; commandAliasIndex++)
             {
-                var commandAlias = command.RawAliases[commandAliasIndex];
+                var commandAlias = command.RawAliases.ToArray()[commandAliasIndex];
+                
                 tokens.Add(
                     commandAlias,
                     new Token(
@@ -579,7 +580,7 @@ namespace System.CommandLine.Parsing
 
                     for (var childAliasIndex = 0; childAliasIndex < child.RawAliases.Count; childAliasIndex++)
                     {
-                        var childAlias = child.RawAliases[childAliasIndex];
+                        var childAlias = child.RawAliases.ToArray()[childAliasIndex];
 
                         tokens[childAlias] =
                             new Token(

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -566,7 +566,7 @@ namespace System.CommandLine.Parsing
 
             for (var commandAliasIndex = 0; commandAliasIndex < command.RawAliases.Count; commandAliasIndex++)
             {
-                var commandAlias = command.RawAliases.ToArray()[commandAliasIndex];
+                var commandAlias = command.RawAliases.ElementAt(commandAliasIndex);
                 
                 tokens.Add(
                     commandAlias,
@@ -580,7 +580,7 @@ namespace System.CommandLine.Parsing
 
                     for (var childAliasIndex = 0; childAliasIndex < child.RawAliases.Count; childAliasIndex++)
                     {
-                        var childAlias = child.RawAliases.ToArray()[childAliasIndex];
+                        var childAlias = child.RawAliases.ElementAt(childAliasIndex);
 
                         tokens[childAlias] =
                             new Token(

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -27,6 +27,8 @@ namespace System.CommandLine.Parsing
 
         public SymbolResult? Parent { get; }
 
+        internal virtual RootCommandResult? Root => (Parent as CommandResult)?.Root;
+
         public ISymbol Symbol { get; }
 
         public IReadOnlyList<Token> Tokens => _tokens;

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -27,7 +27,13 @@ namespace System.CommandLine.Parsing
 
         public SymbolResult? Parent { get; }
 
-        internal virtual RootCommandResult? Root => (Parent as CommandResult)?.Root;
+        internal virtual RootCommandResult? Root =>
+            Parent switch
+            {
+                CommandResult c => c.Root,
+                OptionResult o => o.Parent?.Root,
+                _ => null
+            };
 
         public ISymbol Symbol { get; }
 
@@ -64,6 +70,15 @@ namespace System.CommandLine.Parsing
         }
 
         internal void AddToken(Token token) => _tokens.Add(token);
+
+        public virtual ArgumentResult? FindResultFor(IArgument argument) =>
+            Root?.FindResultFor(argument);
+
+        public virtual CommandResult? FindResultFor(ICommand command) =>
+            Root?.FindResultFor(command);
+
+        public virtual OptionResult? FindResultFor(IOption option) =>
+            Root?.FindResultFor(option);
 
         internal ArgumentResult GetOrCreateDefaultArgumentResult(Argument argument) =>
             _defaultArgumentValues.GetOrAdd(

--- a/src/System.CommandLine/Parsing/SymbolResultSet.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultSet.cs
@@ -12,10 +12,10 @@ namespace System.CommandLine.Parsing
         internal SymbolResult? ResultFor(ISymbol symbol) =>
             Items.SingleOrDefault(i => i.Symbol == symbol);
 
-        protected override IReadOnlyList<string> GetAliases(SymbolResult item) =>
+        protected override IReadOnlyCollection<string> GetAliases(SymbolResult item) =>
             item.Symbol.Aliases;
 
-        protected override IReadOnlyList<string> GetRawAliases(SymbolResult item) =>
+        protected override IReadOnlyCollection<string> GetRawAliases(SymbolResult item) =>
             item.Symbol.RawAliases;
     }
 }

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -11,8 +11,8 @@ namespace System.CommandLine
 {
     public abstract class Symbol : ISymbol
     {
-        private readonly List<string> _aliases = new List<string>();
-        private readonly List<string> _rawAliases = new List<string>();
+        private readonly HashSet<string> _aliases = new HashSet<string>();
+        private readonly HashSet<string> _rawAliases = new HashSet<string>();
         private string _longestAlias = "";
         private string? _specifiedName;
 
@@ -44,9 +44,9 @@ namespace System.CommandLine
             Description = description;
         }
 
-        public IReadOnlyList<string> Aliases => _aliases;
+        public IReadOnlyCollection<string> Aliases => _aliases;
 
-        public IReadOnlyList<string> RawAliases => _rawAliases;
+        public IReadOnlyCollection<string> RawAliases => _rawAliases;
 
         public string? Description { get; set; }
 
@@ -132,7 +132,7 @@ namespace System.CommandLine
 
             return _aliases.Contains(alias.RemovePrefix());
         }
-
+  
         public bool HasRawAlias(string alias) => _rawAliases.Contains(alias);
 
         public bool IsHidden { get; set; }


### PR DESCRIPTION
This improves a number of lookups by shifting from iterations to `HashSet` and `Dictionary` lookups. 

It also adds a `SymbolResult.FindResultFor` method which can be used to simplify the usage of `ParseArgument<T>` by providing a more robust mechanism than traversing the result tree.