### PR TITLE
Fix broken links and update staled repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ This project has adopted the code of conduct defined by the [Contributor Covenan
 
 ## Contributing
 
-See the [Contributing guide](CONTRIBUTING) for developer documentation.
+See the [Contributing guide](CONTRIBUTING.md) for developer documentation.
 
 ## License
 
-This project is licensed under the [MIT license](LICENSE.TXT).
+This project is licensed under the [MIT license](LICENSE.md).
 
 ## .NET Foundation
 

--- a/docs/DragonFruit-overview.md
+++ b/docs/DragonFruit-overview.md
@@ -103,6 +103,6 @@ Options:
   --version                    Display version information
 ```
 
-The argument follows the same conventions for arity as described in [arguments](Syntax-Concepts-and-Parser#Arguments-and-arity).
+The argument follows the same conventions for arity as described in [arguments](Syntax-Concepts-and-Parser.md#Arguments-and-arity).
 
 You can try out DragonFruit by installing the latest preview [package](https://www.nuget.org/packages/System.CommandLine.DragonFruit).

--- a/docs/Features-overview.md
+++ b/docs/Features-overview.md
@@ -129,7 +129,7 @@ The raw text written to standard out in the first example is this:
 
  ## Rendering directives
 
-Output modes can also be specified directly. If you know that you want a specific form of output, you can bypass the mode detection of `System.CommandLine.Rendering` and use a [directive](Syntax-Concepts-and-Parser#directives).
+Output modes can also be specified directly. If you know that you want a specific form of output, you can bypass the mode detection of `System.CommandLine.Rendering` and use a [directive](Syntax-Concepts-and-Parser.md#directives).
 
 The following example will output ANSI to a text file.
 

--- a/docs/How-To.md
+++ b/docs/How-To.md
@@ -2,7 +2,7 @@
 
 ## Add an alias to an option or command
 
-Both commands and options support [aliases](Concepts#Aliases). You can add an alias to an option like this:
+Both commands and options support [aliases](Concepts.md#Aliases). You can add an alias to an option like this:
 
 ``` csharp
 var option = new Option("--verbose");
@@ -122,7 +122,7 @@ public static void DoSomething(int anInt, string aString)
 
 ### Method-first
 
-Another approach is to let `System.CommandLine` configure the parser for you based on your method signature using the `Command.ConfigureFromMethod` extension method found in the `System.CommandLine.DragonFruit` library. (The  [DragonFruit](Your-first-app-with-System.CommandLine.DragonFruit) app model uses this approach for its strongly-typed `Main` method but it can be used with any method.)
+Another approach is to let `System.CommandLine` configure the parser for you based on your method signature using the `Command.ConfigureFromMethod` extension method found in the `System.CommandLine.DragonFruit` library. (The  [DragonFruit](Your-first-app-with-System.CommandLine.DragonFruit.md) app model uses this approach for its strongly-typed `Main` method but it can be used with any method.)
 
 
 ```csharp

--- a/docs/Syntax-Concepts-and-Parser.md
+++ b/docs/Syntax-Concepts-and-Parser.md
@@ -60,7 +60,7 @@ In both POSIX and Windows command lines, it's common for some options to have al
 -v, --verbose    Show verbose output 
 ```
 
-In `System.CommandLine`, both the `Command` and `Option` classes support adding [aliases](How-To#Add-an-alias-to-an-option-or-command).
+In `System.CommandLine`, both the `Command` and `Option` classes support adding [aliases](How-To#Add-an-alias-to-an-option-or-command.md).
 
 ## Arguments and arity
 

--- a/docs/Your-first-app-with-System-CommandLine-DragonFruit.md
+++ b/docs/Your-first-app-with-System-CommandLine-DragonFruit.md
@@ -58,6 +58,6 @@ The value for --bool-option is: False
 The value for --file-option is: null
 ```
 
-This program is equivalent to the one demonstrated in [Your first app with System.CommandLine](Your-first-app-with-System.CommandLine).
+This program is equivalent to the one demonstrated in [Your first app with System.CommandLine](Your-first-app-with-System.CommandLine.md).
 
-To explore its features, take a look at [Features: overview](Features-overview)
+To explore its features, take a look at [Features: overview](Features-overview.md)

--- a/docs/Your-first-app-with-System-CommandLine.md
+++ b/docs/Your-first-app-with-System-CommandLine.md
@@ -87,6 +87,6 @@ The value for --bool-option is: False
 The value for --file-option is: null
 ```
 
-This program is equivalent to the one demonstrated in [Your first app with System.CommandLine.DragonFruit](Your-first-app-with-System.CommandLine.DragonFruit).
+This program is equivalent to the one demonstrated in [Your first app with System.CommandLine.DragonFruit](Your-first-app-with-System.CommandLine.DragonFruit.md).
 
-To explore its features, take a look at [Features: overview](Features-overview)
+To explore its features, take a look at [Features: overview](Features-overview.md)

--- a/docs/dotnet-suggest.md
+++ b/docs/dotnet-suggest.md
@@ -12,12 +12,12 @@ On the machine where you'd like to enable completion, you'll need to do two thin
 
 2. Add the appropriate shim script to your shell profile. You may have to create a shell profile file. The shim script will forward completion requests from your shell to the `dotnet-suggest` tool, which delegates to the appropriate `System.CommandLine`-based app.
 
-    * For bash, add the contents of [dotnet-suggest-shim.bash](https://github.com/dotnet/System.CommandLine/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash) to `~/.bash_profile`.
+    * For bash, add the contents of [dotnet-suggest-shim.bash](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash) to `~/.bash_profile`.
 
-    * For PowerShell, add the contents of [dotnet-suggest-shim.ps1](https://github.com/dotnet/System.CommandLine/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1) to your PowerShell profile. You can find the expected path to your PowerShell profile by running the following in your console:
+    * For PowerShell, add the contents of [dotnet-suggest-shim.ps1](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1) to your PowerShell profile. You can find the expected path to your PowerShell profile by running the following in your console:
 
 ```console
 > echo $profile
 ``` 
 
-(For other shells, please [look for](https://github.com/dotnet/System.CommandLine/issues?q=is%3Aissue+is%3Aopen+label%3A%22shell+suggestion%22) or open an [issue](https://github.com/dotnet/System.CommandLine/issues).)
+(For other shells, please [look for](https://github.com/dotnet/command-line-api/issues?q=is%3Aissue+is%3Aopen+label%3A%22shell+suggestion%22) or open an [issue](https://github.com/dotnet/command-line-api/issues).)

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -13,16 +13,16 @@ _Give your users a great experience with your .NET console applications while le
 
 You can read more about it here:
 
-* [History](History)
-* [Functional goals](Functional-goals)
-* [Technical motivations](Technical-motivations)
+* [History](History.md)
+* [Functional goals](Functional-goals.md)
+* [Technical motivations](Technical-motivations.md)
 
 ## Try it out
 
-The simplest way to create your parser is with the experimental [DragonFruit app model](DragonFruit-overview). This works well if you have a single layer of commands (no subcommands).
+The simplest way to create your parser is with the experimental [DragonFruit app model](DragonFruit-overview.md). This works well if you have a single layer of commands (no subcommands).
 
-[Your first app with System.CommandLine.DragonFruit](Your-first-app-with-System-CommandLine-DragonFruit)
+[Your first app with System.CommandLine.DragonFruit](Your-first-app-with-System-CommandLine-DragonFruit.md)
 
 For more complex scenarios, you can use the core APIs directly.
 
-[Your first app with System.CommandLine](Your-first-app-with-System-CommandLine)
+[Your first app with System.CommandLine](Your-first-app-with-System-CommandLine.md)


### PR DESCRIPTION
From #971, */docs* had been added, there were broken links from missing file extension, *.md*. Also in */docs/dotnet-suggest.md*, it has used staled url (i.e., *https://github.com/dotnet/System.CommandLine/...*), it fixes and updates them.

please review these changes 🙏  cc. @jonsequitur 