### PR TITLE
Nit: Override Write(string?) in StandardStreamWriter

### DIFF
--- a/src/System.CommandLine/IO/TestConsole.cs
+++ b/src/System.CommandLine/IO/TestConsole.cs
@@ -33,6 +33,11 @@ namespace System.CommandLine.IO
                 _stringBuilder.Append(value);
             }
 
+            public override void Write(string? value)
+            {
+                _stringBuilder.Append(value);
+            }
+
             public override Encoding Encoding { get; } = Encoding.Unicode;
 
             public override string ToString() => _stringBuilder.ToString();


### PR DESCRIPTION
`TextWriter` uses `string.ToCharArray` which is slow.

Besides, this is the only overload that is exposed through `IStandardStreamWriter`.