### PR TITLE
prevent argument alias from matching tokens

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1681,6 +1681,24 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void Argument_name_is_not_matched_as_a_token()
+        {
+            var nameArg = new Argument<string>("name");
+            var columnsArg = new Argument<IEnumerable<string>>("columns");
+
+            var command = new Command("add", "Adds a new series")
+            {
+                nameArg,
+                columnsArg
+            };
+
+            var result = command.Parse("name one two three");
+
+            result.ValueForArgument(nameArg).Should().Be("name");
+            result.ValueForArgument(columnsArg).Should().BeEquivalentTo("one", "two", "three");
+        }
+
+        [Fact]
         public void Option_aliases_do_not_need_to_be_prefixed()
         {
             var option = new Option("noprefix");

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -568,7 +568,7 @@ namespace System.CommandLine.Parsing
             for (var commandAliasIndex = 0; commandAliasIndex < command.Aliases.Count; commandAliasIndex++)
             {
                 var commandAlias = command.Aliases.ElementAt(commandAliasIndex);
-                
+
                 tokens.Add(
                     commandAlias,
                     new Token(
@@ -583,12 +583,16 @@ namespace System.CommandLine.Parsing
                     {
                         var childAlias = child.Aliases.ElementAt(childAliasIndex);
 
-                        tokens[childAlias] =
-                            new Token(
-                                childAlias,
-                                child is ICommand
-                                    ? TokenType.Command
-                                    : TokenType.Option);
+                        switch (child)
+                        {
+                            case ICommand _:
+                                tokens.TryAdd(childAlias, new Token(childAlias, TokenType.Command));
+                                break;
+
+                            case IOption _:
+                                tokens.TryAdd(childAlias, new Token(childAlias, TokenType.Option));
+                                break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
A recent change introduced a bug where the tokenizer would classify a token as an option if it matched the name of an argument. This fixes that.