### PR TITLE
Bug #970 ansi escape codes

### DIFF
--- a/samples/RenderingPlayground/Program.cs
+++ b/samples/RenderingPlayground/Program.cs
@@ -28,7 +28,7 @@ namespace RenderingPlayground
         public static void Main(
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             InvocationContext invocationContext,
-            SampleName sample = SampleName.Cursor,
+            SampleName sample = SampleName.Dir,
             int? height = null,
             int? width = null,
             int top = 0,

--- a/samples/RenderingPlayground/Program.cs
+++ b/samples/RenderingPlayground/Program.cs
@@ -164,14 +164,14 @@ namespace RenderingPlayground
                             RowDefinition.SizeToContent(),
                             RowDefinition.Star(1)
                         );
-
                         var content = new ContentView("Instructions:\n" +
-                            "Use direction arrows to move the cursor.\n" +
-                            "CTRL + UP to scroll up.\n" +
-                            "CTRL + DOWN to scroll down.\n" +
+                            $"DIRECTION ARROWS move the cursor.\n" +
+                            "CTRL + UP scrolls up.\n" +
+                            "CTRL + DOWN scrolls down.\n" +
                             "S saves the cursor position, R restores it.\n" +
                             "ENTER navigates to the start of the next line.\n" +
-                            "L moves to location (10, 9).");
+                            "L moves to location (10, 9).\n" +
+                            "ESC quits.");
                         gridView.SetChild(content, 0, 0);
                         gridView.SetChild(new ColorsView("#"), 0, 1);
 
@@ -179,7 +179,9 @@ namespace RenderingPlayground
                         screen.Render(region);
                         console.GetTerminal().ShowCursor();
 
+                        // move the cursor back to the home position.
                         Console.Write(Ansi.Cursor.Move.ToUpperLeftCorner);
+
                         var key = Console.ReadKey(true);
                         while (key.Key != ConsoleKey.Escape)
                         {
@@ -235,7 +237,9 @@ namespace RenderingPlayground
                         }
                     }
 
+                    // reset the screen and cursor.
                     Console.Write(Ansi.Clear.EntireScreen);
+                    Console.Write(Ansi.Cursor.Move.ToUpperLeftCorner);
 
                     return;
 

--- a/samples/RenderingPlayground/Program.cs
+++ b/samples/RenderingPlayground/Program.cs
@@ -28,7 +28,7 @@ namespace RenderingPlayground
         public static void Main(
 #pragma warning disable CS1573 // Parameter has no matching param tag in the XML comment (but other parameters do)
             InvocationContext invocationContext,
-            SampleName sample = SampleName.Dir,
+            SampleName sample = SampleName.Cursor,
             int? height = null,
             int? width = null,
             int top = 0,
@@ -154,6 +154,81 @@ namespace RenderingPlayground
                     screen.Render();
                 }
                     break;
+
+                case SampleName.Cursor:
+                    {
+                        var screen = new ScreenView(renderer: consoleRenderer, console);
+                        var gridView = new GridView();
+                        gridView.SetColumns(ColumnDefinition.SizeToContent());
+                        gridView.SetRows(
+                            RowDefinition.SizeToContent(),
+                            RowDefinition.Star(1)
+                        );
+
+                        var content = new ContentView("Instructions:\n" +
+                            "Use direction arrows to move the cursor.\n" +
+                            "CTRL + UP to scroll up.\n" +
+                            "CTRL + DOWN to scroll down.\n" +
+                            "S saves the cursor position, R restores it.");
+                        gridView.SetChild(content, 0, 0);
+                        gridView.SetChild(new ColorsView("#"), 0, 1);
+
+                        screen.Child = gridView;
+                        screen.Render(region);
+                        console.GetTerminal().ShowCursor();
+
+                        Console.Write(Ansi.Cursor.Move.ToUpperLeftCorner);
+
+                        var key = Console.ReadKey(true);
+                        while (key.Key != ConsoleKey.Escape)
+                        {
+                            key = Console.ReadKey(true);
+                            switch (key.Key) {
+                                case ConsoleKey.DownArrow:
+                                    if (key.Modifiers.HasFlag(ConsoleModifiers.Control))
+                                    {
+                                        Console.Write(Ansi.Cursor.Scroll.DownOne);
+                                    }
+                                    else
+                                    {
+                                        Console.Write(Ansi.Cursor.Move.Down());
+                                    }
+                                    
+                                    break;
+
+                                case ConsoleKey.UpArrow:
+                                    if (key.Modifiers.HasFlag(ConsoleModifiers.Control))
+                                    {
+                                        Console.Write(Ansi.Cursor.Scroll.UpOne);
+                                    }
+                                    else
+                                    {
+                                        Console.Write(Ansi.Cursor.Move.Up());
+                                    }
+                                    break;
+
+                                case ConsoleKey.RightArrow:
+                                    Console.Write(Ansi.Cursor.Move.Right());
+                                    break;
+
+                                case ConsoleKey.LeftArrow:
+                                    Console.Write(Ansi.Cursor.Move.Left());
+                                    break;
+
+                                case ConsoleKey.S:
+                                    Console.Write(Ansi.Cursor.SavePosition);
+                                    break;
+
+                                case ConsoleKey.R:
+                                    Console.Write(Ansi.Cursor.RestorePosition);
+                                    break;
+                            }
+                        }
+                    }
+
+                    Console.Write(Ansi.Clear.EntireScreen);
+
+                    return;
 
                 default:
                     if (!string.IsNullOrWhiteSpace(text))

--- a/samples/RenderingPlayground/Program.cs
+++ b/samples/RenderingPlayground/Program.cs
@@ -169,7 +169,9 @@ namespace RenderingPlayground
                             "Use direction arrows to move the cursor.\n" +
                             "CTRL + UP to scroll up.\n" +
                             "CTRL + DOWN to scroll down.\n" +
-                            "S saves the cursor position, R restores it.");
+                            "S saves the cursor position, R restores it.\n" +
+                            "ENTER navigates to the start of the next line.\n" +
+                            "L moves to location (10, 9).");
                         gridView.SetChild(content, 0, 0);
                         gridView.SetChild(new ColorsView("#"), 0, 1);
 
@@ -178,7 +180,6 @@ namespace RenderingPlayground
                         console.GetTerminal().ShowCursor();
 
                         Console.Write(Ansi.Cursor.Move.ToUpperLeftCorner);
-
                         var key = Console.ReadKey(true);
                         while (key.Key != ConsoleKey.Escape)
                         {
@@ -215,12 +216,20 @@ namespace RenderingPlayground
                                     Console.Write(Ansi.Cursor.Move.Left());
                                     break;
 
+                                case ConsoleKey.Enter:
+                                    Console.Write(Ansi.Cursor.Move.NextLine());
+                                    break;
+
                                 case ConsoleKey.S:
                                     Console.Write(Ansi.Cursor.SavePosition);
                                     break;
 
                                 case ConsoleKey.R:
                                     Console.Write(Ansi.Cursor.RestorePosition);
+                                    break;
+
+                                case ConsoleKey.L:
+                                    Console.Write(Ansi.Cursor.Move.ToLocation(10, 9));
                                     break;
                             }
                         }
@@ -259,6 +268,11 @@ namespace RenderingPlayground
             {
                 Console.ReadKey();
             }
+        }
+
+        private static void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/samples/RenderingPlayground/SampleName.cs
+++ b/samples/RenderingPlayground/SampleName.cs
@@ -9,5 +9,6 @@
         TableView,
         Clock,
         GridLayout,
+        Cursor,
     }
 }

--- a/src/System.CommandLine.Rendering.Tests/AnsiTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/AnsiTests.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Rendering.Tests
+{
+    // see https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+    public class AnsiTests
+    {
+        [Fact]
+        public void Ansi_esc_returns_correct_terminal_sequence()
+        {
+            Ansi.Esc.Should().Be("\u001b");
+        }
+
+        [Fact]
+        public void Ansi_cursor_move_up_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Move.Up().EscapeSequence.Should().Be($"{Ansi.Esc}[1A");
+            Ansi.Cursor.Move.Up(5).EscapeSequence.Should().Be($"{Ansi.Esc}[5A");
+        }
+
+        [Fact]
+        public void Ansi_cursor_move_down_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Move.Down().EscapeSequence.Should().Be($"{Ansi.Esc}[1B");
+            Ansi.Cursor.Move.Down(5).EscapeSequence.Should().Be($"{Ansi.Esc}[5B");
+        }
+
+        [Fact]
+        public void Ansi_cursor_move_right_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Move.Right().EscapeSequence.Should().Be($"{Ansi.Esc}[1C");
+            Ansi.Cursor.Move.Right(5).EscapeSequence.Should().Be($"{Ansi.Esc}[5C");
+        }
+
+        [Fact]
+        public void Ansi_cursor_move_left_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Move.Left().EscapeSequence.Should().Be($"{Ansi.Esc}[1D");
+            Ansi.Cursor.Move.Left(5).EscapeSequence.Should().Be($"{Ansi.Esc}[5D");
+        }
+
+        [Fact]
+        public void Ansi_cursor_move_next_line_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Move.NextLine().EscapeSequence.Should().Be($"{Ansi.Esc}[1E");
+            Ansi.Cursor.Move.NextLine(5).EscapeSequence.Should().Be($"{Ansi.Esc}[5E");
+        }
+
+        [Fact]
+        public void Ansi_cursor_move_to_upper_left_corner_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Move.ToUpperLeftCorner.EscapeSequence.Should().Be($"{Ansi.Esc}[H");
+        }
+
+        [Fact]
+        public void Ansi_cursor_move_to_location_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Move.ToLocation().EscapeSequence.Should().Be($"{Ansi.Esc}[1;1H");
+            Ansi.Cursor.Move.ToLocation(3).EscapeSequence.Should().Be($"{Ansi.Esc}[1;3H");
+            Ansi.Cursor.Move.ToLocation(top: 2).EscapeSequence.Should().Be($"{Ansi.Esc}[2;1H");
+            Ansi.Cursor.Move.ToLocation(5,4).EscapeSequence.Should().Be($"{Ansi.Esc}[4;5H");
+        }
+
+        [Fact]
+        public void Ansi_cursor_scroll_up_one_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Scroll.UpOne.EscapeSequence.Should().Be($"{Ansi.Esc}[S");
+        }
+
+        [Fact]
+        public void Ansi_cursor_scroll_down_one_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Scroll.DownOne.EscapeSequence.Should().Be($"{Ansi.Esc}[T");
+        }
+
+        [Fact]
+        public void Ansi_cursor_hide_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Hide.EscapeSequence.Should().Be($"{Ansi.Esc}[?25l");
+        }
+
+        [Fact]
+        public void Ansi_cursor_show_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.Show.EscapeSequence.Should().Be($"{Ansi.Esc}[?25h");
+        }
+
+        [Fact]
+        public void Ansi_cursor_save_position_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.SavePosition.EscapeSequence.Should().Be($"{Ansi.Esc}7");
+        }
+
+        [Fact]
+        public void Ansi_cursor_restore_position_returns_correct_terminal_sequence()
+        {
+            Ansi.Cursor.RestorePosition.EscapeSequence.Should().Be($"{Ansi.Esc}8");
+        }
+    }
+}

--- a/src/System.CommandLine.Rendering/Ansi.cs
+++ b/src/System.CommandLine.Rendering/Ansi.cs
@@ -29,7 +29,7 @@ namespace System.CommandLine.Rendering
         public static class Color
         {
             [DebuggerStepThrough]
-            public class Background
+            public static class Background
             {
                 public static AnsiControlCode Default { get; } = $"{Esc}[49m";
 
@@ -93,11 +93,11 @@ namespace System.CommandLine.Rendering
                 public static AnsiControlCode Left(int columns = 1) => $"{Esc}[{columns}D";
                 public static AnsiControlCode NextLine(int line = 1) => $"{Esc}[{line}E";
                 public static AnsiControlCode ToUpperLeftCorner { get; } = $"{Esc}[H";
-                public static AnsiControlCode ToLocation(int? left = null, int? top = null) => $"{Esc}[{top};{left}H";
+                public static AnsiControlCode ToLocation(int? left = null, int? top = null) => $"{Esc}[{top ?? 1};{left ?? 1}H";
             }
 
             [DebuggerStepThrough]
-            public class Scroll
+            public static class Scroll
             {
                 public static AnsiControlCode UpOne { get; } = $"{Esc}[S";
 

--- a/src/System.CommandLine.Rendering/Ansi.cs
+++ b/src/System.CommandLine.Rendering/Ansi.cs
@@ -90,7 +90,7 @@ namespace System.CommandLine.Rendering
                 public static AnsiControlCode Down(int lines = 1) => $"{Esc}[{lines}B";
                 public static AnsiControlCode Right(int columns = 1) => $"{Esc}[{columns}C";
                 public static AnsiControlCode Left(int columns = 1) => $"{Esc}[{columns}D";
-                public static AnsiControlCode NextLine(int line = 1) => $"{Esc}{line}E";
+                public static AnsiControlCode NextLine(int line = 1) => $"{Esc}[{line}E";
                 public static AnsiControlCode ToUpperLeftCorner { get; } = $"{Esc}[H";
                 public static AnsiControlCode ToLocation(int? left = null, int? top = null) => $"{Esc}[{top};{left}H";
             }

--- a/src/System.CommandLine.Rendering/Ansi.cs
+++ b/src/System.CommandLine.Rendering/Ansi.cs
@@ -80,6 +80,7 @@ namespace System.CommandLine.Rendering
             }
         }
 
+        // see: https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
         [DebuggerStepThrough]
         public static class Cursor
         {
@@ -98,9 +99,9 @@ namespace System.CommandLine.Rendering
             [DebuggerStepThrough]
             public class Scroll
             {
-                public static AnsiControlCode UpOne { get; } = $"{Esc}D";
+                public static AnsiControlCode UpOne { get; } = $"{Esc}[S";
 
-                public static AnsiControlCode DownOne { get; } = $"{Esc}M";
+                public static AnsiControlCode DownOne { get; } = $"{Esc}[T";
             }
 
             public static AnsiControlCode Hide { get; } = $"{Esc}[?25l";


### PR DESCRIPTION
In order to have a valid discussion on this issue I felt it was necessary to add a new sample to the `RenderingPlayground` that used the cursor methods; this can be accessed by running with `--sample Cursor`.

The original implementation worked for the most part, however:

- `Move.NextLine` was wrong, as stated in the bug report, and this has been fixed.
- `Scroll.UpOne / DownOne` were partially correct, in that one direction worked, but not both. I think that the problem here was that short sequences were being used, but there is only one scroll short sequence. I've changed it to use the full scroll sequences, for which there is one in either direction. The suggestion in the bug report looks wrong.

It is worth noting that scroll scrolls the content not the screen, so it goes in the opposite direction to that which you are expecting. This behaviour is maintained in the API, however I've swapped them round so the seem natural in the sample. Also scrolling wipes out the parts of the screen that are scrolled. This seems to be the expected behaviour.

I've added tests (for what they are worth) and marked the non-static classes as static.