### PR TITLE
Extend CommandHandler to handle up to 11 arguments

### DIFF
--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -46,6 +46,22 @@ namespace System.CommandLine.Invocation
             Action<T1, T2, T3, T4, T5, T6, T7> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
         public static ICommandHandler Create(Func<int> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 


### PR DESCRIPTION
This patch fixes `System.CommandLine.Invocation.CommandHandler.Create`
so that it can handle actions with up to 11 arguments. Current limit of
7 arguments is not enough for a more complex applications.

While users can alternatively bind arguments to arbitrary number of
properties, this requires refactoring the code once the limit is
hit. Additionally, some users are not aware of the feature and could
hit the wall unintentionally. With this patch, the arbitrary, but
reasonable limit of 11 arguments should cover most of the use cases
"in the wild".

Fix #983.