### PR TITLE
fix #1007: split token on delimiter only if first part matches an option

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1975,6 +1975,25 @@ namespace System.CommandLine.Tests
             instance.Should().BeEquivalentTo("a", "b", "c");
         }
 
+        [Fact]
+        public void Tokens_are_not_split_if_the_part_before_the_delimiter_is_not_an_option()
+        {
+            var rootCommand = new RootCommand
+            {
+                Name = "jdbc"
+            };
+            rootCommand.Add(new Option<string>("url"));
+            var result = rootCommand.Parse("jdbc url \"jdbc:sqlserver://10.0.0.2;databaseName=main\"");
+
+            _output.WriteLine(result.ToString());
+
+            result.Tokens
+                  .Select(t => t.Value)
+                  .Should()
+                  .BeEquivalentTo("url",
+                                  "jdbc:sqlserver://10.0.0.2;databaseName=main");
+        }
+
         [TypeConverter(typeof(CustomTypeConverter))]
         public class ClassWithCustomTypeConverter
         {

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Binding;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -68,7 +68,7 @@ namespace System.CommandLine.Parsing
             var foundEndOfDirectives = !configuration.EnableDirectives;
             var argList = NormalizeRootCommand(configuration, args);
 
-            var argumentDelimiters = configuration.ArgumentDelimitersInternal;
+            var argumentDelimiters = configuration.ArgumentDelimitersInternal.ToArray();
 
             var knownTokens = configuration.RootCommand.ValidTokens();
 
@@ -125,7 +125,8 @@ namespace System.CommandLine.Parsing
                                               out var first, 
                                               out var rest))
                 {
-                    if (knownTokens.ContainsKey(first!))
+                    if (knownTokens.TryGetValue(first!, out var token) &&
+                        token.Type == TokenType.Option)
                     {
                         tokenList.Add(Option(first!));
 
@@ -412,13 +413,13 @@ namespace System.CommandLine.Parsing
 
         internal static bool TrySplitIntoSubtokens(
             this string arg,
-            IReadOnlyCollection<char> delimiters,
+            char[] delimiters,
             out string? first,
             out string? rest)
         {
-            var delimitersArray = delimiters.ToArray();
+            var delimitersArray = delimiters;
 
-            for (var j = 0; j < delimiters.Count; j++)
+            for (var j = 0; j < delimiters.Length; j++)
             {
                 var i = arg.IndexOfAny(delimitersArray);
 


### PR DESCRIPTION
This fixes #1007.