### PR TITLE
don't auto-generate assembly version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,13 +11,18 @@
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
     <PreReleaseVersionLabel></PreReleaseVersionLabel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(UseGlobalToolVersion)' == 'true'">
+    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(UseBetaVersion)' == 'true'">
     <VersionPrefix>2.0.0</VersionPrefix>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
+    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseAlphaVersion)' == 'true'">
     <VersionPrefix>0.3.0</VersionPrefix>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
   </PropertyGroup>
   <PropertyGroup>
     <UsingToolSourceLink>true</UsingToolSourceLink>


### PR DESCRIPTION
As part of #1113 I forgot to ensure that `AutoGenerateAssemblyVersion` is false for all projects, but true in the general sense.  This is also part of the workaround mentioned in the issue, supra.

Internal build has all of the correct assembly version numbers and package numbers.