### PR TITLE
Improve default XML-doc probing logic for bundled applications

### DIFF
--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -311,9 +311,26 @@ namespace System.CommandLine.DragonFruit
 
         private static string GetDefaultXmlDocsFileLocation(Assembly assembly)
         {
-            return Path.Combine(
-                Path.GetDirectoryName(assembly.Location),
-                Path.GetFileNameWithoutExtension(assembly.Location) + ".xml");
+            if (!string.IsNullOrEmpty(assembly.Location))
+            {
+                return Path.Combine(
+                    Path.GetDirectoryName(assembly.Location),
+                    Path.GetFileNameWithoutExtension(assembly.Location) + ".xml");
+            }
+
+            // Assembly.Location is empty for bundled (i.e, single-file) assemblies, but we can't be confident
+            // that whenever Assembly.Location is empty the corresponding assembly is bundled.
+            //
+            // Provisionally assume that the entry-assembly is bundled. If this query is for something other
+            // than the entry-assembly, then return nothing. 
+            if (assembly == Assembly.GetEntryAssembly())
+            {
+                return Path.Combine(
+                    AppContext.BaseDirectory,
+                    assembly.GetName().Name + ".xml");
+            }
+
+            return string.Empty;
         }
     }
 }


### PR DESCRIPTION
`Assembly.Location` in bundled applications returns `string.Empty`, which breaks the current logic for probing the XML docs file location.

This change uses `AppContext.BaseDirectory` to look for the XML docs for bundled apps.

Fixes #1031