### PR TITLE
enable v3 package publish via arcade

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -160,4 +160,5 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
+      publishingInfraVersion: 3
       enableSourceLinkValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <PublishingVersion>3</PublishingVersion>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
The same change was made in dotnet/fsharp#10257 and makes the signed build status much better to look at.

~~Marked as WIP until the [internal signed build](https://dev.azure.com/dnceng/internal/_build/results?buildId=898750&view=results) shows all green.~~  Internal build is as expected.