### PR TITLE
invert version selector properties

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,22 +6,18 @@
   </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <!-- Default version number. -->
+    <!-- Default version number to global tool. -->
     <VersionPrefix>0.1.0</VersionPrefix>
-    <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
+    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
   </PropertyGroup>
-  <PropertyGroup Condition="$(UseBetaVersion) == 'true'">
+  <PropertyGroup Condition="'$(UseBetaVersion)' == 'true'">
     <VersionPrefix>2.0.0</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
   </PropertyGroup>
-  <PropertyGroup Condition="$(UseAlphaVersion) == 'true'">
+  <PropertyGroup Condition="'$(UseAlphaVersion)' == 'true'">
     <VersionPrefix>0.3.0</VersionPrefix>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(UseGlobalToolVersion) == 'true'">
-    <VersionPrefix>1.1</VersionPrefix>
-    <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
-    <PreReleaseVersionLabel />
   </PropertyGroup>
   <PropertyGroup>
     <UsingToolSourceLink>true</UsingToolSourceLink>


### PR DESCRIPTION
To temporarily work around issue dotnet/arcade#6616, this PR inverts the version selector stuff so that by default `AutoGenerateAssemblyVersion` = `true` and `PreReleaseVersionLabel` is empty to enable publishing a stable package to a non-isolated feed.

The next immediate section effectively reverts those values if `UseGlobalToolVersion` isn't `true` (which is all projects _except_ `dotnet-suggest.csproj`) and finally the next 2 sections override those values again if `UseAlphaVersion` or `UseBetaVersion` is true.