### PR TITLE
Fix complete registration issue where items with spaces are registere…

### DIFF
--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash
@@ -24,6 +24,11 @@ _dotnet_bash_complete()
     fi
 }
 
-complete -F _dotnet_bash_complete `dotnet-suggest list`
+_dotnet_bash_register_complete()
+{
+    local IFS=$'\n'
+    complete -F _dotnet_bash_complete `dotnet-suggest list`
+}
+_dotnet_bash_register_complete
 export DOTNET_SUGGEST_SCRIPT_VERSION="1.0.0"
 # dotnet suggest shell complete script end

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash
@@ -30,5 +30,5 @@ _dotnet_bash_register_complete()
     complete -F _dotnet_bash_complete `dotnet-suggest list`
 }
 _dotnet_bash_register_complete
-export DOTNET_SUGGEST_SCRIPT_VERSION="1.0.0"
+export DOTNET_SUGGEST_SCRIPT_VERSION="1.0.1"
 # dotnet suggest shell complete script end


### PR DESCRIPTION
…d separately

Call a function that changes the value of IFS to newline only. This ensures IFS is
restored to whatever it was before and would work any various platforms.

Fix #1085