### PR TITLE
Differentiate symbol types

### DIFF
--- a/src/System.CommandLine.Tests/NamedSymbolTests.cs
+++ b/src/System.CommandLine.Tests/NamedSymbolTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public abstract class NamedSymbolTests : SymbolTests
+    {
+        [Fact]
+        public void When_Name_is_changed_then_old_name_is_not_among_aliases()
+        {
+            var symbol = (NamedSymbol) CreateSymbol("original");
+
+            symbol.Name = "changed";
+
+            symbol.HasAlias("original").Should().BeFalse();
+            symbol.Aliases.Should().NotContain("original");
+            symbol.Aliases.Should().NotContain("original");
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -22,7 +22,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Option_Suggest_returns_argument_suggestions_if_configured()
+        public void Option_GetSuggestions_returns_argument_suggestions_if_configured()
         {
             var option = new Option("--hello")
             {
@@ -39,7 +39,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Command_Suggest_returns_available_option_aliases()
+        public void Command_GetSuggestions_returns_available_option_aliases()
         {
             IReadOnlyCollection<Symbol> symbols = new[] {
                 new Option("--one", "option one"),
@@ -64,7 +64,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Command_Suggest_returns_available_subcommands()
+        public void Command_GetSuggestions_returns_available_subcommands()
         {
             var command = new Command("command")
             {
@@ -79,7 +79,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Command_Suggest_returns_available_subcommands_and_option_aliases()
+        public void Command_GetSuggestions_returns_available_subcommands_and_option_aliases()
         {
             var command = new Command("command")
             {
@@ -93,17 +93,17 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Command_Suggest_returns_available_subcommands_and_option_aliases_and_configured_arguments()
+        public void Command_GetSuggestions_returns_available_subcommands_and_option_aliases_and_configured_arguments()
         {
             var command = new Command("command")
             {
                 new Command("subcommand", "subcommand"),
                 new Option("--option", "option"),
                 new Argument
-                    {
-                        Arity = ArgumentArity.OneOrMore,
-                        Suggestions = { "command-argument" }
-                    }
+                {
+                    Arity = ArgumentArity.OneOrMore,
+                    Suggestions = { "command-argument" }
+                }
             };
 
             var suggestions = command.GetSuggestions();
@@ -113,7 +113,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Command_Suggest_without_text_to_match_orders_alphabetically()
+        public void Command_GetSuggestions_without_text_to_match_orders_alphabetically()
         {
             var command = new Command("command")
             {
@@ -128,7 +128,20 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Command_Suggest_with_text_to_match_orders_by_match_position_then_alphabetically()
+        public void Command_GetSuggestions_does_not_return_argument_names()
+        {
+            var command = new Command("command")
+            {
+                new Argument("the-argument")
+            };
+
+            var suggestions = command.GetSuggestions();
+
+            suggestions.Should().NotContain("the-argument");
+        }
+
+        [Fact]
+        public void Command_GetSuggestions_with_text_to_match_orders_by_match_position_then_alphabetically()
         {
             var command = new Command("command")
             {
@@ -171,7 +184,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Command_suggest_can_access_ParseResult()
+        public void Command_Getsuggestions_can_access_ParseResult()
         {
             var parser = new Parser(
                 new Option("--origin")
@@ -203,7 +216,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Command_suggest_can_access_ParseResult_reverse_order()
+        public void Command_Getsuggestions_can_access_ParseResult_reverse_order()
         {
             var parser = new Parser(
                 new Option("--origin")
@@ -510,7 +523,7 @@ namespace System.CommandLine.Tests
         [Theory(Skip = "Needs discussion, Issue #19")]
         [InlineData("outer ")]
         [InlineData("outer -")]
-        public void Option_suggestions_are_not_provided_without_matching_prefix(string input)
+        public void Option_Getsuggestionsions_are_not_provided_without_matching_prefix(string input)
         {
             var command = new Command("outer")
             {
@@ -526,7 +539,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Option_suggestions_can_be_based_on_the_proximate_option()
+        public void Option_Getsuggestionsions_can_be_based_on_the_proximate_option()
         {
             var parser = new Parser(
                 new Command("outer")
@@ -573,7 +586,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Option_suggestions_can_be_based_on_the_proximate_option_and_partial_input()
+        public void Option_Getsuggestionsions_can_be_based_on_the_proximate_option_and_partial_input()
         {
             var parser = new Parser(
                 new Command("outer")

--- a/src/System.CommandLine.Tests/SymbolTests.cs
+++ b/src/System.CommandLine.Tests/SymbolTests.cs
@@ -18,18 +18,6 @@ namespace System.CommandLine.Tests
             symbol.Name.Should().Be("changed");
         }
 
-        [Fact]
-        public void When_Name_is_changed_then_old_name_is_not_among_aliases()
-        {
-            var symbol = CreateSymbol("original");
-
-            symbol.Name = "changed";
-
-            symbol.HasAlias("original").Should().BeFalse();
-            symbol.Aliases.Should().NotContain("original");
-            symbol.Aliases.Should().NotContain("original");
-        }
-
         protected abstract Symbol CreateSymbol(string name);
     }
 }

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -27,8 +27,6 @@ namespace System.CommandLine
             {
                 Name = name!;
             }
-
-            AddAliasInner(name);
         }
 
         internal HashSet<string>? AllowedValues { get; private set; }

--- a/src/System.CommandLine/Binding/Binder.cs
+++ b/src/System.CommandLine/Binding/Binder.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine.Binding
                           parameterName,
                           StringComparison.OrdinalIgnoreCase);
 
-        internal static bool IsMatch(this string parameterName, ISymbol symbol) =>
+        internal static bool IsMatch(this string parameterName, IOption symbol) =>
             parameterName.IsMatch(symbol.Name) || 
             symbol.HasAlias(parameterName);
 

--- a/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
+++ b/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine.Binding
             {
                 // TODO: (FailedArgumentTypeConversionResult) localize
 
-                var firstParent = a.Parents[0];
+                var firstParent = (INamedSymbol) a.Parents[0];
 
                 var symbolType =
                     firstParent switch {

--- a/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
+++ b/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine.Binding
             {
                 // TODO: (FailedArgumentTypeConversionResult) localize
 
-                var firstParent = (INamedSymbol) a.Parents[0];
+                var firstParent = (IIdentifierSymbol) a.Parents[0];
 
                 var symbolType =
                     firstParent switch {

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -44,7 +44,7 @@ namespace System.CommandLine.Collections
         {
             EnsureAliasIndexIsCurrent();
 
-            if (!(item is INamedSymbol optionOrCommand))
+            if (!(item is IIdentifierSymbol optionOrCommand))
             {
                 for (var i = 0; i < Items.Count; i++)
                 {
@@ -88,7 +88,7 @@ namespace System.CommandLine.Collections
         protected override IReadOnlyCollection<string> GetAliases(ISymbol item) =>
             item switch
             {
-                INamedSymbol named => named.Aliases,
+                IIdentifierSymbol named => named.Aliases,
                 _ => new[] { item.Name }
             };
     }

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -44,7 +44,22 @@ namespace System.CommandLine.Collections
         {
             EnsureAliasIndexIsCurrent();
 
-            if (!(item is IIdentifierSymbol optionOrCommand))
+            if (item is IIdentifierSymbol identifier)
+            {
+                var aliases = identifier.Aliases.ToArray();
+
+                for (var i = 0; i < aliases.Length; i++)
+                {
+                    var alias = aliases[i];
+
+                    if (ItemsByAlias.ContainsKey(alias))
+                    {
+                        aliasAlreadyInUse = alias;
+                        return true;
+                    }
+                }
+            }
+            else
             {
                 for (var i = 0; i < Items.Count; i++)
                 {
@@ -52,21 +67,6 @@ namespace System.CommandLine.Collections
                     if (string.Equals(item.Name, existing.Name, StringComparison.Ordinal))
                     {
                         aliasAlreadyInUse = existing.Name;
-                        return true;
-                    }
-                }
-            }
-            else
-            {
-                var itemRawAliases = optionOrCommand.Aliases.ToArray();
-
-                for (var i = 0; i < itemRawAliases.Length; i++)
-                {
-                    var alias = itemRawAliases[i];
-
-                    if (ItemsByAlias.ContainsKey(alias))
-                    {
-                        aliasAlreadyInUse = alias;
                         return true;
                     }
                 }

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -44,9 +44,8 @@ namespace System.CommandLine.Collections
         {
             EnsureAliasIndexIsCurrent();
 
-            if (item is IArgument)
+            if (!(item is INamedSymbol optionOrCommand))
             {
-                // arguments don't have aliases so match based on Name
                 for (var i = 0; i < Items.Count; i++)
                 {
                     var existing = Items[i];
@@ -59,7 +58,7 @@ namespace System.CommandLine.Collections
             }
             else
             {
-                var itemRawAliases = item.Aliases.ToArray();
+                var itemRawAliases = optionOrCommand.Aliases.ToArray();
 
                 for (var i = 0; i < itemRawAliases.Length; i++)
                 {
@@ -87,6 +86,10 @@ namespace System.CommandLine.Collections
         }
 
         protected override IReadOnlyCollection<string> GetAliases(ISymbol item) =>
-            item.Aliases;
+            item switch
+            {
+                INamedSymbol named => named.Aliases,
+                _ => new[] { item.Name }
+            };
     }
 }

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -11,7 +11,7 @@ using System.Linq;
 namespace System.CommandLine
 {
     public class Command : 
-        Symbol, 
+        NamedSymbol, 
         ICommand, 
         IEnumerable<Symbol>
     {

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -19,7 +19,7 @@ namespace System.CommandLine
 
         public CommandLineConfiguration(
             IReadOnlyCollection<Symbol> symbols,
-            IReadOnlyCollection<char>? argumentDelimiters = null,
+            IReadOnlyList<char>? argumentDelimiters = null,
             bool enablePosixBundling = true,
             bool enableDirectives = true,
             ValidationMessages? validationMessages = null,
@@ -39,26 +39,30 @@ namespace System.CommandLine
 
             if (argumentDelimiters is null)
             {
-                ArgumentDelimitersInternal = new HashSet<char>
+                ArgumentDelimitersInternal = new []
                 {
-                    ':', 
+                    ':',
                     '='
                 };
             }
             else
             {
-                ArgumentDelimitersInternal = new HashSet<char>(argumentDelimiters);
+                ArgumentDelimitersInternal = argumentDelimiters;
             }
 
             foreach (var symbol in symbols)
             {
-                foreach (var alias in symbol.Aliases)
+                if (symbol is INamedSymbol optionOrCommand)
                 {
-                    foreach (var delimiter in ArgumentDelimiters)
+                    foreach (var alias in optionOrCommand.Aliases)
                     {
-                        if (alias.Contains(delimiter))
+                        for (var i = 0; i < ArgumentDelimiters.Count; i++)
                         {
-                            throw new ArgumentException($"{symbol.GetType().Name} \"{alias}\" is not allowed to contain a delimiter but it contains \"{delimiter}\"");
+                            var delimiter = ArgumentDelimiters[i];
+                            if (alias.Contains(delimiter))
+                            {
+                                throw new ArgumentException($"{symbol.GetType().Name} \"{alias}\" is not allowed to contain a delimiter but it contains \"{delimiter}\"");
+                            }
                         }
                     }
                 }
@@ -123,9 +127,9 @@ namespace System.CommandLine
 
         public ISymbolSet Symbols => _symbols;
 
-        public IReadOnlyCollection<char> ArgumentDelimiters => ArgumentDelimitersInternal;
+        public IReadOnlyList<char> ArgumentDelimiters => ArgumentDelimitersInternal;
 
-        internal HashSet<char> ArgumentDelimitersInternal { get; }
+        internal IReadOnlyList<char> ArgumentDelimitersInternal { get; }
      
         public bool EnableDirectives { get; }
 

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -47,14 +47,14 @@ namespace System.CommandLine
             }
             else
             {
-                ArgumentDelimitersInternal = argumentDelimiters;
+                ArgumentDelimitersInternal = argumentDelimiters.Distinct().ToArray();
             }
 
             foreach (var symbol in symbols)
             {
-                if (symbol is IIdentifierSymbol optionOrCommand)
+                if (symbol is IIdentifierSymbol identifier)
                 {
-                    foreach (var alias in optionOrCommand.Aliases)
+                    foreach (var alias in identifier.Aliases)
                     {
                         for (var i = 0; i < ArgumentDelimiters.Count; i++)
                         {

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -52,7 +52,7 @@ namespace System.CommandLine
 
             foreach (var symbol in symbols)
             {
-                if (symbol is INamedSymbol optionOrCommand)
+                if (symbol is IIdentifierSymbol optionOrCommand)
                 {
                     foreach (var alias in optionOrCommand.Aliases)
                     {

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -478,7 +478,7 @@ namespace System.CommandLine.Help
                 _ => ""
             };
 
-        private IEnumerable<HelpItem> GetOptionHelpItems(INamedSymbol symbol)
+        private IEnumerable<HelpItem> GetOptionHelpItems(IIdentifierSymbol symbol)
         {
             var rawAliases = symbol
                              .Aliases

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -478,7 +478,7 @@ namespace System.CommandLine.Help
                 _ => ""
             };
 
-        private IEnumerable<HelpItem> GetOptionHelpItems(ISymbol symbol)
+        private IEnumerable<HelpItem> GetOptionHelpItems(INamedSymbol symbol)
         {
             var rawAliases = symbol
                              .Aliases

--- a/src/System.CommandLine/ICommand.cs
+++ b/src/System.CommandLine/ICommand.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace System.CommandLine
 {
-    public interface ICommand : INamedSymbol
+    public interface ICommand : IIdentifierSymbol
     {
         bool TreatUnmatchedTokensAsErrors { get; }
 

--- a/src/System.CommandLine/ICommand.cs
+++ b/src/System.CommandLine/ICommand.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace System.CommandLine
 {
-    public interface ICommand : ISymbol
+    public interface ICommand : INamedSymbol
     {
         bool TreatUnmatchedTokensAsErrors { get; }
 

--- a/src/System.CommandLine/IIdentifierSymbol.cs
+++ b/src/System.CommandLine/IIdentifierSymbol.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace System.CommandLine
 {
-    public interface INamedSymbol : ISymbol
+    public interface IIdentifierSymbol : ISymbol
     {
         IReadOnlyCollection<string> Aliases { get; }
 

--- a/src/System.CommandLine/INamedSymbol.cs
+++ b/src/System.CommandLine/INamedSymbol.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.CommandLine
+{
+    public interface INamedSymbol : ISymbol
+    {
+        IReadOnlyCollection<string> Aliases { get; }
+
+        bool HasAlias(string alias);
+    }
+}

--- a/src/System.CommandLine/IOption.cs
+++ b/src/System.CommandLine/IOption.cs
@@ -5,7 +5,7 @@ using System.CommandLine.Binding;
 
 namespace System.CommandLine
 {
-    public interface IOption : ISymbol, IValueDescriptor
+    public interface IOption : INamedSymbol, IValueDescriptor
     {
         IArgument Argument { get; }
 

--- a/src/System.CommandLine/IOption.cs
+++ b/src/System.CommandLine/IOption.cs
@@ -5,7 +5,7 @@ using System.CommandLine.Binding;
 
 namespace System.CommandLine
 {
-    public interface IOption : INamedSymbol, IValueDescriptor
+    public interface IOption : IIdentifierSymbol, IValueDescriptor
     {
         IArgument Argument { get; }
 

--- a/src/System.CommandLine/ISymbol.cs
+++ b/src/System.CommandLine/ISymbol.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.CommandLine.Collections;
 using System.CommandLine.Suggestions;
 
@@ -13,19 +12,10 @@ namespace System.CommandLine
 
         string? Description { get; }
 
-        IReadOnlyCollection<string> Aliases { get; }
-
-        bool HasAlias(string alias);
-
         bool IsHidden { get; }
 
         ISymbolSet Children { get; }
 
         ISymbolSet Parents { get; }
-    }
-
-    public interface INamedSymbol : ISymbol
-    {
-
     }
 }

--- a/src/System.CommandLine/ISymbol.cs
+++ b/src/System.CommandLine/ISymbol.cs
@@ -23,4 +23,9 @@ namespace System.CommandLine
 
         ISymbolSet Parents { get; }
     }
+
+    public interface INamedSymbol : ISymbol
+    {
+
+    }
 }

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -37,7 +37,9 @@ namespace System.CommandLine.Invocation
 
         private IEnumerable<string> GetPossibleTokens(ISymbol targetSymbol, string token)
         {
-            IEnumerable<string> possibleMatches = targetSymbol.Children
+            IEnumerable<string> possibleMatches = targetSymbol
+                .Children
+                .OfType<INamedSymbol>()
                 .Where(x => !x.IsHidden)
                 .Where(x => x.Aliases.Count > 0)
                 .Select(symbol => 

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -39,7 +39,7 @@ namespace System.CommandLine.Invocation
         {
             IEnumerable<string> possibleMatches = targetSymbol
                 .Children
-                .OfType<INamedSymbol>()
+                .OfType<IIdentifierSymbol>()
                 .Where(x => !x.IsHidden)
                 .Where(x => x.Aliases.Count > 0)
                 .Select(symbol => 

--- a/src/System.CommandLine/NamedSymbol.cs
+++ b/src/System.CommandLine/NamedSymbol.cs
@@ -23,7 +23,7 @@ namespace System.CommandLine
 
         public IReadOnlyCollection<string> Aliases => _aliases;
 
-        public virtual string Name
+        public override string Name
         {
             get => _specifiedName ?? DefaultName;
             set

--- a/src/System.CommandLine/NamedSymbol.cs
+++ b/src/System.CommandLine/NamedSymbol.cs
@@ -1,0 +1,61 @@
+﻿// // Copyright (c) .NET Foundation and contributors. All rights reserved.
+// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.CommandLine
+{
+    public abstract class NamedSymbol : Symbol
+    {
+        private readonly HashSet<string> _aliases = new HashSet<string>();
+        private string? _specifiedName;
+
+        protected NamedSymbol(string? description = null)
+        {
+            Description = description;
+        }
+
+        protected NamedSymbol(string name, string? description = null)
+        {
+            Name = name;
+            Description = description;
+        }
+
+        public IReadOnlyCollection<string> Aliases => _aliases;
+
+        public virtual string Name
+        {
+            get => _specifiedName ?? DefaultName;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Value cannot be null or whitespace.", nameof(value));
+                }
+
+                RemoveAlias(_specifiedName);
+
+                _specifiedName = value;
+
+                AddAliasInner(value);
+            }
+        }
+
+        private protected virtual void AddAliasInner(string alias)
+        {
+            _aliases.Add(alias);
+
+            OnNameOrAliasChanged?.Invoke(this);
+        }
+
+        private protected virtual void RemoveAlias(string? alias)
+        {
+            if (alias != null)
+            {
+                _aliases.Remove(alias);
+            }
+        }
+
+        public virtual bool HasAlias(string alias) => _aliases.Contains(alias);
+    }
+}

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -9,7 +9,7 @@ using System.Linq;
 namespace System.CommandLine
 {
     public class Option :
-        Symbol,
+        NamedSymbol,
         IOption
     {
         private string? _implicitName;

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -55,7 +55,8 @@ namespace System.CommandLine.Parsing
         {
             var children = commandResult
                            .Children
-                           .Where(o => valueDescriptor.ValueName?.IsMatch(o.Symbol) == true)
+                           .OfType<OptionResult>()
+                           .Where(o => valueDescriptor.ValueName?.IsMatch(o.Option) == true)
                            .ToArray();
 
             SymbolResult? symbolResult = null;

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -269,8 +269,11 @@ namespace System.CommandLine.Parsing
                         .Where(c => c.IsArgumentLimitReached);
 
                 var exclude = optionsWithArgLimitReached
-                              .SelectMany(c => c.Symbol.Aliases)
-                              .Concat(commandResult.Symbol.Aliases)
+                              .OfType<OptionResult>()
+                              .Select(o => o.Symbol)
+                              .OfType<INamedSymbol>()
+                              .SelectMany(c => c.Aliases)
+                              .Concat(commandResult.Command.Aliases)
                               .ToArray();
 
                 return exclude;

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -271,7 +271,7 @@ namespace System.CommandLine.Parsing
                 var exclude = optionsWithArgLimitReached
                               .OfType<OptionResult>()
                               .Select(o => o.Symbol)
-                              .OfType<INamedSymbol>()
+                              .OfType<IIdentifierSymbol>()
                               .SelectMany(c => c.Aliases)
                               .Concat(commandResult.Command.Aliases)
                               .ToArray();

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -577,21 +577,23 @@ namespace System.CommandLine.Parsing
 
                 for (var childIndex = 0; childIndex < command.Children.Count; childIndex++)
                 {
-                    var child = command.Children[childIndex];
+                    if (command.Children[childIndex] is INamedSymbol optionOrCommand)
 
-                    for (var childAliasIndex = 0; childAliasIndex < child.Aliases.Count; childAliasIndex++)
                     {
-                        var childAlias = child.Aliases.ElementAt(childAliasIndex);
-
-                        switch (child)
+                        for (var childAliasIndex = 0; childAliasIndex < optionOrCommand.Aliases.Count; childAliasIndex++)
                         {
-                            case ICommand _:
-                                tokens.TryAdd(childAlias, new Token(childAlias, TokenType.Command));
-                                break;
+                            var childAlias = optionOrCommand.Aliases.ElementAt(childAliasIndex);
 
-                            case IOption _:
-                                tokens.TryAdd(childAlias, new Token(childAlias, TokenType.Option));
-                                break;
+                            switch (optionOrCommand)
+                            {
+                                case ICommand _:
+                                    tokens.TryAdd(childAlias, new Token(childAlias, TokenType.Command));
+                                    break;
+
+                                case IOption _:
+                                    tokens.TryAdd(childAlias, new Token(childAlias, TokenType.Option));
+                                    break;
+                            }
                         }
                     }
                 }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -577,14 +577,11 @@ namespace System.CommandLine.Parsing
 
                 for (var childIndex = 0; childIndex < command.Children.Count; childIndex++)
                 {
-                    if (command.Children[childIndex] is IIdentifierSymbol optionOrCommand)
-
+                    if (command.Children[childIndex] is IIdentifierSymbol identifier)
                     {
-                        for (var childAliasIndex = 0; childAliasIndex < optionOrCommand.Aliases.Count; childAliasIndex++)
+                        foreach (var childAlias in identifier.Aliases)
                         {
-                            var childAlias = optionOrCommand.Aliases.ElementAt(childAliasIndex);
-
-                            switch (optionOrCommand)
+                            switch (identifier)
                             {
                                 case ICommand _:
                                     tokens.TryAdd(childAlias, new Token(childAlias, TokenType.Command));

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -577,7 +577,7 @@ namespace System.CommandLine.Parsing
 
                 for (var childIndex = 0; childIndex < command.Children.Count; childIndex++)
                 {
-                    if (command.Children[childIndex] is INamedSymbol optionOrCommand)
+                    if (command.Children[childIndex] is IIdentifierSymbol optionOrCommand)
 
                     {
                         for (var childAliasIndex = 0; childAliasIndex < optionOrCommand.Aliases.Count; childAliasIndex++)

--- a/src/System.CommandLine/Parsing/SymbolResultSet.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultSet.cs
@@ -12,7 +12,11 @@ namespace System.CommandLine.Parsing
         internal SymbolResult? ResultFor(ISymbol symbol) =>
             Items.FirstOrDefault(i => Equals(i.Symbol, symbol));
 
-        protected override IReadOnlyCollection<string> GetAliases(SymbolResult item) =>
-            item.Symbol.Aliases;
+        protected override IReadOnlyCollection<string> GetAliases(SymbolResult result) =>
+            result.Symbol switch
+            {
+                INamedSymbol named => named.Aliases,
+                _ => new[] { result.Symbol.Name }
+            };
     }
 }

--- a/src/System.CommandLine/Parsing/SymbolResultSet.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultSet.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Parsing
         protected override IReadOnlyCollection<string> GetAliases(SymbolResult result) =>
             result.Symbol switch
             {
-                INamedSymbol named => named.Aliases,
+                IIdentifierSymbol named => named.Aliases,
                 _ => new[] { result.Symbol.Name }
             };
     }

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine
 {
     public abstract class Symbol : ISymbol
     {
-        private string _name;
+        private string? _name;
         private readonly SymbolSet _parents = new SymbolSet();
 
         private protected Symbol()

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -67,7 +67,7 @@ namespace System.CommandLine
 
             return Children
                    .Where(s => !s.IsHidden)
-                   .OfType<INamedSymbol>()
+                   .OfType<IIdentifierSymbol>()
                    .SelectMany(s => s.Aliases)
                    .Concat(argumentSuggestions)
                    .Distinct()


### PR DESCRIPTION
I'm looking for feedback on this change. Does it make sense? Is it helpful?

The key change is to introduce the interface `IIdentifierSymbol : ISymbol` and to have `Command` and `Option` implement this new interface, while `Argument` implements only `ISymbol`.

Distinctions between these types are:

* An `IIdentifierSymbol` can have aliases, so the `HasAlias` method and `Aliases` property are there. `Argument` never really supported these so removing them from `Argument` seems more honest.
* `Argument.Name` is used for help output and for binding, but _not_ for token matching during parsing.
* `IIdentifierSymbol.Aliases` are used for help output, binding, and token matching.