### PR TITLE
adds ParseResult parameter for suggestions

### DIFF
--- a/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine.Tests
                 .AddSuggestions("apple", "banana", "cherry");
 
             _vegetableOption = new Option<string>("--vegetable")
-                .AddSuggestions(_ => new[] { "asparagus", "broccoli", "carrot" });
+                .AddSuggestions("asparagus", "broccoli", "carrot");
 
             _eatCommand = new Command("eat")
             {

--- a/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine.Tests
                 .AddSuggestions("apple", "banana", "cherry");
 
             _vegetableOption = new Option<string>("--vegetable")
-                .AddSuggestions("asparagus", "broccoli", "carrot");
+                .AddSuggestions((_, __) => new[] { "asparagus", "broccoli", "carrot" });
 
             _eatCommand = new Command("eat")
             {

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -137,7 +137,7 @@ namespace System.CommandLine.Tests
                 new Command("andmyothersubcommand"),
             };
 
-            var suggestions = command.GetSuggestions(null, "my");
+            var suggestions = command.GetSuggestions("my");
 
             suggestions.Should().BeEquivalentSequenceTo("mysubcommand", "andmyothersubcommand", "andmythirdsubcommand");
         }
@@ -622,7 +622,7 @@ namespace System.CommandLine.Tests
                     new Argument
                         {
                             Arity = ArgumentArity.ExactlyOne,
-                            Suggestions = { "vegetable", "mineral", "animal" }
+                            Suggestions = { (_, __) => new[] { "vegetable", "mineral", "animal" } }
                         }
                 }
             };
@@ -642,7 +642,7 @@ namespace System.CommandLine.Tests
                 {
                     Argument = new Argument<string>()
                     {
-                        Suggestions = { "vegetable", "mineral", "animal" }
+                        Suggestions = { (_, __) => new [] { "vegetable", "mineral", "animal" } }
                     }
                 }
             };

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -137,7 +137,7 @@ namespace System.CommandLine.Tests
                 new Command("andmyothersubcommand"),
             };
 
-            var suggestions = command.GetSuggestions("my");
+            var suggestions = command.GetSuggestions(null, "my");
 
             suggestions.Should().BeEquivalentSequenceTo("mysubcommand", "andmyothersubcommand", "andmythirdsubcommand");
         }
@@ -168,6 +168,71 @@ namespace System.CommandLine.Tests
                   .BeEquivalentTo("--apple",
                                   "--banana",
                                   "--cherry");
+        }
+
+        [Fact]
+        public void Command_suggest_can_access_ParseResult()
+        {
+            var parser = new Parser(
+                new Option("--origin")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--clone")
+                {
+                    Argument = new Argument<string>()
+                    {
+                        Suggestions =
+                        {
+                            (parseResult, match) =>
+                            {
+                                var opt1Value = parseResult?.ValueForOption<string>("--origin");
+                                return opt1Value != null ? new[] { opt1Value } : Array.Empty<string>();
+                            }
+                        }
+                    }
+                });
+
+            var result = parser.Parse("--origin test --clone ");
+
+            _output.WriteLine(result.ToString());
+
+            result.GetSuggestions()
+                  .Should()
+                  .BeEquivalentTo("test");
+        }
+
+        [Fact]
+        public void Command_suggest_can_access_ParseResult_reverse_order()
+        {
+            var parser = new Parser(
+                new Option("--origin")
+                {
+                    Argument = new Argument<string>()
+                },
+                new Option("--clone")
+                {
+                    Argument = new Argument<string>()
+                    {
+                        Suggestions =
+                        {
+                            (parseResult, match) =>
+                            {
+                                var opt1Value = parseResult?.ValueForOption<string>("--origin");
+                                return opt1Value != null ? new[] { opt1Value } : Array.Empty<string>();
+                            }
+
+                        }
+                    }
+                });
+
+            var result = parser.Parse("--clone  --origin test");
+
+            _output.WriteLine(result.ToString());
+
+            result.GetSuggestions(8)
+                  .Should()
+                  .BeEquivalentTo("test");
         }
 
         [Fact]
@@ -557,7 +622,7 @@ namespace System.CommandLine.Tests
                     new Argument
                         {
                             Arity = ArgumentArity.ExactlyOne,
-                            Suggestions = { _ => new[] { "vegetable", "mineral", "animal" } }
+                            Suggestions = { "vegetable", "mineral", "animal" }
                         }
                 }
             };
@@ -577,7 +642,7 @@ namespace System.CommandLine.Tests
                 {
                     Argument = new Argument<string>()
                     {
-                        Suggestions = { _ => new[] { "vegetable", "mineral", "animal" } }
+                        Suggestions = { "vegetable", "mineral", "animal" }
                     }
                 }
             };

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -178,10 +178,10 @@ namespace System.CommandLine
             AllowedValues.UnionWith(values);
         }
 
-        public override IEnumerable<string?> GetSuggestions(string? textToMatch = null)
+        public override IEnumerable<string?> GetSuggestions(ParseResult? parseResult = null, string? textToMatch = null)
         {
             var dynamicSuggestions = Suggestions
-                .SelectMany(source => source.GetSuggestions(textToMatch));
+                .SelectMany(source => source.GetSuggestions(parseResult, textToMatch));
 
             return dynamicSuggestions
                    .Distinct()

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -216,7 +216,7 @@ namespace System.CommandLine.Parsing
 
             var currentSymbolSuggestions =
                 currentSymbol is ISuggestionSource currentSuggestionSource
-                    ? currentSuggestionSource.GetSuggestions(textToMatch)
+                    ? currentSuggestionSource.GetSuggestions(parseResult, textToMatch)
                     : Array.Empty<string>();
 
             IEnumerable<string?> siblingSuggestions;
@@ -230,7 +230,7 @@ namespace System.CommandLine.Parsing
             else
             {
                 siblingSuggestions = parentSymbol
-                                     .GetSuggestions(textToMatch)
+                                     .GetSuggestions(parseResult, textToMatch)
                                      .Except(parentSymbol
                                              .Children
                                              .OfType<ICommand>()

--- a/src/System.CommandLine/SuggestionSourceExtensions.cs
+++ b/src/System.CommandLine/SuggestionSourceExtensions.cs
@@ -39,7 +39,7 @@ namespace System.CommandLine
                 throw new ArgumentNullException(nameof(suggestions));
             }
 
-            suggestionSources.Add(new AnonymousSuggestionSource(_ => suggestions));
+            suggestionSources.Add(new AnonymousSuggestionSource((_, __) => suggestions));
         }
     }
 }

--- a/src/System.CommandLine/Suggestions/AnonymousSuggestionSource.cs
+++ b/src/System.CommandLine/Suggestions/AnonymousSuggestionSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.CommandLine.Parsing;
 
 namespace System.CommandLine.Suggestions
 {
@@ -14,9 +15,9 @@ namespace System.CommandLine.Suggestions
             _suggest = suggest ?? throw new ArgumentNullException(nameof(suggest));
         }
 
-        public IEnumerable<string> GetSuggestions(string? textToMatch = null)
+        public IEnumerable<string> GetSuggestions(ParseResult? parseResult = null, string? textToMatch = null)
         {
-            return _suggest(textToMatch);
+            return _suggest(parseResult, textToMatch);
         }
     }
 }

--- a/src/System.CommandLine/Suggestions/ISuggestionSource.cs
+++ b/src/System.CommandLine/Suggestions/ISuggestionSource.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.CommandLine.Parsing;
 
 namespace System.CommandLine.Suggestions
 {
     public interface ISuggestionSource
     {
-        IEnumerable<string?> GetSuggestions(string? textToMatch = null);
+        IEnumerable<string?> GetSuggestions(ParseResult? parseResult = null, string? textToMatch = null);
     }
 }

--- a/src/System.CommandLine/Suggestions/SuggestDelegate.cs
+++ b/src/System.CommandLine/Suggestions/SuggestDelegate.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.CommandLine.Parsing;
 
 namespace System.CommandLine.Suggestions
 {
-    public delegate IEnumerable<string> SuggestDelegate(string? textToMatch);
+    public delegate IEnumerable<string> SuggestDelegate(ParseResult? parseResult, string? textToMatch);
 }

--- a/src/System.CommandLine/Suggestions/SuggestionSource.cs
+++ b/src/System.CommandLine/Suggestions/SuggestionSource.cs
@@ -31,18 +31,18 @@ namespace System.CommandLine.Suggestions
                 if (t.IsEnum)
                 {
                     var names = Enum.GetNames(t);
-                    return new AnonymousSuggestionSource(_ => names);
+                    return new AnonymousSuggestionSource((_,__) => names);
                 }
 
                 if (t == typeof(bool))
                 {
-                    return new AnonymousSuggestionSource(_ => _trueAndFalse);
+                    return new AnonymousSuggestionSource((_, __) => _trueAndFalse);
                 }
 
                 return Empty;
             }
         }
 
-        public static ISuggestionSource Empty { get; } = new AnonymousSuggestionSource(_ => Array.Empty<string>());
+        public static ISuggestionSource Empty { get; } = new AnonymousSuggestionSource((_, __) => Array.Empty<string>());
     }
 }

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -137,12 +137,12 @@ namespace System.CommandLine
 
         public bool IsHidden { get; set; }
 
-        public virtual IEnumerable<string?> GetSuggestions(string? textToMatch = null)
+        public virtual IEnumerable<string?> GetSuggestions(ParseResult? parseResult = null, string? textToMatch = null)
         {
             var argumentSuggestions =
                 Children
                     .OfType<IArgument>()
-                    .SelectMany(a => a.GetSuggestions(textToMatch))
+                    .SelectMany(a => a.GetSuggestions(parseResult, textToMatch))
                     .ToArray();
 
             return this.ChildSymbolAliases()

--- a/src/System.CommandLine/SymbolExtensions.cs
+++ b/src/System.CommandLine/SymbolExtensions.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace System.CommandLine
 {
-    internal static class SymbolExtensions
+    public static class SymbolExtensions
     {
         internal static IEnumerable<string> ChildSymbolAliases(this ISymbol symbol) =>
             symbol.Children
@@ -32,6 +32,11 @@ namespace System.CommandLine
                 default:
                     throw new NotSupportedException();
             }
+        }
+
+        public static IEnumerable<string?> GetSuggestions(this ISymbol symbol, string? textToMatch = null)
+        {
+            return symbol.GetSuggestions(null, textToMatch);
         }
     }
 }


### PR DESCRIPTION
This PR adds support for accessing other options when providing suggestions. Imagine following scenarios:
- Add a user to group
  `addusertogroup -user <user> -group <group>`
  Suggestions for `group` should only only include groups the user `user` is not already member of.
- Delete an Azure resource from a resource group
  `deleteresource -resourcegroup <resouregroup> -resource <resource>`
  Suggestions for `resource` should only include resources in the specified `resouregroup`.

When implementing suggestion, you won't get the `textToParse` only, but also `ParseResult`, which allows access to all options parsed so far.

**Please note that this is a breaking change.**

This fixes #1019 