### PR TITLE
Making the debug directive opt-in

### DIFF
--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -212,21 +212,21 @@ namespace System.CommandLine.Builder
             {
                 if (context.ParseResult.Directives.Contains("debug"))
                 {
-                    const string environmentVariableName = "SYSTEM_COMMANDLINE_DEBUG_PROCESSES";
+                    const string environmentVariableName = "DOTNET_COMMANDLINE_DEBUG_PROCESSES";
 
+                    var process = Diagnostics.Process.GetCurrentProcess();
                     string debuggableProcessNames = GetEnvironmentVariable(environmentVariableName);
                     if (string.IsNullOrWhiteSpace(debuggableProcessNames))
                     {
                         context.Console.Error.WriteLine("Debug directive specified, but no process names are listed as allowed for debug.");
                         context.Console.Error.WriteLine($"Add your process name to the '{environmentVariableName}' environment variable.");
+                        context.Console.Error.WriteLine($"The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{environmentVariableName}={process.ProcessName}'");
                         context.ExitCode = errorExitCode ?? 1;
                         return;
                     }
                     else
                     {
                         string[] processNames = debuggableProcessNames.Split(';');
-
-                        var process = Diagnostics.Process.GetCurrentProcess();
                         if (processNames.Contains(process.ProcessName, StringComparer.Ordinal))
                         {
                             var processId = process.Id;


### PR DESCRIPTION
One possible solution for addressing the debug directive.

Some questions:
1. Is the environment variable name `SYSTEM_COMMANDLINE_DEBUG_PROCESSES` acceptable?
2. Currently the messages if you specify the debug directive but have not opted-in with the environment variable are written to standard error. Is that correct?
3. Should error conditions like that short-circuit or continue calling through the pipeline? If they should short-circuit what should the exit code be?
4. I added an optional timeout, with a default of infinite, should this default be changed?


Fixes #468 