### PR TITLE
Replace | with or when searching for Argument value

### DIFF
--- a/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
@@ -415,5 +415,96 @@ namespace System.CommandLine.Tests.Invocation
             testClass.boundName.Should().Be("Gandalf");
             testClass.boundAge.Should().Be(425);
         }
+
+        [Fact]
+        public async Task Method_parameters_on_the_invoked_method_are_bound_to_matching_argument_names()
+        {
+            string boundName = default;
+            int boundAge = default;
+
+            void Execute(string name, int age)
+            {
+                boundName = name;
+                boundAge = age;
+            }
+
+            var command = new Command("command");
+            command.AddArgument(new Argument<int>("age"));
+            command.AddArgument(new Argument<string>("name"));
+            command.Handler = CommandHandler.Create<string, int>(Execute);
+
+            await command.InvokeAsync("command 425 Gandalf", _console);
+
+            boundName.Should().Be("Gandalf");
+            boundAge.Should().Be(425);
+        }
+
+
+        [Fact]
+        public async Task Method_parameters_on_the_invoked_method_can_be_bound_to_hyphenated_argument_names()
+        {
+            string boundFirstName = default;
+
+            void Execute(string firstName)
+            {
+                boundFirstName = firstName;
+            }
+
+            var command = new Command("command")
+            {
+                new Argument<string>("first-name")
+            };
+            command.Handler = CommandHandler.Create<string>(Execute);
+
+            await command.InvokeAsync("command Gandalf", _console);
+
+            boundFirstName.Should().Be("Gandalf");
+        }
+
+        [Fact]
+        public async Task Method_parameters_on_the_invoked_method_can_be_bound_to_argument_names_case_insensitively()
+        {
+            string boundName = default;
+            int boundAge = default;
+
+            void Execute(string name, int AGE)
+            {
+                boundName = name;
+                boundAge = AGE;
+            }
+
+            var command = new Command("command");
+            command.AddArgument(new Argument<int>("AGE"));
+            command.AddArgument(new Argument<string>("Name"));
+            command.Handler = CommandHandler.Create<string, int>(Execute);
+
+            await command.InvokeAsync("command 425 Gandalf", _console);
+
+            boundName.Should().Be("Gandalf");
+            boundAge.Should().Be(425);
+        }
+
+        [Fact]
+        public async Task Method_parameters_on_the_invoked_method_are_bound_to_matching_argument_names_with_pipe_in()
+        {
+            string boundName = default;
+            int boundAge = default;
+
+            void Execute(string fullnameOrNickname, int age)
+            {
+                boundName = fullnameOrNickname;
+                boundAge = age;
+            }
+
+            var command = new Command("command");
+            command.AddArgument(new Argument<int>("age"));
+            command.AddArgument(new Argument<string>("fullname|nickname"));
+            command.Handler = CommandHandler.Create<string, int>(Execute);
+
+            await command.InvokeAsync("command 425 Gandalf", _console);
+
+            boundName.Should().Be("Gandalf");
+            boundAge.Should().Be(425);
+        }
     }
 }

--- a/src/System.CommandLine/Binding/Binder.cs
+++ b/src/System.CommandLine/Binding/Binder.cs
@@ -9,7 +9,8 @@ namespace System.CommandLine.Binding
     {
         internal static bool IsMatch(this string parameterName, string alias) =>
             string.Equals(alias?.RemovePrefix()
-                              .Replace("-", ""),
+                              .Replace("-", "")
+                              .Replace("|", "or"),
                           parameterName,
                           StringComparison.OrdinalIgnoreCase);
 

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -36,7 +36,7 @@ namespace System.CommandLine.Parsing
             {
                 foreach (var argument in commandResult.Command.Arguments)
                 {
-                    if (valueName.IsMatch(argument.Name) || valueName.IsMatch(argument.Name.Replace("|","or")))
+                    if (valueName.IsMatch(argument.Name))
                     {
                         value = commandResult.ArgumentConversionResults[argument.Name]?.GetValueOrDefault();
                         return true;

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -36,7 +36,7 @@ namespace System.CommandLine.Parsing
             {
                 foreach (var argument in commandResult.Command.Arguments)
                 {
-                    if (valueName.IsMatch(argument.Name))
+                    if (valueName.IsMatch(argument.Name.Replace("|","or")))
                     {
                         value = commandResult.ArgumentConversionResults[argument.Name]?.GetValueOrDefault();
                         return true;

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -36,7 +36,7 @@ namespace System.CommandLine.Parsing
             {
                 foreach (var argument in commandResult.Command.Arguments)
                 {
-                    if (valueName.IsMatch(argument.Name.Replace("|","or")))
+                    if (valueName.IsMatch(argument.Name) || valueName.IsMatch(argument.Name.Replace("|","or")))
                     {
                         value = commandResult.ArgumentConversionResults[argument.Name]?.GetValueOrDefault();
                         return true;


### PR DESCRIPTION
This allows the CommandHandler to be registered with `fileOrString` for an Argument named `File|String`.

#1051