### PR TITLE
Update Syntax-Concepts-and-Parser.md

### DIFF
--- a/docs/Syntax-Concepts-and-Parser.md
+++ b/docs/Syntax-Concepts-and-Parser.md
@@ -68,8 +68,8 @@ An argument is a value passed to an option or command.
 
 ```console
 > myapp --int-option 123
-        ^----------^
-        option argument
+                     ^-^
+                     option argument
        
 > myapp --int-option 123 "hello there"
                          ^-----------^


### PR DESCRIPTION
I believe option argument illustration here is meant to be on the numeric value 123 instead of on the option itself. --int-option is the option and 123 is the option argument.