### PR TITLE
CommandHandler.Create without name matching

### DIFF
--- a/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.BindingByName.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.BindingByName.cs
@@ -1,0 +1,167 @@
+﻿// // Copyright (c) .NET Foundation and contributors. All rights reserved.
+// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Binding;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests.Binding
+{
+    public partial class ModelBindingCommandHandlerTests
+    {
+        public class BindingByName
+        {
+            [Theory]
+            [InlineData(typeof(bool), "--value", true)]
+            [InlineData(typeof(bool), "--value false", false)]
+            [InlineData(typeof(string), "--value hello", "hello")]
+            [InlineData(typeof(int), "--value 123", 123)]
+            public async Task Option_arguments_are_bound_by_name_to_method_parameters(
+                Type type,
+                string commandLine,
+                object expectedValue)
+            {
+                var targetType = typeof(ClassWithMethodHavingParameter<>).MakeGenericType(type);
+
+                var handlerMethod = targetType.GetMethod(nameof(ClassWithMethodHavingParameter<int>.HandleAsync));
+
+                var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
+                                               .GetCommandHandler();
+
+                var command = new Command("the-command")
+                {
+                    new Option("--value", argumentType: type)
+                };
+
+                var console = new TestConsole();
+
+                await handler.InvokeAsync(
+                    new InvocationContext(command.Parse(commandLine), console));
+
+                console.Out.ToString().Should().Be(expectedValue.ToString());
+            }
+
+            [Theory]
+            [InlineData(typeof(bool), "--value", true)]
+            [InlineData(typeof(bool), "--value false", false)]
+            [InlineData(typeof(string), "--value hello", "hello")]
+            [InlineData(typeof(int), "--value 123", 123)]
+            public async Task Option_arguments_are_bound_by_name_to_the_properties_of_method_parameters(
+                Type type,
+                string commandLine,
+                object expectedValue)
+            {
+                var complexParameterType = typeof(ClassWithSetter<>).MakeGenericType(type);
+
+                var handlerType = typeof(ClassWithMethodHavingParameter<>).MakeGenericType(complexParameterType);
+
+                var handlerMethod = handlerType.GetMethod("HandleAsync");
+
+                var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
+                                               .GetCommandHandler();
+
+                var command = new Command("the-command")
+                {
+                    new Option("--value", argumentType: type)
+                };
+
+                var console = new TestConsole();
+
+                await handler.InvokeAsync(
+                    new InvocationContext(command.Parse(commandLine), console));
+
+                console.Out.ToString().Should().Be($"ClassWithSetter<{type.Name}>: {expectedValue}");
+            }
+
+            [Theory]
+            [InlineData(typeof(bool), "--value", true)]
+            [InlineData(typeof(bool), "--value false", false)]
+            [InlineData(typeof(string), "--value hello", "hello")]
+            [InlineData(typeof(int), "--value 123", 123)]
+            public async Task Option_arguments_are_bound_by_name_to_the_constructor_parameters_of_method_parameters(
+                Type type,
+                string commandLine,
+                object expectedValue)
+            {
+                var complexParameterType = typeof(ClassWithCtorParameter<>).MakeGenericType(type);
+
+                var handlerType = typeof(ClassWithMethodHavingParameter<>).MakeGenericType(complexParameterType);
+
+                var handlerMethod = handlerType.GetMethod("HandleAsync");
+
+                var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
+                                               .GetCommandHandler();
+
+                var command = new Command("the-command")
+                {
+                    new Option("--value", argumentType: type)
+                };
+
+                var console = new TestConsole();
+
+                await handler.InvokeAsync(
+                    new InvocationContext(command.Parse(commandLine), console));
+
+                console.Out.ToString().Should().Be($"ClassWithCtorParameter<{type.Name}>: {expectedValue}");
+            }
+
+            [Theory]
+            [InlineData(typeof(string), "hello", "hello")]
+            [InlineData(typeof(int), "123", 123)]
+            public async Task Command_arguments_are_bound_by_name_to_handler_method_parameters(
+                Type type,
+                string commandLine,
+                object expectedValue)
+            {
+                var targetType = typeof(ClassWithMethodHavingParameter<>).MakeGenericType(type);
+
+                var handlerMethod = targetType.GetMethod(nameof(ClassWithMethodHavingParameter<int>.HandleAsync));
+
+                var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
+                                               .GetCommandHandler();
+
+                var command = new Command("the-command")
+                {
+                    new Argument
+                    {
+                        Name = "value",
+                        ArgumentType = type
+                    }
+                };
+
+                var console = new TestConsole();
+
+                await handler.InvokeAsync(
+                    new InvocationContext(command.Parse(commandLine), console));
+
+                console.Out.ToString().Should().Be(expectedValue.ToString());
+            }
+
+            [Fact]
+            public void When_argument_type_is_more_specific_than_parameter_type_then_parameter_is_bound_correctly()
+            {
+                FileSystemInfo received = null;
+
+                var root = new RootCommand
+                {
+                    new Option<DirectoryInfo>("-f")
+                };
+                root.Handler = CommandHandler.Create<FileSystemInfo>(f => received = f);
+                var path = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}";
+
+                root.Invoke($"-f {path}");
+
+                received.Should()
+                        .BeOfType<DirectoryInfo>()
+                        .Which
+                        .FullName
+                        .Should()
+                        .Be(path);
+            }
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.BindingBySymbol.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.BindingBySymbol.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.CommandLine.Invocation;
+using System.Linq;
+using FluentAssertions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.CommandLine.Tests.Binding
+{
+    public partial class ModelBindingCommandHandlerTests
+    {
+        public class BindingBySymbol
+        {
+            [Theory]
+            [InlineData(1)]
+            [InlineData(2)]
+            [InlineData(3)]
+            [InlineData(4)]
+            [InlineData(5)]
+            [InlineData(6)]
+            [InlineData(7)]
+            [InlineData(8)]
+            [InlineData(9)]
+            [InlineData(10)]
+            [InlineData(11)]
+            [InlineData(12)]
+            [InlineData(13)]
+            [InlineData(14)]
+            [InlineData(15)]
+            [InlineData(16)]
+            public void Binding_is_correct_for_overload_having_arity_(int arity)
+            {
+                var command = new RootCommand();
+                var commandLine = "";
+
+                for (var i = 1; i <= arity; i++)
+                {
+                    command.AddArgument(new Argument<int>($"i{i}"));
+
+                    commandLine += $" {i}";
+                }
+
+                var receivedValues = new List<int>();
+                Delegate handlerFunc = arity switch
+                {
+                    1 => new Func<int, Task>(
+                        i1 =>
+                            Received(i1)),
+                    2 => new Func<int, int, Task>(
+                        (i1, i2) =>
+                            Received(i1, i2)),
+                    3 => new Func<int, int, int, Task>(
+                        (i1, i2, i3) =>
+                            Received(i1, i2, i3)),
+                    4 => new Func<int, int, int, int, Task>(
+                        (i1, i2, i3, i4) =>
+                            Received(i1, i2, i3, i4)),
+                    5 => new Func<int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5) =>
+                            Received(i1, i2, i3, i4, i5)),
+                    6 => new Func<int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6) =>
+                            Received(i1, i2, i3, i4, i5, i6)),
+                    7 => new Func<int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7)),
+                    8 => new Func<int, int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7, i8) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8)),
+                    9 => new Func<int, int, int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7, i8, i9) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8, i9)),
+                    10 => new Func<int, int, int, int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8, i9, i10)),
+                    11 => new Func<int, int, int, int, int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11)),
+                    12 => new Func<int, int, int, int, int, int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12)),
+                    13 => new Func<int, int, int, int, int, int, int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13)),
+                    14 => new Func<int, int, int, int, int, int, int, int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14)),
+                    15 => new Func<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, Task>(
+                        (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15)),
+                    16 => new Func<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, Task>(
+                        
+                        (i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16) =>
+                            Received(i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12, i13, i14, i15, i16)),
+
+                    _ => throw new ArgumentOutOfRangeException()
+                };
+
+                // build up the method invocation
+                var genericMethodDef = typeof(CommandHandler)
+                                       .GetMethods()
+                                       .Where(m => m.Name == nameof(CommandHandler.Create))
+                                       .Where(m => m.IsGenericMethod /* symbols + handler Func */)
+                                       .Single(m => m.GetParameters().Length == arity + 1);
+
+                var genericParameterTypes = Enumerable.Range(1, arity)
+                                                      .Select(_ => typeof(int))
+                                                      .ToArray();
+
+                var createMethod = genericMethodDef.MakeGenericMethod(genericParameterTypes);
+
+                var parameters = new List<object>();
+
+                parameters.AddRange(command.Arguments);
+                parameters.Add(handlerFunc);
+
+                var handler = (ICommandHandler) createMethod.Invoke(null, parameters.ToArray());
+
+                command.Handler = handler;
+
+                command.Invoke(commandLine);
+
+                receivedValues.Should().BeEquivalentTo(
+                    Enumerable.Range(1, arity),
+                    config => config.WithStrictOrdering());
+
+                Task Received(params int[] values)
+                {
+                    receivedValues.AddRange(values);
+                    return Task.CompletedTask;
+                }
+            }
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.IO;
@@ -15,134 +14,8 @@ using Xunit;
 
 namespace System.CommandLine.Tests.Binding
 {
-    public class ModelBindingCommandHandlerTests
+    public partial class ModelBindingCommandHandlerTests
     {
-        [Theory]
-        [InlineData(typeof(bool), "--value", true)]
-        [InlineData(typeof(bool), "--value false", false)]
-        [InlineData(typeof(string), "--value hello", "hello")]
-        [InlineData(typeof(int), "--value 123", 123)]
-        public async Task Option_arguments_are_bound_by_name_to_method_parameters(
-            Type type,
-            string commandLine,
-            object expectedValue)
-        {
-            var targetType = typeof(ClassWithMethodHavingParameter<>).MakeGenericType(type);
-
-            var handlerMethod = targetType.GetMethod(nameof(ClassWithMethodHavingParameter<int>.HandleAsync));
-
-            var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
-                                           .GetCommandHandler();
-
-            var command = new Command("the-command")
-                          {
-                              new Option("--value", argumentType: type)
-                          };
-
-            var console = new TestConsole();
-
-            await handler.InvokeAsync(
-                new InvocationContext(command.Parse(commandLine), console));
-
-            console.Out.ToString().Should().Be(expectedValue.ToString());
-        }
-
-        [Theory]
-        [InlineData(typeof(bool), "--value", true)]
-        [InlineData(typeof(bool), "--value false", false)]
-        [InlineData(typeof(string), "--value hello", "hello")]
-        [InlineData(typeof(int), "--value 123", 123)]
-        public async Task Option_arguments_are_bound_by_name_to_the_properties_of_method_parameters(
-            Type type,
-            string commandLine,
-            object expectedValue)
-        {
-            var complexParameterType = typeof(ClassWithSetter<>).MakeGenericType(type);
-
-            var handlerType = typeof(ClassWithMethodHavingParameter<>).MakeGenericType(complexParameterType);
-
-            var handlerMethod = handlerType.GetMethod("HandleAsync");
-
-            var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
-                                           .GetCommandHandler();
-
-            var command = new Command("the-command")
-                          {
-                              new Option("--value", argumentType: type)
-                          };
-
-            var console = new TestConsole();
-
-            await handler.InvokeAsync(
-                new InvocationContext(command.Parse(commandLine), console));
-
-            console.Out.ToString().Should().Be($"ClassWithSetter<{type.Name}>: {expectedValue}");
-        }
-
-        [Theory]
-        [InlineData(typeof(bool), "--value", true)]
-        [InlineData(typeof(bool), "--value false", false)]
-        [InlineData(typeof(string), "--value hello", "hello")]
-        [InlineData(typeof(int), "--value 123", 123)]
-        public async Task Option_arguments_are_bound_by_name_to_the_constructor_parameters_of_method_parameters(
-            Type type,
-            string commandLine,
-            object expectedValue)
-        {
-            var complexParameterType = typeof(ClassWithCtorParameter<>).MakeGenericType(type);
-
-            var handlerType = typeof(ClassWithMethodHavingParameter<>).MakeGenericType(complexParameterType);
-
-            var handlerMethod = handlerType.GetMethod("HandleAsync");
-
-            var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
-                                           .GetCommandHandler();
-
-            var command = new Command("the-command")
-                          {
-                              new Option("--value", argumentType: type)
-                          };
-
-            var console = new TestConsole();
-
-            await handler.InvokeAsync(
-                new InvocationContext(command.Parse(commandLine), console));
-
-            console.Out.ToString().Should().Be($"ClassWithCtorParameter<{type.Name}>: {expectedValue}");
-        }
-
-        [Theory]
-        [InlineData(typeof(string), "hello", "hello")]
-        [InlineData(typeof(int), "123", 123)]
-        public async Task Command_arguments_are_bound_by_name_to_handler_method_parameters(
-            Type type,
-            string commandLine,
-            object expectedValue)
-        {
-            var targetType = typeof(ClassWithMethodHavingParameter<>).MakeGenericType(type);
-
-            var handlerMethod = targetType.GetMethod(nameof(ClassWithMethodHavingParameter<int>.HandleAsync));
-
-            var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
-                                           .GetCommandHandler();
-
-            var command = new Command("the-command")
-            {
-                new Argument
-                {
-                    Name = "value",
-                    ArgumentType = type
-                }
-            };
-
-            var console = new TestConsole();
-
-            await handler.InvokeAsync(
-                new InvocationContext(command.Parse(commandLine), console));
-
-            console.Out.ToString().Should().Be(expectedValue.ToString());
-        }
-
         [Theory]
         [InlineData(typeof(string), "")]
         [InlineData(typeof(FileInfo), null)]
@@ -212,28 +85,6 @@ namespace System.CommandLine.Tests.Binding
             received.Should().Be(123);
         }
 
-        [Fact]
-        public void When_argument_type_is_more_specific_than_parameter_type_then_parameter_is_bound_correctly()
-        {
-            FileSystemInfo received = null;
-
-            var root = new RootCommand
-            {
-                new Option<DirectoryInfo>("-f")
-            };
-            root.Handler = CommandHandler.Create<FileSystemInfo>(f => received = f);
-            var path = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}";
-
-            root.Invoke($"-f {path}");
-
-            received.Should()
-                    .BeOfType<DirectoryInfo>()
-                    .Which
-                    .FullName
-                    .Should()
-                    .Be(path);
-        }
-
         [Theory]
         [InlineData(typeof(ClassWithCtorParameter<int>), false)]
         [InlineData(typeof(ClassWithCtorParameter<int>), true)]
@@ -292,7 +143,7 @@ namespace System.CommandLine.Tests.Binding
 
                 var @delegate = createCaptureDelegate.Invoke(null, null);
 
-                handler = CommandHandler.Create((dynamic)@delegate);
+                handler = CommandHandler.Create((Delegate)@delegate);
             }
 
             var command = new Command("command")

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
@@ -28,8 +28,7 @@ namespace System.CommandLine.Tests.Help
                 },
                 new Argument<FileAccess>("the-root-arg-enum-default", () => FileAccess.Read)
                 {
-                    Description = "the-root-arg-enum-default-description",
-                    ArgumentType = typeof(FileAccess)
+                    Description = "the-root-arg-enum-default-description"
                 },
                 new Option(aliases: new string[] {"--the-root-option-no-arg", "-trna"}) {
                     Description = "the-root-option-no-arg-description",

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -1,19 +1,20 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Binding;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
 
 namespace System.CommandLine
 {
-    ///<inheritdoc/>
-    public class Argument<T> : Argument
+    /// <inheritdoc cref="Argument" />
+    public class Argument<T> : Argument, IValueDescriptor<T>
     {
         /// <summary>
         /// Initializes a new instance of the Argument class.
         /// </summary>
         public Argument()
         {
-            ArgumentType = typeof(T);
         }
 
         /// <summary>
@@ -25,7 +26,6 @@ namespace System.CommandLine
             string name, 
             string? description = null) : base(name)
         {
-            ArgumentType = typeof(T);
             Description = description;
         }
 
@@ -121,6 +121,13 @@ namespace System.CommandLine
         /// <param name="isDefault"><see langword="true"/> to use the <paramref name="parse"/> result as default value.</param>
         public Argument(ParseArgument<T> parse, bool isDefault = false) : this(null, parse, isDefault)
         {
+        }
+
+        /// <inheritdoc />
+        public override Type ArgumentType
+        {
+            get => typeof(T);
+            set => throw new NotImplementedException();
         }
     }
 }

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine.Binding;
 using System.CommandLine.Parsing;
-using System.Diagnostics;
 
 namespace System.CommandLine
 {

--- a/src/System.CommandLine/Binding/HandlerDescriptor.cs
+++ b/src/System.CommandLine/Binding/HandlerDescriptor.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Invocation;
-using System.Linq;
 using System.Reflection;
 
 namespace System.CommandLine.Binding

--- a/src/System.CommandLine/Binding/IValueDescriptor.cs
+++ b/src/System.CommandLine/Binding/IValueDescriptor.cs
@@ -13,4 +13,9 @@ namespace System.CommandLine.Binding
 
         object? GetDefaultValue();
     }
+
+    public interface IValueDescriptor<T> : IValueDescriptor
+    {
+        // FIX: (IValueDescriptor) 
+    }
 }

--- a/src/System.CommandLine/Invocation/CommandHandler.NameBasedBinding.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.NameBasedBinding.cs
@@ -1,0 +1,282 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Binding;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace System.CommandLine.Invocation
+{
+    public static partial class CommandHandler
+    {
+        public static ICommandHandler Create(Delegate @delegate) =>
+            HandlerDescriptor.FromDelegate(@delegate).GetCommandHandler();
+
+        public static ICommandHandler Create(MethodInfo method, object? target = null) =>
+            HandlerDescriptor.FromMethodInfo(method, target).GetCommandHandler();
+
+        public static ICommandHandler Create<T>(
+            Action<T> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2>(
+            Action<T1, T2> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3>(
+            Action<T1, T2, T3> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4>(
+            Action<T1, T2, T3, T4> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
+            Action<T1, T2, T3, T4, T5> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
+            Action<T1, T2, T3, T4, T5, T6> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
+            Action<T1, T2, T3, T4, T5, T6, T7> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+        
+        public static ICommandHandler Create(Func<int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T>(
+            Func<T, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2>(
+            Func<T1, T2, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3>(
+            Func<T1, T2, T3, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4>(
+            Func<T1, T2, T3, T4, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
+            Func<T1, T2, T3, T4, T5, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
+            Func<T1, T2, T3, T4, T5, T6, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
+            Func<T1, T2, T3, T4, T5, T6, T7, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, int> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create(Func<Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T>(
+            Func<T, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2>(
+            Func<T1, T2, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3>(
+            Func<T1, T2, T3, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4>(
+            Func<T1, T2, T3, T4, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
+            Func<T1, T2, T3, T4, T5, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
+            Func<T1, T2, T3, T4, T5, T6, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
+            Func<T1, T2, T3, T4, T5, T6, T7, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create(Func<Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T>(
+            Func<T, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2>(
+            Func<T1, T2, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3>(
+            Func<T1, T2, T3, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4>(
+            Func<T1, T2, T3, T4, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
+            Func<T1, T2, T3, T4, T5, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
+            Func<T1, T2, T3, T4, T5, T6, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
+            Func<T1, T2, T3, T4, T5, T6, T7, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+
+        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task<int>> action) =>
+            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+    }
+}

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -2,285 +2,379 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Binding;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation
 {
-    public static class CommandHandler
+    public static partial class CommandHandler
     {
-        public static ICommandHandler Create(Delegate @delegate) =>
-            HandlerDescriptor.FromDelegate(@delegate).GetCommandHandler();
-
-        public static ICommandHandler Create(MethodInfo method, object? target = null) =>
-            HandlerDescriptor.FromMethodInfo(method, target).GetCommandHandler();
-
         public static ICommandHandler Create(Action action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
-        public static ICommandHandler Create<T>(
-            Action<T> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+        public static ICommandHandler Create<T1>(
+            IValueDescriptor<T1> symbol1,
+            Func<T1, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!));
 
         public static ICommandHandler Create<T1, T2>(
-            Action<T1, T2> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            Func<T1, T2, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!));
 
         public static ICommandHandler Create<T1, T2, T3>(
-            Action<T1, T2, T3> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            Func<T1, T2, T3, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4>(
-            Action<T1, T2, T3, T4> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            Func<T1, T2, T3, T4, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5>(
-            Action<T1, T2, T3, T4, T5> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            Func<T1, T2, T3, T4, T5, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
-            Action<T1, T2, T3, T4, T5, T6> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            Func<T1, T2, T3, T4, T5, T6, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
-            Action<T1, T2, T3, T4, T5, T6, T7> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            Func<T1, T2, T3, T4, T5, T6, T7, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            IValueDescriptor<T9> symbol9,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!,
+                                     context.ParseResult.ValueFor(symbol9)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            IValueDescriptor<T9> symbol9,
+            IValueDescriptor<T10> symbol10,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!,
+                                     context.ParseResult.ValueFor(symbol9)!,
+                                     context.ParseResult.ValueFor(symbol10)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            IValueDescriptor<T9> symbol9,
+            IValueDescriptor<T10> symbol10,
+            IValueDescriptor<T11> symbol11,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!,
+                                     context.ParseResult.ValueFor(symbol9)!,
+                                     context.ParseResult.ValueFor(symbol10)!,
+                                     context.ParseResult.ValueFor(symbol11)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            IValueDescriptor<T9> symbol9,
+            IValueDescriptor<T10> symbol10,
+            IValueDescriptor<T11> symbol11,
+            IValueDescriptor<T12> symbol12,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!,
+                                     context.ParseResult.ValueFor(symbol9)!,
+                                     context.ParseResult.ValueFor(symbol10)!,
+                                     context.ParseResult.ValueFor(symbol11)!,
+                                     context.ParseResult.ValueFor(symbol12)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            IValueDescriptor<T9> symbol9,
+            IValueDescriptor<T10> symbol10,
+            IValueDescriptor<T11> symbol11,
+            IValueDescriptor<T12> symbol12,
+            IValueDescriptor<T13> symbol13,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!,
+                                     context.ParseResult.ValueFor(symbol9)!,
+                                     context.ParseResult.ValueFor(symbol10)!,
+                                     context.ParseResult.ValueFor(symbol11)!,
+                                     context.ParseResult.ValueFor(symbol12)!,
+                                     context.ParseResult.ValueFor(symbol13)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            IValueDescriptor<T9> symbol9,
+            IValueDescriptor<T10> symbol10,
+            IValueDescriptor<T11> symbol11,
+            IValueDescriptor<T12> symbol12,
+            IValueDescriptor<T13> symbol13,
+            IValueDescriptor<T14> symbol14,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!,
+                                     context.ParseResult.ValueFor(symbol9)!,
+                                     context.ParseResult.ValueFor(symbol10)!,
+                                     context.ParseResult.ValueFor(symbol11)!,
+                                     context.ParseResult.ValueFor(symbol12)!,
+                                     context.ParseResult.ValueFor(symbol13)!,
+                                     context.ParseResult.ValueFor(symbol14)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            IValueDescriptor<T9> symbol9,
+            IValueDescriptor<T10> symbol10,
+            IValueDescriptor<T11> symbol11,
+            IValueDescriptor<T12> symbol12,
+            IValueDescriptor<T13> symbol13,
+            IValueDescriptor<T14> symbol14,
+            IValueDescriptor<T15> symbol15,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!,
+                                     context.ParseResult.ValueFor(symbol9)!,
+                                     context.ParseResult.ValueFor(symbol10)!,
+                                     context.ParseResult.ValueFor(symbol11)!,
+                                     context.ParseResult.ValueFor(symbol12)!,
+                                     context.ParseResult.ValueFor(symbol13)!,
+                                     context.ParseResult.ValueFor(symbol14)!,
+                                     context.ParseResult.ValueFor(symbol15)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-        
-        public static ICommandHandler Create(Func<int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            IValueDescriptor<T1> symbol1,
+            IValueDescriptor<T2> symbol2,
+            IValueDescriptor<T3> symbol3,
+            IValueDescriptor<T4> symbol4,
+            IValueDescriptor<T5> symbol5,
+            IValueDescriptor<T6> symbol6,
+            IValueDescriptor<T7> symbol7,
+            IValueDescriptor<T8> symbol8,
+            IValueDescriptor<T9> symbol9,
+            IValueDescriptor<T10> symbol10,
+            IValueDescriptor<T11> symbol11,
+            IValueDescriptor<T12> symbol12,
+            IValueDescriptor<T13> symbol13,
+            IValueDescriptor<T14> symbol14,
+            IValueDescriptor<T15> symbol15,
+            IValueDescriptor<T16> symbol16,
+            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task> handle) =>
+            new AnonymousCommandHandler(
+                async context => await handle(
+                                     context.ParseResult.ValueFor(symbol1)!,
+                                     context.ParseResult.ValueFor(symbol2)!,
+                                     context.ParseResult.ValueFor(symbol3)!,
+                                     context.ParseResult.ValueFor(symbol4)!,
+                                     context.ParseResult.ValueFor(symbol5)!,
+                                     context.ParseResult.ValueFor(symbol6)!,
+                                     context.ParseResult.ValueFor(symbol7)!,
+                                     context.ParseResult.ValueFor(symbol8)!,
+                                     context.ParseResult.ValueFor(symbol9)!,
+                                     context.ParseResult.ValueFor(symbol10)!,
+                                     context.ParseResult.ValueFor(symbol11)!,
+                                     context.ParseResult.ValueFor(symbol12)!,
+                                     context.ParseResult.ValueFor(symbol13)!,
+                                     context.ParseResult.ValueFor(symbol14)!,
+                                     context.ParseResult.ValueFor(symbol15)!,
+                                     context.ParseResult.ValueFor(symbol16)!));
 
-        public static ICommandHandler Create<T>(
-            Func<T, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+        private class AnonymousCommandHandler : ICommandHandler
+        {
+            private readonly Func<InvocationContext, Task> _getResult;
 
-        public static ICommandHandler Create<T1, T2>(
-            Func<T1, T2, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            public AnonymousCommandHandler(Func<InvocationContext, Task> getResult)
+            {
+                _getResult = getResult;
+            }
 
-        public static ICommandHandler Create<T1, T2, T3>(
-            Func<T1, T2, T3, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4>(
-            Func<T1, T2, T3, T4, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
-            Func<T1, T2, T3, T4, T5, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
-            Func<T1, T2, T3, T4, T5, T6, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
-            Func<T1, T2, T3, T4, T5, T6, T7, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, int> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create(Func<Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T>(
-            Func<T, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2>(
-            Func<T1, T2, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3>(
-            Func<T1, T2, T3, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4>(
-            Func<T1, T2, T3, T4, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
-            Func<T1, T2, T3, T4, T5, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
-            Func<T1, T2, T3, T4, T5, T6, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
-            Func<T1, T2, T3, T4, T5, T6, T7, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create(Func<Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T>(
-            Func<T, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2>(
-            Func<T1, T2, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3>(
-            Func<T1, T2, T3, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4>(
-            Func<T1, T2, T3, T4, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5>(
-            Func<T1, T2, T3, T4, T5, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
-            Func<T1, T2, T3, T4, T5, T6, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
-            Func<T1, T2, T3, T4, T5, T6, T7, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
-
-        public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
-            Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task<int>> action) =>
-            HandlerDescriptor.FromDelegate(action).GetCommandHandler();
+            public Task<int> InvokeAsync(InvocationContext context) =>
+                GetExitCodeAsync(_getResult(context), context);
+        }
 
         internal static async Task<int> GetExitCodeAsync(object value, InvocationContext context)
         {

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -140,7 +140,7 @@ namespace System.CommandLine
         /// <summary>
         /// Gets or sets the arity of the option.
         /// </summary>
-        public IArgumentArity Arity
+        public virtual IArgumentArity Arity
         {
             get => Argument.Arity;
             init

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Binding;
 using System.CommandLine.Parsing;
 
 namespace System.CommandLine
 {
-    public class Option<T> : Option
+    public class Option<T> : Option, IValueDescriptor<T>
     {
         public Option(
             string alias,

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -48,8 +48,15 @@ namespace System.CommandLine
         public Option(
             string[] aliases,
             Func<T> getDefaultValue,
-            string? description = null) 
+            string? description = null)
             : base(aliases, description, new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))))
-        { }
+        {
+        }
+
+        public override IArgumentArity Arity
+        {
+            get => base.Arity;
+            init => Argument.Arity = value;
+        }
     }
 }

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -84,6 +84,16 @@ namespace System.CommandLine.Parsing
 
         public IReadOnlyList<string> UnparsedTokens => _unparsedTokens.Select(t => t.Value).ToArray();
 
+        [return: MaybeNull]
+        internal T ValueFor<T>(IValueDescriptor<T> symbol) =>
+            symbol switch
+            {
+                Argument<T> argument => ValueForArgument(argument),
+                Option<T> option => ValueForOption(option),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+
         [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.ValueForOption<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
         public object? ValueForOption(string alias) =>
             ValueForOption<object?>(alias);


### PR DESCRIPTION
The approach I'm experimenting with here is to avoid the most common gotcha in the System.CommandLine API, which is the name-based matching of options/arguments to their corresponding parameters in a command handler.

Given:

```csharp
var stringOption = new Option<string>("--the-string");
var intOption = new Option<int>("--the-int");
var filesArg = new Argument<FileInfo[]>("the-files");
var command = new RootCommand
{
    stringOption,
    intOption,
    filesArg
};

```

Handler with name-based matching:

```csharp
command.Handler = 
    // You have to specify the types and they have to match the options/arguments:
    CommandHandler.Create<string, int, FileInfo[]>( 
        // The names must match some alias of the symbol:
        (theString, theInt, theFiles) => 
        {
            
        });
```

Handler with the new proposed API: 

```csharp
command.Handler = 
    // Types are inferred:
    CommandHandler.Create(
        stringOption, intOption, filesArg,
        // The names don't matter:
        (s, i, fs) => 
        {
            
        });
```

Pros:

* No more failed binding because of naming mismatches.
* Type inference means it's all strongly-typed without having to repeat information, and no worries about a type mismatch.

Cons / design problems to be solved:

* No current solution for complex model binding, since parameters map one-to-one with options/arguments, meaning we need a lot more overloads. (People have asked for this anyway since the complex model binding is non-obvious.)
* No current solution for service parameters, e.g. `IConsole`, `ParseResult`, etc.

Please discuss.