### PR TITLE
More perf tuning

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -138,8 +138,7 @@ namespace System.CommandLine.DragonFruit.Tests
                                              "args"
                                          };
 
-            rootCommand.Children
-                       .OfType<IOption>()
+            rootCommand.Options
                        .Should()
                        .NotContain(o => argumentParameterNames.Contains(o.Name));
         }

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -223,12 +223,13 @@ namespace System.CommandLine.DragonFruit
                         }
                         else
                         {
-                            foreach (var argument in builder.Command.Arguments)
+                            for (var i = 0; i < builder.Command.Arguments.Count; i++)
                             {
+                                var argument = builder.Command.Arguments[i];
                                 if (string.Equals(
-                                        argument.Name,
-                                        kebabCasedParameterName, 
-                                        StringComparison.OrdinalIgnoreCase))
+                                    argument.Name,
+                                    kebabCasedParameterName,
+                                    StringComparison.OrdinalIgnoreCase))
                                 {
                                     argument.Description = parameterDescription.Value;
                                 }

--- a/src/System.CommandLine.Rendering/StringExtensions.cs
+++ b/src/System.CommandLine.Rendering/StringExtensions.cs
@@ -7,11 +7,11 @@ namespace System.CommandLine.Rendering
     {
         public static bool EndsWithWhitespace(this string value) =>
             value.Length > 0
-            && Char.IsWhiteSpace(value[value.Length - 1]);
+            && char.IsWhiteSpace(value[value.Length - 1]);
 
         public static bool StartsWithWhitespace(this string value) =>
             value.Length > 0
-            && Char.IsWhiteSpace(value[0]);
+            && char.IsWhiteSpace(value[0]);
 
         public static bool IsNewLine(this string value) => value == "\n" || value == "\r\n";
     }

--- a/src/System.CommandLine.Suggest/GlobalToolsSuggestionRegistration.cs
+++ b/src/System.CommandLine.Suggest/GlobalToolsSuggestionRegistration.cs
@@ -46,7 +46,10 @@ namespace System.CommandLine.Suggest
 
         public Registration FindRegistration(FileInfo soughtExecutable)
         {
-            if (soughtExecutable == null) throw new ArgumentNullException(nameof(soughtExecutable));
+            if (soughtExecutable == null)
+            {
+                throw new ArgumentNullException(nameof(soughtExecutable));
+            }
 
             if (_nullableToolsShimPath == null)
             {

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -179,7 +179,7 @@ namespace System.CommandLine.Suggest
 
                     yield return fileNameWithoutExtension;
 
-                    if (fileNameWithoutExtension.StartsWith("dotnet-", StringComparison.Ordinal))
+                    if (fileNameWithoutExtension?.StartsWith("dotnet-", StringComparison.Ordinal) == true)
                     {
                         yield return "dotnet " + fileNameWithoutExtension.Substring("dotnet-".Length);
                     }

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -493,16 +493,18 @@ namespace System.CommandLine.Tests.Binding
         {
             var directoryInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
 
+            var argument = new Argument<DirectoryInfo>("the-arg", () => directoryInfo);
+
             var command = new Command("something")
             {
-                new Argument<DirectoryInfo>("the-arg", () => directoryInfo)
+                argument
             };
 
             var result = command.Parse("something");
 
             result.Errors.Should().BeEmpty();
 
-            var value = result.CommandResult.GetArgumentValueOrDefault("the-arg");
+            var value = result.ValueForArgument("the-arg");
 
             value.Should().Be(directoryInfo);
         }

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -134,36 +134,6 @@ namespace System.CommandLine.Tests
                   .BeEquivalentTo("arg2", "arg3");
         }
 
-        [Theory]
-        [InlineData("aa:", ":")]
-        [InlineData("aa=", "=")]
-        [InlineData(":aa", ":")]
-        [InlineData("=aa", "=")]
-        [InlineData("aa:aa", ":")]
-        [InlineData("aa=aa", "=")]
-        public void When_a_command_name_contains_a_delimiter_then_an_error_is_returned(
-            string commandWithDelimiter,
-            string delimiter)
-        {
-            Action create = () =>
-            {
-                var c = new Command(commandWithDelimiter)
-                {
-                    new Argument
-                    {
-                        Arity = ArgumentArity.ExactlyOne
-                    }
-                };
-            };
-
-            create.Should()
-                  .Throw<ArgumentException>()
-                  .Which
-                  .Message
-                  .Should()
-                  .Be($"Command \"{commandWithDelimiter}\" is not allowed to contain a delimiter but it contains \"{delimiter}\"");
-        }
-
         [Fact]
         public void Aliases_is_aware_of_added_alias()
         {

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -147,14 +147,13 @@ namespace System.CommandLine.Tests
         {
             Action create = () =>
             {
-                new Parser(
-                    new Command(commandWithDelimiter)
+                var c = new Command(commandWithDelimiter)
+                {
+                    new Argument
                     {
-                        new Argument
-                        {
-                            Arity = ArgumentArity.ExactlyOne
-                        }
-                    });
+                        Arity = ArgumentArity.ExactlyOne
+                    }
+                };
             };
 
             create.Should()

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -76,22 +76,6 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Global_options_appear_in_child_command_options_list()
-        {
-            var root = new Command("parent");
-
-            var option = new Option<int>("--global");
-
-            root.AddGlobalOption(option);
-
-            var child = new Command("child");
-
-            root.AddCommand(child);
-
-            child.Options.Should().Contain(option);
-        }
-
-        [Fact]
         public void Subcommands_added_after_a_global_option_is_added_to_parent_will_recognize_the_global_option()
         {
             var root = new Command("parent");

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -166,32 +166,6 @@ namespace System.CommandLine.Tests
         }
 
         [Theory]
-        [InlineData(":", "-x{0}")]
-        [InlineData("=", "-x{0}")]
-        [InlineData(":", "{0}-x")]
-        [InlineData("=", "{0}-x")]
-        [InlineData(":", "--aa{0}aa")]
-        [InlineData("=", "--aa{0}aa")]
-        public void When_an_option_alias_contains_a_delimiter_then_an_informative_error_is_returned(
-            string delimiter,
-            string template)
-        {
-            var alias = string.Format(template, delimiter);
-
-            Action create = () =>
-            {
-                new Parser(new Option(alias));
-            };
-
-            create.Should()
-                  .Throw<ArgumentException>()
-                  .Which
-                  .Message
-                  .Should()
-                  .Be($"Option \"{alias}\" is not allowed to contain a delimiter but it contains \"{delimiter}\"");
-        }
-
-        [Theory]
         [InlineData("-x ")]
         [InlineData(" -x")]
         [InlineData("--aa aa")]

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -33,11 +33,9 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2 3 4");
 
-                var several = result.CommandResult
-                                    .GetArgumentValueOrDefault<IEnumerable<string>>("several");
+                var several = result.ValueForArgument<IEnumerable<string>>("several");
 
-                var one = result.CommandResult
-                                .GetArgumentValueOrDefault<IEnumerable<string>>("one");
+                var one = result.ValueForArgument<IEnumerable<string>>("one");
 
                 several.Should()
                        .BeEquivalentSequenceTo("1", "2", "3");
@@ -62,11 +60,9 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2");
 
-                var theString = result.CommandResult
-                                    .GetArgumentValueOrDefault<string>("the-string");
+                var theString = result.ValueForArgument<string>("the-string");
 
-                var theInt = result.CommandResult
-                                .GetArgumentValueOrDefault<int>("the-int");
+                var theInt = result.ValueForArgument<int>("the-int");
 
                 theString.Should().Be("1");
                 theInt.Should().Be(2);
@@ -124,27 +120,29 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Multiple_arguments_of_unspecified_type_are_parsed_correctly()
             {
+                var sourceArg = new Argument("source")
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                };
+                var destinationArg = new Argument("destination")
+                {
+                    Arity = ArgumentArity.ExactlyOne
+                };
                 var root = new RootCommand
                 {
-                    new Argument("source")
-                    {
-                        Arity = ArgumentArity.ExactlyOne
-                    },
-                    new Argument("destination")
-                    {
-                        Arity = ArgumentArity.ExactlyOne
-                    }
+                    sourceArg,
+                    destinationArg
                 };
 
                 var result = root.Parse("src.txt dest.txt");
 
-                result.RootCommandResult
-                      .GetArgumentValueOrDefault("source")
+                result.FindResultFor(sourceArg)
+                      .GetValueOrDefault()
                       .Should()
                       .Be("src.txt");
                 
-                result.RootCommandResult
-                      .GetArgumentValueOrDefault("destination")
+                result.FindResultFor(destinationArg)
+                      .GetValueOrDefault()
                       .Should()
                       .Be("dest.txt");
             }

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1344,8 +1344,7 @@ namespace System.CommandLine.Tests
 
             ParseResult result = command.Parse("command");
 
-            result.CommandResult
-                  .GetArgumentValueOrDefault("the-arg")
+            result.ValueForArgument("the-arg")
                   .Should()
                   .Be("default");
         }
@@ -1441,8 +1440,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("the-directory");
 
-            result.CommandResult
-                  .GetArgumentValueOrDefault<DirectoryInfo>("the-arg")
+            result.ValueForArgument<DirectoryInfo>("the-arg")
                   .Name
                   .Should()
                   .Be("the-directory");

--- a/src/System.CommandLine.Tests/SymbolSetTests.cs
+++ b/src/System.CommandLine.Tests/SymbolSetTests.cs
@@ -127,6 +127,7 @@ namespace System.CommandLine.Tests
                    .Should()
                    .BeSameAs(symbol);
         }
+
         [Fact]
         public void When_command_alias_is_changed_then_GetByAlias_returns_true_for_the_new_alias()
         {

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -223,7 +223,7 @@ namespace System.CommandLine
             return dynamicSuggestions
                    .Distinct()
                    .OrderBy(c => c, StringComparer.OrdinalIgnoreCase)
-                   .Containing(textToMatch);
+                   .Containing(textToMatch ?? "");
         }
 
         public override string ToString() => $"{nameof(Argument)}: {Name}";

--- a/src/System.CommandLine/ArgumentExtensions.cs
+++ b/src/System.CommandLine/ArgumentExtensions.cs
@@ -117,8 +117,10 @@ namespace System.CommandLine
             
             argument.AddValidator(symbol =>
             {
-                foreach (var token in symbol.Tokens)
+                for (var i = 0; i < symbol.Tokens.Count; i++)
                 {
+                    var token = symbol.Tokens[i];
+
                     // File class no longer check invalid character
                     // https://blogs.msdn.microsoft.com/jeremykuhne/2018/03/09/custom-directory-enumeration-in-net-core-2-1/
                     var invalidCharactersIndex = token.Value.IndexOfAny(invalidPathChars);

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -24,8 +24,8 @@ namespace System.CommandLine.Binding
                     return new DirectoryInfo(value);
                 }
 
-                if (value.EndsWith(Path.DirectorySeparatorChar.ToString()) ||
-                    value.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+                if (value.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) ||
+                    value.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
                 {
                     return new DirectoryInfo(value);
                 }

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -141,9 +141,10 @@ namespace System.CommandLine.Binding
                 ModelDescriptor.ModelType,
                 includeMissingValues: false);
 
-            foreach (var boundValue in boundValues)
+            for (var i = 0; i < boundValues.Count; i++)
             {
-                ((PropertyDescriptor)boundValue.ValueDescriptor).SetValue(instance, boundValue.Value);
+                var boundValue = boundValues[i];
+                ((PropertyDescriptor) boundValue.ValueDescriptor).SetValue(instance, boundValue.Value);
             }
 
             return anyNonDefaults;

--- a/src/System.CommandLine/Builder/CommandBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandBuilder.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Builder
 
         public Command Command { get; }
 
-        public IEnumerable<Option> Options => Command.Children.OfType<Option>();
+        public IEnumerable<Option> Options => Command.Options;
 
         internal void AddCommand(Command command) => Command.AddCommand(command);
 

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -469,7 +469,7 @@ namespace System.CommandLine.Builder
         {
             builder.AddMiddleware(async (context, next) =>
             {
-                if ((context.ParseResult.UnmatchedTokens.Count > 0) &&
+                if (context.ParseResult.UnmatchedTokens.Count > 0 &&
                     context.ParseResult.CommandResult.Command.TreatUnmatchedTokensAsErrors)
                 {
                     var typoCorrection = new TypoCorrection(maxLevenshteinDistance);

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -198,8 +198,8 @@ namespace System.CommandLine.Builder
                     }
                     finally
                     {
-                        StringBuilderPool.Default.Return(stdOut);
-                        StringBuilderPool.Default.Return(stdErr);
+                        StringBuilderPool.Default.ReturnToPool(stdOut);
+                        StringBuilderPool.Default.ReturnToPool(stdErr);
                     }
                 });
 

--- a/src/System.CommandLine/Collections/AliasedSet.cs
+++ b/src/System.CommandLine/Collections/AliasedSet.cs
@@ -12,9 +12,18 @@ namespace System.CommandLine.Collections
     {
         private protected readonly Dictionary<string, T> ItemsByAlias = new Dictionary<string, T>();
 
+        public int Count => Items.Count;
+
         private protected List<T> Items { get; } = new List<T>();
 
         private protected HashSet<T> DirtyItems { get; } = new HashSet<T>();
+
+        public bool Contains(string alias)
+        {
+            EnsureAliasIndexIsCurrent();
+
+            return ItemsByAlias.ContainsKey(alias);
+        }
 
         public T? GetByAlias(string alias)
         {
@@ -24,8 +33,6 @@ namespace System.CommandLine.Collections
 
             return value;
         }
-
-        public int Count => Items.Count;
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -53,17 +60,11 @@ namespace System.CommandLine.Collections
 
         protected abstract IReadOnlyCollection<string> GetAliases(T item);
 
-        public bool Contains(string alias)
-        {
-            EnsureAliasIndexIsCurrent();
-
-            return ItemsByAlias.ContainsKey(alias);
-        }
-
         public T this[int index] => Items[index];
 
         private protected void EnsureAliasIndexIsCurrent()
         {
+            // FIX: (EnsureAliasIndexIsCurrent) 
             if (DirtyItems.Count == 0)
             {
                 return;

--- a/src/System.CommandLine/Collections/AliasedSet.cs
+++ b/src/System.CommandLine/Collections/AliasedSet.cs
@@ -69,14 +69,11 @@ namespace System.CommandLine.Collections
                 return;
             }
 
-            var array = DirtyItems.ToArray();
-
-            for (var i = 0; i < array.Length; i++)
+            foreach (var dirtyItem in DirtyItems)
             {
-                var dirtyItem = array[i];
                 var aliases = GetAliases(dirtyItem).ToArray();
 
-                foreach (var pair in ItemsByAlias.Where(p => p.Value.Equals(dirtyItem)).ToArray())
+                foreach (var pair in ItemsByAlias)
                 {
                     if (pair.Value.Equals(dirtyItem))
                     {
@@ -84,9 +81,7 @@ namespace System.CommandLine.Collections
                     }
                 }
 
-                var wasRemoved = !Items.Contains(dirtyItem);
-
-                if (!wasRemoved)
+                if (Items.Contains(dirtyItem))
                 {
                     for (var j = 0; j < aliases.Length; j++)
                     {
@@ -94,9 +89,9 @@ namespace System.CommandLine.Collections
                         ItemsByAlias.TryAdd(alias, dirtyItem);
                     }
                 }
-
-                DirtyItems.Remove(dirtyItem);
             }
+
+            DirtyItems.Clear();
         }
     }
 }

--- a/src/System.CommandLine/Collections/AliasedSet.cs
+++ b/src/System.CommandLine/Collections/AliasedSet.cs
@@ -74,7 +74,7 @@ namespace System.CommandLine.Collections
             {
                 var aliases = GetAliases(dirtyItem).ToArray();
 
-                foreach (var pair in ItemsByAlias)
+                foreach (var pair in ItemsByAlias.ToArray())
                 {
                     if (pair.Value.Equals(dirtyItem))
                     {

--- a/src/System.CommandLine/Collections/AliasedSet.cs
+++ b/src/System.CommandLine/Collections/AliasedSet.cs
@@ -12,11 +12,11 @@ namespace System.CommandLine.Collections
     {
         private protected readonly Dictionary<string, T> ItemsByAlias = new Dictionary<string, T>();
 
-        public int Count => Items.Count;
-
         private protected List<T> Items { get; } = new List<T>();
 
         private protected HashSet<T> DirtyItems { get; } = new HashSet<T>();
+        
+        public int Count => Items.Count;
 
         public bool Contains(string alias)
         {
@@ -64,7 +64,6 @@ namespace System.CommandLine.Collections
 
         private protected void EnsureAliasIndexIsCurrent()
         {
-            // FIX: (EnsureAliasIndexIsCurrent) 
             if (DirtyItems.Count == 0)
             {
                 return;

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -9,11 +9,16 @@ namespace System.CommandLine.Collections
 {
     public class SymbolSet : AliasedSet<ISymbol>, ISymbolSet
     {
+        private List<Argument>? _arguments;
+        private List<Option>? _options;
+
         internal override void Add(ISymbol item)
         {
             ThrowIfAnyAliasIsInUse(item);
 
             base.Add(item);
+
+            ResetIndex(item);
 
             if (item is Symbol symbol)
             {
@@ -25,9 +30,24 @@ namespace System.CommandLine.Collections
         {
             base.Remove(item);
 
+            ResetIndex(item);
+
             if (item is Symbol symbol)
             {
                 symbol.OnNameOrAliasChanged -= Resync;
+            }
+        }
+
+        private void ResetIndex(ISymbol item)
+        {
+            switch (item)
+            {
+                case Argument _:
+                    _arguments = null;
+                    break;
+                case Option _:
+                    _options = null;
+                    break;
             }
         }
 
@@ -91,5 +111,51 @@ namespace System.CommandLine.Collections
                 IIdentifierSymbol named => named.Aliases,
                 _ => new[] { item.Name }
             };
+
+        internal IReadOnlyList<Argument> Arguments
+        {
+            get
+            {
+                return _arguments ??= BuildArgumentsList();
+
+                List<Argument> BuildArgumentsList()
+                {
+                    var arguments = new List<Argument>(Count);
+
+                    for (var i = 0; i < Count; i++)
+                    {
+                        if (this[i] is Argument argument)
+                        {
+                            arguments.Add(argument);
+                        }
+                    }
+
+                    return arguments;
+                }
+            }
+        }
+        
+        internal IReadOnlyList<Option> Options
+        {
+            get
+            {
+                return _options ??= BuildOptionsList();
+
+                List<Option> BuildOptionsList()
+                {
+                    var options = new List<Option>(Count);
+
+                    for (var i = 0; i < Count; i++)
+                    {
+                        if (this[i] is Option Option)
+                        {
+                            options.Add(Option);
+                        }
+                    }
+
+                    return options;
+                }
+            }
+        }
     }
 }

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -21,7 +21,7 @@ namespace System.CommandLine.Collections
             ResetIndex(item);
 
             if (item is Symbol symbol)
-            {
+            {   
                 symbol.OnNameOrAliasChanged += Resync;
             }
         }

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -37,21 +37,17 @@ namespace System.CommandLine
         /// <summary>
         /// Represents all of the arguments for the command.
         /// </summary>
-        public IEnumerable<Argument> Arguments => 
-            Children.OfType<Argument>();
+        public IReadOnlyList<Argument> Arguments => Children.Arguments;
 
         /// <summary>
         /// Represents all of the options for the command, including global options.
         /// </summary>
-        public IEnumerable<Option> Options =>
-            Children.OfType<Option>()
-                    .Concat(Parents
-                            .OfType<Command>()
-                            .SelectMany(c => c.GlobalOptions));
+        public IReadOnlyList<Option> Options => Children.Options;
+
         /// <summary>
         /// Represents all of the global options for the command
         /// </summary>
-        public IEnumerable<Option> GlobalOptions => _globalOptions.OfType<Option>();
+        public IReadOnlyList<Option> GlobalOptions => _globalOptions.Options;
 
         /// <summary>
         /// Adds an <see cref="Argument"/> to the command.
@@ -92,7 +88,7 @@ namespace System.CommandLine
         /// <returns><c>true</c> if the option was added;<c>false</c> if it was already in use.</returns>
         /// <remarks>Global options are applied to the command and recursively to subcommands. They do not apply to
         /// parent commands.</remarks>
-        public bool TryAddGlobalOption(Option option)
+        internal bool TryAddGlobalOption(Option option)
         {
             if (!_globalOptions.IsAnyAliasInUse(option, out _))
             {
@@ -180,10 +176,10 @@ namespace System.CommandLine
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <inheritdoc />
-        IEnumerable<IArgument> ICommand.Arguments => Arguments;
+        IReadOnlyList<IArgument> ICommand.Arguments => Arguments;
 
         /// <inheritdoc />
-        IEnumerable<IOption> ICommand.Options => Options;
+        IReadOnlyList<IOption> ICommand.Options => Options;
 
         internal Parser? ImplicitParser { get; set; }
     }

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -123,16 +123,17 @@ namespace System.CommandLine
 
         private void AddGlobalOptionsToChildren(Command parentCommand)
         {
-            foreach (var child in parentCommand.Children.FlattenBreadthFirst(c => c.Children))
+            for (var childIndex = 0; childIndex < parentCommand.Children.Count; childIndex++)
             {
+                var child = parentCommand.Children[childIndex];
+
                 if (child is Command childCommand)
                 {
-                    foreach (var globalOption in parentCommand.GlobalOptions)
+                    var globalOptions = parentCommand.GlobalOptions;
+
+                    for (var globalOptionIndex = 0; globalOptionIndex < globalOptions.Count; globalOptionIndex++)
                     {
-                        if (!childCommand.Children.IsAnyAliasInUse(globalOption, out _))
-                        {
-                            childCommand.AddOption(globalOption);
-                        }
+                        childCommand.TryAddGlobalOption(globalOptions[globalOptionIndex]);
                     }
 
                     AddGlobalOptionsToChildren(childCommand);

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -22,8 +22,6 @@ namespace System.CommandLine
         /// Initializes a new instance of the CommandLineConfiguration class.
         /// </summary>
         /// <param name="symbols">The symbols to parse.</param>
-        /// <param name="argumentDelimiters">The characters used to delimit an option from its argument. In addition to
-        /// one or more spaces, the default delimiters include <c>:</c> and <c>=</c>.</param>
         /// <param name="enablePosixBundling"><c>true</c> to enable POSIX bundling; otherwise, <c>false</c>.</param>
         /// <param name="enableDirectives"><c>true</c> to enable directive parsing; otherwise, <c>false</c>.</param>
         /// <param name="validationMessages">Provide custom validation messages.</param>
@@ -34,7 +32,6 @@ namespace System.CommandLine
         /// <exception cref="ArgumentException">Thrown when <paramref name="symbols"/> does not contain at least one option or command.</exception>
         public CommandLineConfiguration(
             IReadOnlyList<Symbol> symbols,
-            IReadOnlyList<char>? argumentDelimiters = null,
             bool enablePosixBundling = true,
             bool enableDirectives = true,
             ValidationMessages? validationMessages = null,
@@ -51,20 +48,7 @@ namespace System.CommandLine
             {
                 throw new ArgumentException("You must specify at least one option or command.");
             }
-
-            if (argumentDelimiters is null)
-            {
-                ArgumentDelimiters = new []
-                {
-                    ':',
-                    '='
-                };
-            }
-            else
-            {
-                ArgumentDelimiters = argumentDelimiters.Distinct().ToArray();
-            }
-
+          
             if (symbols.Count == 1 &&
                 symbols[0] is Command rootCommand)
             {
@@ -72,24 +56,6 @@ namespace System.CommandLine
             }
             else
             {
-                for (var symbolIndex = 0; symbolIndex < symbols.Count; symbolIndex++)
-                {
-                    var symbol = symbols[symbolIndex];
-                    if (symbol is IIdentifierSymbol identifier)
-                    {
-                        foreach (var alias in identifier.Aliases)
-                        {
-                            for (var delimiterIndex = 0; delimiterIndex < ArgumentDelimiters.Count; delimiterIndex++)
-                            {
-                                var delimiter = ArgumentDelimiters[delimiterIndex];
-                                if (alias.Contains(delimiter))
-                                {
-                                    throw new ArgumentException($"{symbol.GetType().Name} \"{alias}\" is not allowed to contain a delimiter but it contains \"{delimiter}\"");
-                                }
-                            }
-                        }
-                    }
-                }
                 // Reuse existing auto-generated root command, if one is present, to prevent repeated mutations
                 RootCommand? parentRootCommand = 
                     symbols.SelectMany(s => s.Parents)
@@ -145,11 +111,6 @@ namespace System.CommandLine
         /// Represents all of the symbols to parse.
         /// </summary>
         public ISymbolSet Symbols => _symbols;
-
-        /// <summary>
-        /// Represents all of the argument delimiters.
-        /// </summary>
-        public IReadOnlyList<char> ArgumentDelimiters { get; }
 
         /// <summary>
         /// Gets whether directives are enabled.

--- a/src/System.CommandLine/EnumerableExtensions.cs
+++ b/src/System.CommandLine/EnumerableExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.CommandLine.Collections;
 
 namespace System.CommandLine
 {
@@ -57,16 +58,11 @@ namespace System.CommandLine
         /// <param name="source">The <see cref="IEnumerable"/> whose elements to filter.</param>
         /// <returns><see langword="true" /> if the source sequence contains any elements of type <typeparamref name="T"/>; otherwise, <see langword="false" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static bool HasAnyOfType<T>(this IEnumerable source)
+        public static bool HasAnyOfType<T>(this ISymbolSet source)
         {
-            if (source is null)
+            for (var i = 0; i < source.Count; i++)
             {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            foreach (var obj in source)
-            {
-                if (obj is T)
+                if (source[i] is T)
                 {
                     return true;
                 }
@@ -83,23 +79,18 @@ namespace System.CommandLine
         /// <returnsThe first <typeparamref name="T"/> element of <paramref name="source"/>, if one exists; otherwise,the default value of <typeparamref name="T"/> <see cref="default{t}"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
 #nullable disable
-// requires C# 9.0
-        public static T FirstOrDefaultOfType<T>(this IEnumerable source)
+        // requires C# 9.0
+        public static T FirstOrDefaultOfType<T>(this ISymbolSet source)
         {
-            if (source is null)
+            for (var i = 0; i < source.Count; i++)
             {
-                throw new ArgumentNullException(nameof(source));
-            }
-
-            foreach (var obj in source)
-            {
-                if (obj is T result)
+                if (source[i] is T result)
                 {
                     return result;
                 }
             }
 
-            return default(T);
+            return default;
         }
 #nullable restore
     }

--- a/src/System.CommandLine/EnumerableExtensions.cs
+++ b/src/System.CommandLine/EnumerableExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.CommandLine.Collections;
 
 namespace System.CommandLine
 {
@@ -50,48 +49,5 @@ namespace System.CommandLine
                 yield return source;
             }
         }
-
-        /// <summary>
-        /// Determines whether any element of <paramref name="source"/> is of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <typeparam name="T">The type to filter the elements of the <paramref name="source"/> on.</typeparam>
-        /// <param name="source">The <see cref="IEnumerable"/> whose elements to filter.</param>
-        /// <returns><see langword="true" /> if the source sequence contains any elements of type <typeparamref name="T"/>; otherwise, <see langword="false" />.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static bool HasAnyOfType<T>(this ISymbolSet source)
-        {
-            for (var i = 0; i < source.Count; i++)
-            {
-                if (source[i] is T)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Returns the first <typeparamref name="T"/> element of <paramref name="source"/>, or a default value if no element is found.
-        /// </summary>
-        /// <typeparam name="T">The type to filter the elements of the <paramref name="source"/> on.</typeparam>
-        /// <param name="source">The <see cref="IEnumerable"/> whose elements to filter.</param>
-        /// <returnsThe first <typeparamref name="T"/> element of <paramref name="source"/>, if one exists; otherwise,the default value of <typeparamref name="T"/> <see cref="default{t}"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-#nullable disable
-        // requires C# 9.0
-        public static T FirstOrDefaultOfType<T>(this ISymbolSet source)
-        {
-            for (var i = 0; i < source.Count; i++)
-            {
-                if (source[i] is T result)
-                {
-                    return result;
-                }
-            }
-
-            return default;
-        }
-#nullable restore
     }
 }

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -455,7 +455,7 @@ namespace System.CommandLine.Help
             }
             finally
             {
-                StringBuilderPool.Default.Return(lineBuilder);
+                StringBuilderPool.Default.ReturnToPool(lineBuilder);
             }
 
             void appendLine()
@@ -726,7 +726,7 @@ namespace System.CommandLine.Help
             }
             finally
             {
-                StringBuilderPool.Default.Return(sb);
+                StringBuilderPool.Default.ReturnToPool(sb);
             }
 
             bool IsMultiParented(IArgument argument) =>

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -496,20 +496,23 @@ namespace System.CommandLine.Help
         /// <returns>A new <see cref="HelpItem"/></returns>
         private IEnumerable<HelpItem> GetArgumentHelpItems(ISymbol symbol)
         {
-            foreach (var argument in symbol.Arguments())
+            var arguments = symbol.Arguments();
+
+            for (var i = 0; i < arguments.Count; i++)
             {
+                var argument = arguments[i];
                 if (ShouldShowHelp(argument))
                 {
                     var argumentDescriptor = ArgumentDescriptor(argument);
 
                     var invocation = string.IsNullOrWhiteSpace(argumentDescriptor)
-                                        ? ""
-                                        : $"<{argumentDescriptor}>";
+                                         ? ""
+                                         : $"<{argumentDescriptor}>";
 
                     var argumentDescription = argument?.Description ?? "";
                     var defaultValueHint = argument != null
-                        ? BuildDefaultValueHint(argument)
-                        : null;
+                                               ? BuildDefaultValueHint(argument)
+                                               : null;
                     yield return new HelpItem(invocation, argumentDescription, defaultValueHint);
                 }
             }
@@ -640,20 +643,18 @@ namespace System.CommandLine.Help
 
                 if (subcommand != command)
                 {
-                    usage.Add(FormatArgumentUsage(subcommand.Arguments.ToArray()));
+                    usage.Add(FormatArgumentUsage(subcommand.Arguments));
                 }
             }
 
-            var hasOptionHelp = command.Children
-                .OfType<IOption>()
-                .Any(ShouldShowHelp);
+            var hasOptionHelp = command.Options.Any(ShouldShowHelp);
 
             if (hasOptionHelp)
             {
                 usage.Add(Usage.Options);
             }
 
-            usage.Add(FormatArgumentUsage(command.Arguments.ToArray()));
+            usage.Add(FormatArgumentUsage(command.Arguments));
 
             var hasCommandHelp = command.Children
                 .OfType<ICommand>()
@@ -672,7 +673,7 @@ namespace System.CommandLine.Help
             HelpSection.WriteHeading(this, Usage.Title, string.Join(" ", usage.Where(u => !string.IsNullOrWhiteSpace(u))));
         }
 
-        private string FormatArgumentUsage(IReadOnlyCollection<IArgument> arguments)
+        private string FormatArgumentUsage(IReadOnlyList<IArgument> arguments)
         {
             var sb = StringBuilderPool.Default.Rent();
 
@@ -680,8 +681,9 @@ namespace System.CommandLine.Help
             {
                 var end = default(Stack<char>);
 
-                foreach (var argument in arguments)
+                for (var i = 0; i < arguments.Count; i++)
                 {
+                    var argument = arguments[i];
                     if (!ShouldShowHelp(argument))
                     {
                         continue;
@@ -711,7 +713,7 @@ namespace System.CommandLine.Help
                 {
                     sb.Length--;
 
-                    if (end is Stack<char>)
+                    if (end is { })
                     {
                         while (end.Count > 0)
                         {
@@ -748,12 +750,12 @@ namespace System.CommandLine.Help
                 cmd.Parents.FirstOrDefault() is ICommand parent &&
                 ShouldDisplayArgumentHelp(parent))
             {
-                addHelpItems(helpItems, parent);
+                AddHelpItemsFor(parent);
             }
 
             if (ShouldDisplayArgumentHelp(command))
             {
-                addHelpItems(helpItems, command);
+                AddHelpItemsFor(command);
             }
 
             HelpSection.WriteItems(
@@ -761,7 +763,7 @@ namespace System.CommandLine.Help
                 Arguments.Title,
                 helpItems);
 
-            void addHelpItems(HashSet<HelpItem> helpItems, ICommand command)
+            void AddHelpItemsFor(ICommand command)
             {
                 foreach (var helpItem in GetArgumentHelpItems(command))
                 {
@@ -778,8 +780,7 @@ namespace System.CommandLine.Help
         protected virtual void AddOptions(ICommand command)
         {
             var options = command
-                          .Children
-                          .OfType<IOption>()
+                          .Options
                           .Where(ShouldShowHelp)
                           .ToArray();
 

--- a/src/System.CommandLine/ICommand.cs
+++ b/src/System.CommandLine/ICommand.cs
@@ -9,8 +9,8 @@ namespace System.CommandLine
     {
         bool TreatUnmatchedTokensAsErrors { get; }
 
-        IEnumerable<IArgument> Arguments { get; }
-        
-        IEnumerable<IOption> Options { get; }
+        IReadOnlyList<IArgument> Arguments { get; }
+
+        IReadOnlyList<IOption> Options { get; }
     }
 }

--- a/src/System.CommandLine/IdentifierSymbol.cs
+++ b/src/System.CommandLine/IdentifierSymbol.cs
@@ -33,7 +33,10 @@ namespace System.CommandLine
                     throw new ArgumentException("Value cannot be null or whitespace.", nameof(value));
                 }
 
-                RemoveAlias(_specifiedName);
+                if (_specifiedName is { })
+                {
+                    RemoveAlias(_specifiedName);
+                }
 
                 _specifiedName = value;
 
@@ -48,12 +51,9 @@ namespace System.CommandLine
             OnNameOrAliasChanged?.Invoke(this);
         }
 
-        private protected virtual void RemoveAlias(string? alias)
+        private protected virtual void RemoveAlias(string alias)
         {
-            if (alias != null)
-            {
-                _aliases.Remove(alias);
-            }
+            _aliases.Remove(alias);
         }
 
         public virtual bool HasAlias(string alias) => _aliases.Contains(alias);

--- a/src/System.CommandLine/Invocation/Process.cs
+++ b/src/System.CommandLine/Invocation/Process.cs
@@ -66,8 +66,9 @@ namespace System.CommandLine.Invocation
 
             if (environmentVariables?.Length > 0)
             {
-                foreach (var tuple in environmentVariables)
+                for (var i = 0; i < environmentVariables.Length; i++)
                 {
+                    var tuple = environmentVariables[i];
                     process.StartInfo.Environment.Add(tuple.key, tuple.value);
                 }
             }

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -24,8 +24,9 @@ namespace System.CommandLine.Invocation
 
         public void ProvideSuggestions(ParseResult result, IConsole console)
         {
-            foreach (var token in result.UnmatchedTokens)
+            for (var i = 0; i < result.UnmatchedTokens.Count; i++)
             {
+                var token = result.UnmatchedTokens[i];
                 string suggestions = string.Join(", or ", GetPossibleTokens(result.CommandResult.Command, token).Select(x => $"'{x}'"));
 
                 if (suggestions.Length > 0)

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -89,9 +89,9 @@ namespace System.CommandLine
 
         public bool HasAliasIgnorePrefix(string alias) => _unprefixedAliases.Contains(alias.RemovePrefix());
 
-        private protected override void RemoveAlias(string? alias)
+        private protected override void RemoveAlias(string alias)
         {
-            _unprefixedAliases.Remove(alias!);
+            _unprefixedAliases.Remove(alias);
 
             base.RemoveAlias(alias);
         }

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -44,6 +44,7 @@ namespace System.CommandLine
             get => Arguments.FirstOrDefault() ?? Argument.None;
             set
             {
+                // FIX: (Argument) 
                 foreach (var argument in Arguments.ToArray())
                 {
                     Children.Remove(argument);

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -41,20 +41,19 @@ namespace System.CommandLine
 
         public virtual Argument Argument
         {
-            get => Arguments.FirstOrDefault() ?? Argument.None;
+            get => Children.Arguments.Count > 0
+                       ? Children.Arguments[0]
+                       : Argument.None;
             set
             {
-                // FIX: (Argument) 
-                foreach (var argument in Arguments.ToArray())
+                for (var i = 0; i < Children.Arguments.Count; i++)
                 {
-                    Children.Remove(argument);
+                    Children.Remove(Children.Arguments[i]);
                 }
 
                 AddArgumentInner(value);
             }
         }
-
-        private IEnumerable<Argument> Arguments => Children.OfType<Argument>();
 
         public override string Name
         {

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -1,15 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.CommandLine.Binding;
-using System.Linq;
-
 namespace System.CommandLine.Parsing
 {
     public class CommandResult : SymbolResult
     {
-        private ArgumentConversionResultSet? _results;
-
         internal CommandResult(
             ICommand command,
             Token token,
@@ -25,28 +20,6 @@ namespace System.CommandLine.Parsing
         public ICommand Command { get; }
 
         public Token Token { get; }
-
-        internal ArgumentConversionResultSet ArgumentConversionResults
-        {
-            get
-            {
-                if (_results is null)
-                {
-                    var results = Children
-                                  .OfType<ArgumentResult>()
-                                  .Select(r => r.GetArgumentConversionResult());
-
-                    _results = new ArgumentConversionResultSet();
-
-                    foreach (var result in results)
-                    {
-                        _results.Add(result);
-                    }
-                }
-
-                return _results;
-            }
-        }
 
         internal override bool UseDefaultValueFor(IArgument argument) =>
             Children.ResultFor(argument) switch

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -11,9 +11,11 @@ namespace System.CommandLine.Parsing
             IValueDescriptor valueDescriptor,
             out object? value)
         {
-            for (var i = 0; i < commandResult.Command.Arguments.Count; i++)
+            var arguments = commandResult.Command.Arguments;
+
+            for (var i = 0; i < arguments.Count; i++)
             {
-                var argument = commandResult.Command.Arguments[i];
+                var argument = arguments[i];
 
                 if (valueDescriptor.ValueName.IsMatch(argument.Name))
                 {
@@ -31,9 +33,11 @@ namespace System.CommandLine.Parsing
             IValueDescriptor valueDescriptor,
             out object? value)
         {
-            for (var i = 0; i < commandResult.Command.Options.Count; i++)
+            var options = commandResult.Command.Options;
+
+            for (var i = 0; i < options.Count; i++)
             {
-                var option = commandResult.Command.Options[i];
+                var option = options[i];
 
                 if (valueDescriptor.ValueName.IsMatch(option))
                 {

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Binding;
-using System.Linq;
 
 namespace System.CommandLine.Parsing
 {
@@ -141,9 +140,17 @@ namespace System.CommandLine.Parsing
                 return null;
             }
 
-            var argument = commandNode.Command
-                                      .Arguments
-                                      .FirstOrDefault(a => !IsFull(a));
+            IArgument? argument = default;
+
+            for (var i = 0; i < commandNode.Command.Arguments.Count; i++)
+            {
+                if (commandNode.Command.Arguments[i] is {} arg &&
+                    !IsFull(arg))
+                {
+                    argument = arg;
+                    break;
+                }
+            }
 
             if (argument is null)
             {

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -90,22 +90,18 @@ namespace System.CommandLine.Parsing
                 return null;
             }
 
-            var command = parentNode.Command
-                                    .Children
-                                    .GetByAlias(CurrentToken.Value) as ICommand;
-
-            if (command is null)
+            if (parentNode.Command.Children.GetByAlias(CurrentToken.Value) is ICommand command)
             {
-                return null;
+                var commandNode = new CommandNode(CurrentToken, command, parentNode);
+
+                Advance();
+
+                ParseCommandChildren(commandNode);
+
+                return commandNode;
             }
 
-            var commandNode = new CommandNode(CurrentToken, command, parentNode);
-
-            Advance();
-
-            ParseCommandChildren(commandNode);
-
-            return commandNode;
+            return null;
         }
 
         private void ParseCommandChildren(CommandNode parent)
@@ -286,10 +282,6 @@ namespace System.CommandLine.Parsing
                 else if (foundEndOfArguments)
                 {
                     UnparsedTokens.Add(CurrentToken);
-                }
-                else
-                {
-                    UnmatchedTokens.Add(CurrentToken);
                 }
 
                 Advance();

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -79,9 +79,9 @@ namespace System.CommandLine.Parsing
 
         internal string? RawInput { get; }
 
-        public IReadOnlyCollection<string> UnmatchedTokens => _unmatchedTokens.Select(t => t.Value).ToArray();
+        public IReadOnlyList<string> UnmatchedTokens => _unmatchedTokens.Select(t => t.Value).ToArray();
 
-        public IReadOnlyCollection<string> UnparsedTokens => _unparsedTokens.Select(t => t.Value).ToArray();
+        public IReadOnlyList<string> UnparsedTokens => _unparsedTokens.Select(t => t.Value).ToArray();
 
         public object? ValueForOption(string alias) =>
             ValueForOption<object?>(alias);

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -99,7 +99,7 @@ namespace System.CommandLine.Parsing
             }
             finally
             {
-                StringBuilderPool.Default.Return(builder);
+                StringBuilderPool.Default.ReturnToPool(builder);
             }
         }
 

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -123,7 +123,7 @@ namespace System.CommandLine.Parsing
                 var includeArgumentName =
                     argumentResult.Argument is Argument argument &&
                     argument.Parents[0] is ICommand command &&
-                    command.Arguments.Count() > 1;
+                    command.Arguments.Count > 1;
 
                 if (includeArgumentName)
                 {

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -56,8 +56,8 @@ namespace System.CommandLine.Parsing
 
             if (string.IsNullOrWhiteSpace(rawInput))
             {
-                if ((source.UnmatchedTokens.Count > 0) ||
-                    (lastToken?.Type == TokenType.Argument))
+                if (source.UnmatchedTokens.Count > 0 ||
+                    lastToken?.Type == TokenType.Argument)
                 {
                     return textToMatch ?? "";
                 }

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -87,8 +87,9 @@ namespace System.CommandLine.Parsing
                 {
                     builder.Append("   ???-->");
 
-                    foreach (var error in result.UnmatchedTokens)
+                    for (var i = 0; i < result.UnmatchedTokens.Count; i++)
                     {
+                        var error = result.UnmatchedTokens[i];
                         builder.Append(" ");
                         builder.Append(error);
                     }
@@ -178,8 +179,9 @@ namespace System.CommandLine.Parsing
                 builder.Append("[ ");
                 builder.Append(symbolResult.Token().Value);
 
-                foreach (var child in symbolResult.Children)
+                for (var i = 0; i < symbolResult.Children.Count; i++)
                 {
+                    var child = symbolResult.Children[i];
                     builder.Append(" ");
                     builder.Diagram(child, parseResult);
                 }

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -162,14 +162,12 @@ namespace System.CommandLine.Parsing
 
         protected override void Stop(SyntaxNode node)
         {
-            var helpWasRequested =
-                _innermostCommandResult
-                    ?.Children
-                    .Any(o => o.Symbol is HelpOption) == true;
-
-            if (helpWasRequested)
+            for (var i = 0; i < _innermostCommandResult!.Children.Count; i++)
             {
-                return;
+                if (_innermostCommandResult!.Children[i].Symbol is HelpOption)
+                {
+                    return;
+                }
             }
 
             ValidateCommandHandler();
@@ -189,9 +187,9 @@ namespace System.CommandLine.Parsing
 
             if (argumentResults.Count > 0)
             {
-                var arguments = _innermostCommandResult!.Command.Arguments.ToArray();
+                var arguments = _innermostCommandResult!.Command.Arguments;
 
-                for (var i = 0; i < arguments.Length; i++)
+                for (var i = 0; i < arguments.Count; i++)
                 {
                     if (argumentResults.Count == i)
                     {
@@ -203,13 +201,14 @@ namespace System.CommandLine.Parsing
                         var previousArgumentResult = argumentResults[i - 1];
 
                         var passedOnTokens = _innermostCommandResult.Tokens.Skip(previousArgumentResult.Tokens.Count);
-                        
+
                         foreach (var token in passedOnTokens)
                         {
                             if (nextArgumentResult.IsArgumentLimitReached)
                             {
                                 break;
                             }
+
                             nextArgumentResult.AddToken(token);
                         }
 
@@ -224,10 +223,10 @@ namespace System.CommandLine.Parsing
 
                     ValidateAndConvertArgumentResult(argumentResult);
 
-                    if (argumentResult.PassedOnTokens is {} && 
-                        i == arguments.Length - 1)
+                    if (argumentResult.PassedOnTokens is {} &&
+                        i == arguments.Count - 1)
                     {
-                       _unparsedTokens.AddRange(argumentResult.PassedOnTokens.Select(t => t.Value));
+                        _unparsedTokens.AddRange(argumentResult.PassedOnTokens.Select(t => t.Value));
                     }
                 }
             }

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -15,8 +15,8 @@ namespace System.CommandLine.Parsing
         private readonly string? _rawInput;
 
         private readonly DirectiveCollection _directives = new DirectiveCollection();
-        private readonly List<string> _unparsedTokens;
-        private readonly List<string> _unmatchedTokens;
+        private readonly List<Token> _unparsedTokens;
+        private readonly List<Token> _unmatchedTokens;
         private readonly List<ParseError> _errors;
 
         private RootCommandResult? _rootCommandResult;
@@ -25,34 +25,16 @@ namespace System.CommandLine.Parsing
         public ParseResultVisitor(
             Parser parser,
             TokenizeResult tokenizeResult,
-            IReadOnlyCollection<Token> unparsedTokens,
-            IReadOnlyCollection<Token> unmatchedTokens,
+            List<Token> unparsedTokens,
+            List<Token> unmatchedTokens,
             IReadOnlyCollection<ParseError> parseErrors,
             string? rawInput)
         {
             _parser = parser;
             _tokenizeResult = tokenizeResult;
+            _unparsedTokens = unparsedTokens;
+            _unmatchedTokens = unmatchedTokens;
             _rawInput = rawInput;
-
-            var unparsedTokensCount = unparsedTokens?.Count ?? 0;
-            _unparsedTokens = unparsedTokensCount == 0 ? new List<string>() : new List<string>(unparsedTokensCount);
-            if (unparsedTokensCount > 0)
-            {
-                foreach (var unparsedToken in unparsedTokens!)
-                {
-                    _unparsedTokens.Add(unparsedToken.Value);
-                }
-            }
-
-            var unmatchedTokensCount = unmatchedTokens?.Count ?? 0;
-            _unmatchedTokens = unmatchedTokensCount == 0 ? new List<string>() : new List<string>(unmatchedTokensCount);
-            if (unmatchedTokensCount > 0)
-            {
-                foreach (var unmatchedToken in unmatchedTokens!)
-                {
-                    _unmatchedTokens.Add(unmatchedToken.Value);
-                }
-            }
 
             _errors = new List<ParseError>(_tokenizeResult.Errors.Count + parseErrors.Count);
 
@@ -157,7 +139,7 @@ namespace System.CommandLine.Parsing
 
         protected override void VisitUnknownNode(SyntaxNode node)
         {
-            _unmatchedTokens.Add(node.Token.Value);
+            _unmatchedTokens.Add(node.Token);
         }
 
         protected override void Stop(SyntaxNode node)
@@ -226,7 +208,7 @@ namespace System.CommandLine.Parsing
                     if (argumentResult.PassedOnTokens is {} &&
                         i == arguments.Count - 1)
                     {
-                        _unparsedTokens.AddRange(argumentResult.PassedOnTokens.Select(t => t.Value));
+                        _unparsedTokens.AddRange(argumentResult.PassedOnTokens);
                     }
                 }
             }
@@ -375,13 +357,13 @@ namespace System.CommandLine.Parsing
 
         private void PopulateDefaultValues()
         {
-            var commandResults = _innermostCommandResult!
-                .RecurseWhileNotNull(c => c.Parent as CommandResult);
+            CommandResult? commandResult = _innermostCommandResult;
 
-            foreach (var commandResult in commandResults)
+            while (commandResult != null)
             {
-                foreach (var symbol in commandResult.Command.Children)
+                for (var symbolIndex = 0; symbolIndex < commandResult.Command.Children.Count; symbolIndex++)
                 {
+                    var symbol = commandResult.Command.Children[symbolIndex];
                     var symbolResult = _rootCommandResult!.FindResultForSymbol(symbol);
 
                     if (symbolResult is null)
@@ -425,6 +407,8 @@ namespace System.CommandLine.Parsing
                                 o));
                     }
                 }
+
+                commandResult = commandResult.Parent as CommandResult;
             }
         }
 
@@ -436,7 +420,7 @@ namespace System.CommandLine.Parsing
                 _directives,
                 _tokenizeResult,
                 _unparsedTokens,
-                _unmatchedTokens,
+                _unmatchedTokens.ToArray(),
                 _errors,
                 _rawInput);
     }

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -38,8 +38,9 @@ namespace System.CommandLine.Parsing
 
             _errors = new List<ParseError>(_tokenizeResult.Errors.Count + parseErrors.Count);
 
-            foreach(var error in _tokenizeResult.Errors)
+            for (var i = 0; i < _tokenizeResult.Errors.Count; i++)
             {
+                var error = _tokenizeResult.Errors[i];
                 _errors.Add(new ParseError(error.Message));
             }
 
@@ -182,10 +183,12 @@ namespace System.CommandLine.Parsing
 
                         var previousArgumentResult = argumentResults[i - 1];
 
-                        var passedOnTokens = _innermostCommandResult.Tokens.Skip(previousArgumentResult.Tokens.Count);
+                        var passedOnTokensCount = _innermostCommandResult.Tokens.Count;
 
-                        foreach (var token in passedOnTokens)
+                        for (var j = previousArgumentResult.Tokens.Count; j < passedOnTokensCount; j++)
                         {
+                            var token = _innermostCommandResult.Tokens[j];
+
                             if (nextArgumentResult.IsArgumentLimitReached)
                             {
                                 break;

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -249,12 +249,16 @@ namespace System.CommandLine.Parsing
                 }
             }
 
-            foreach (var option in _innermostCommandResult
-                                   .Command
-                                   .Options)
+            var options = _innermostCommandResult.Command.Options;
+
+            for (var i = 0;
+                i < options.Count;
+                i++)
             {
+                var option = options[i];
+
                 if (option is Option o &&
-                    o.IsRequired && 
+                    o.IsRequired &&
                     _rootCommandResult!.FindResultFor(o) is null)
                 {
                     _errors.Add(
@@ -263,10 +267,14 @@ namespace System.CommandLine.Parsing
                 }
             }
 
-            foreach (var symbol in _innermostCommandResult
-                                   .Command
-                                   .Arguments)
+            var arguments = _innermostCommandResult.Command.Arguments;
+
+            for (var i = 0;
+                i < arguments.Count;
+                i++)
             {
+                var symbol = arguments[i];
+
                 var arityFailure = ArgumentArity.Validate(
                     _innermostCommandResult,
                     symbol,

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -192,9 +192,8 @@ namespace System.CommandLine.Parsing
             {
                 replacement = null;
 
-                if (tokenList.Count == 0)
+                if (arg.Length > 0 && arg[0] != '-')
                 {
-                    replacement = null;
                     return false;
                 }
 

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -33,7 +33,7 @@ namespace System.CommandLine.Parsing
             for (var i = 0; i < _optionPrefixStrings.Length; i++)
             {
                 var prefix = _optionPrefixStrings[i];
-                if (rawAlias.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                if (rawAlias.StartsWith(prefix, StringComparison.Ordinal))
                 {
                     return rawAlias.Substring(prefix.Length);
                 }
@@ -47,7 +47,7 @@ namespace System.CommandLine.Parsing
             for (var i = 0; i < _optionPrefixStrings.Length; i++)
             {
                 var prefix = _optionPrefixStrings[i];
-                if (rawAlias.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                if (rawAlias.StartsWith(prefix, StringComparison.Ordinal))
                 {
                     return (prefix, rawAlias.Substring(prefix.Length));
                 }
@@ -89,8 +89,8 @@ namespace System.CommandLine.Parsing
 
                 if (!foundEndOfDirectives)
                 {
-                    if (arg.StartsWith("[", StringComparison.OrdinalIgnoreCase) &&
-                        arg.EndsWith("]", StringComparison.OrdinalIgnoreCase) &&
+                    if (arg.StartsWith("[", StringComparison.Ordinal) &&
+                        arg.EndsWith("]", StringComparison.Ordinal) &&
                         arg[1] != ']' &&
                         arg[1] != ':')
                     {
@@ -112,7 +112,7 @@ namespace System.CommandLine.Parsing
                 }
 
                 if (configuration.EnablePosixBundling &&
-                    CanBeUnbundled(arg, out IReadOnlyCollection<string>? replacement))
+                    CanBeUnbundled(arg, out var replacement))
                 {
                     argList.InsertRange(i + 1, replacement);
                     argList.RemoveAt(i);
@@ -186,7 +186,7 @@ namespace System.CommandLine.Parsing
 
             return new TokenizeResult(tokenList, errorList);
 
-            bool CanBeUnbundled(string arg, out IReadOnlyCollection<string>? replacement)
+            bool CanBeUnbundled(string arg, out IReadOnlyList<string>? replacement)
             {
                 replacement = null;
 
@@ -240,7 +240,7 @@ namespace System.CommandLine.Parsing
                     }
                 }
 
-                bool TryUnbundle(out IReadOnlyCollection<string>? replacement)
+                bool TryUnbundle(out IReadOnlyList<string>? replacement)
                 {
                     if (alias == string.Empty)
                     {

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -6,7 +6,6 @@ using System.CommandLine.Collections;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace System.CommandLine.Parsing
 {
@@ -41,7 +40,6 @@ namespace System.CommandLine.Parsing
 
             return rawAlias;
         }
-
 
         internal static (string? prefix, string alias) SplitPrefix(this string rawAlias)
         {
@@ -309,14 +307,6 @@ namespace System.CommandLine.Parsing
 
             void ReadResponseFile(string filePath, int i)
             {
-                if (string.IsNullOrWhiteSpace(filePath))
-                {
-                    errorList.Add(
-                        new TokenizeError(
-                            $"Invalid response file token: {filePath}"));
-                    return;
-                }
-
                 try
                 {
                     var next = i + 1;

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine.Parsing
             CultureInfo.InvariantCulture
                        .CompareInfo
                        .IndexOf(source,
-                                value ?? "",
+                                value,
                                 CompareOptions.OrdinalIgnoreCase);
 
         internal static string RemovePrefix(this string rawAlias)
@@ -33,7 +33,7 @@ namespace System.CommandLine.Parsing
             for (var i = 0; i < _optionPrefixStrings.Length; i++)
             {
                 var prefix = _optionPrefixStrings[i];
-                if (rawAlias.StartsWith(prefix))
+                if (rawAlias.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 {
                     return rawAlias.Substring(prefix.Length);
                 }
@@ -47,7 +47,7 @@ namespace System.CommandLine.Parsing
             for (var i = 0; i < _optionPrefixStrings.Length; i++)
             {
                 var prefix = _optionPrefixStrings[i];
-                if (rawAlias.StartsWith(prefix))
+                if (rawAlias.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 {
                     return (prefix, rawAlias.Substring(prefix.Length));
                 }
@@ -89,8 +89,8 @@ namespace System.CommandLine.Parsing
 
                 if (!foundEndOfDirectives)
                 {
-                    if (arg.StartsWith("[") &&
-                        arg.EndsWith("]") &&
+                    if (arg.StartsWith("[", StringComparison.OrdinalIgnoreCase) &&
+                        arg.EndsWith("]", StringComparison.OrdinalIgnoreCase) &&
                         arg[1] != ']' &&
                         arg[1] != ':')
                     {
@@ -104,8 +104,8 @@ namespace System.CommandLine.Parsing
                     }
                 }
 
-                if (configuration.ResponseFileHandling != ResponseFileHandling.Disabled &&
-                    arg.GetResponseFileReference() is { } filePath)
+                if (arg.GetResponseFileReference() is { } filePath &&
+                    configuration.ResponseFileHandling != ResponseFileHandling.Disabled)
                 {
                     ReadResponseFile(filePath, i);
                     continue;
@@ -407,7 +407,7 @@ namespace System.CommandLine.Parsing
         }
 
         private static string? GetResponseFileReference(this string arg) =>
-            arg.StartsWith("@") && arg.Length > 1
+            arg.Length > 1 && arg[0] == '@'
                 ? arg.Substring(1)
                 : null;
 
@@ -421,16 +421,7 @@ namespace System.CommandLine.Parsing
             if (i >= 0)
             {
                 first = arg.Substring(0, i);
-
-                if (arg.Length > i)
-                {
-                    rest = arg.Substring(i + 1, arg.Length - 1 - i);
-                }
-                else
-                {
-                    rest = null;
-                }
-
+                rest = arg.Substring(i + 1, arg.Length - 1 - i);
                 return true;
             }
 
@@ -524,7 +515,7 @@ namespace System.CommandLine.Parsing
             {
                 var arg = line.Trim();
 
-                if (arg.Length == 0 || arg.StartsWith("#"))
+                if (arg.Length == 0 || arg[0] == '#')
                 {
                     yield break;
                 }

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace System.CommandLine.Parsing
 {
@@ -11,7 +10,6 @@ namespace System.CommandLine.Parsing
         private protected readonly List<Token> _tokens = new List<Token>();
         private ValidationMessages? _validationMessages;
         private readonly Dictionary<IArgument, ArgumentResult> _defaultArgumentValues = new Dictionary<IArgument, ArgumentResult>();
-        private RootCommandResult? _root;
 
         private protected SymbolResult(
             ISymbol symbol, 
@@ -21,7 +19,7 @@ namespace System.CommandLine.Parsing
 
             Parent = parent;
 
-            _root = parent?.Root;
+            Root = parent?.Root;
         }
 
         public string? ErrorMessage { get; set; }
@@ -30,14 +28,7 @@ namespace System.CommandLine.Parsing
 
         public SymbolResult? Parent { get; }
 
-        internal virtual RootCommandResult? Root =>
-            _root ??=
-            Parent switch
-            {
-                CommandResult c => c.Root,
-                OptionResult o => o.Parent?.Root,
-                _ => null
-            };
+        internal virtual RootCommandResult? Root { get; }
 
         public ISymbol Symbol { get; }
 

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -50,29 +50,21 @@ namespace System.CommandLine.Parsing
 
         internal int MaximumArgumentCapacity()
         {
-            var maximumArgumentCapacity = Symbol.Arguments()
-                .Sum(a => a.Arity.MaximumNumberOfValues);
-            return (int) Math.Min(maximumArgumentCapacity, int.MaxValue);
+            var value = 0;
+
+            var arguments = Symbol.Arguments();
+            
+            for (var i = 0; i < arguments.Count; i++)
+            {
+                value += arguments[i].Arity.MaximumNumberOfValues;
+            }
+
+            return value;
         }
 
         protected internal ValidationMessages ValidationMessages
         {
-            get
-            {
-                if (_validationMessages is null)
-                {
-                    if (Parent is null)
-                    {
-                        _validationMessages = ValidationMessages.Instance;
-                    }
-                    else
-                    {
-                        _validationMessages = Parent.ValidationMessages;
-                    }
-                }
-
-                return _validationMessages;
-            }
+            get => _validationMessages ??= Parent?.ValidationMessages ?? ValidationMessages.Instance;
             set => _validationMessages = value;
         }
 

--- a/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
@@ -24,22 +24,6 @@ namespace System.CommandLine.Parsing
                 yield return item;
             }
         }
-        
-        internal static IEnumerable<SymbolResult> AllSymbolResults2(this SymbolResult symbolResult)
-        {
-            var tokenPositions = symbolResult.AllSymbolResults()
-                                                   .Select(r => r switch
-                                                   {
-                                                       CommandResult c => (symbol:r, pos: c.Token.Position),
-                                                       OptionResult o => (symbol: r, pos: o.Token?.Position),
-                                                       ArgumentResult a => (symbol: r, pos: a.Tokens.FirstOrDefault()?.Position ?? -1),
-                                                       _ => (r, -1)
-                                                   })
-                                                   .OrderBy(x => x.pos)
-                                                   .Select(x => x.symbol);
-
-            return tokenPositions;
-        }
 
         internal static Token Token(this SymbolResult symbolResult)
         {

--- a/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
@@ -10,11 +10,6 @@ namespace System.CommandLine.Parsing
     {
         internal static IEnumerable<SymbolResult> AllSymbolResults(this SymbolResult symbolResult)
         {
-            if (symbolResult is null)
-            {
-                throw new ArgumentNullException(nameof(symbolResult));
-            }
-
             yield return symbolResult;
 
             foreach (var item in symbolResult

--- a/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
@@ -24,6 +24,22 @@ namespace System.CommandLine.Parsing
                 yield return item;
             }
         }
+        
+        internal static IEnumerable<SymbolResult> AllSymbolResults2(this SymbolResult symbolResult)
+        {
+            var tokenPositions = symbolResult.AllSymbolResults()
+                                                   .Select(r => r switch
+                                                   {
+                                                       CommandResult c => (symbol:r, pos: c.Token.Position),
+                                                       OptionResult o => (symbol: r, pos: o.Token?.Position),
+                                                       ArgumentResult a => (symbol: r, pos: a.Tokens.FirstOrDefault()?.Position ?? -1),
+                                                       _ => (r, -1)
+                                                   })
+                                                   .OrderBy(x => x.pos)
+                                                   .Select(x => x.symbol);
+
+            return tokenPositions;
+        }
 
         internal static Token Token(this SymbolResult symbolResult)
         {

--- a/src/System.CommandLine/Parsing/TokenizeResult.cs
+++ b/src/System.CommandLine/Parsing/TokenizeResult.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
     {
         internal TokenizeResult(
             IReadOnlyList<Token> tokens,
-            IReadOnlyCollection<TokenizeError> errors)
+            IReadOnlyList<TokenizeError> errors)
         {
             Tokens = tokens ?? Array.Empty<Token>();
             Errors = errors ?? Array.Empty<TokenizeError>();
@@ -17,6 +17,6 @@ namespace System.CommandLine.Parsing
 
         public IReadOnlyList<Token> Tokens { get; }
 
-        public IReadOnlyCollection<TokenizeError> Errors { get; }
+        public IReadOnlyList<TokenizeError> Errors { get; }
     }
 }

--- a/src/System.CommandLine/RootCommand.cs
+++ b/src/System.CommandLine/RootCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace System.CommandLine
@@ -35,7 +34,12 @@ namespace System.CommandLine
             var location = _executablePath.Value;
             if (string.IsNullOrEmpty(location))
             {
-                location = Environment.GetCommandLineArgs().FirstOrDefault();
+                var commandLineArgs = Environment.GetCommandLineArgs();
+
+                if (commandLineArgs.Length > 0)
+                {
+                    location = commandLineArgs[0];
+                }
             }
             return Path.GetFileNameWithoutExtension(location).Replace(" ", "");
         });
@@ -54,9 +58,9 @@ namespace System.CommandLine
         /// </summary>
         public static string ExecutablePath => _executablePath.Value;
 
-        private protected override void RemoveAlias(string? alias)
+        private protected override void RemoveAlias(string alias)
         {
-            if (!string.Equals(alias, ExecutableName, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(alias, ExecutableName, StringComparison.Ordinal))
             {
                 base.RemoveAlias(alias);
             }

--- a/src/System.CommandLine/StringBuilderPool.cs
+++ b/src/System.CommandLine/StringBuilderPool.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Linq;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.CommandLine
 {
@@ -48,8 +48,8 @@ namespace System.CommandLine
         {
             for (var i = _pool.Length; --i >= 0;)
             {
-                if (Interlocked.Exchange(ref _pool[i], null) is WeakReference<StringBuilder> builderReference
-                    && builderReference.TryGetTarget(out var builder))
+                if (Interlocked.Exchange(ref _pool[i], null) is { } builderReference && 
+                    builderReference.TryGetTarget(out var builder))
                 {
                     return builder.Clear();
                 }
@@ -63,7 +63,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="stringBuilder">The <see cref="StringBuilderPool"/> to add to the pool.</param>
         /// <remarks>The <see cref="StringBuilderPool"/> doesn't need to be one returned from <see cref="Rent()"/>.</remarks>
-        public void Return(StringBuilder stringBuilder)
+        public void ReturnToPool(StringBuilder stringBuilder)
         {
             var reference = new WeakReference<StringBuilder>(stringBuilder);
 
@@ -86,24 +86,7 @@ namespace System.CommandLine
         {
             var text = stringBuilder.ToString();
 
-            Return(stringBuilder);
-
-            return text;
-        }
-
-        /// <summary>
-        /// Gets the <see cref="string"/> from a subtring of the <paramref name="stringBuilder"/> and returns it to the pool.
-        /// </summary>
-        /// <param name="stringBuilder">The <see cref="StringBuilderPool"/> to add to the pool.</param>
-        /// <param name="startIndex">The index to start in the <paramref name="stringBuilder"/>.</param>
-        /// <param name="length">The number of characters to read in the <paramref name="stringBuilder"/>.</param>
-        /// <returns>The <see cref="string"/> created from the <paramref name="stringBuilder"/>.</returns>
-        /// <remarks>The <see cref="StringBuilderPool"/> doesn't need to be one returned from <see cref="Rent()"/>.</remarks>
-        public string GetStringAndReturn(StringBuilder stringBuilder, int startIndex, int lengh)
-        {
-            var text = stringBuilder.ToString(startIndex, lengh);
-
-            Return(stringBuilder);
+            ReturnToPool(stringBuilder);
 
             return text;
         }

--- a/src/System.CommandLine/Suggestions/Suggestions.cs
+++ b/src/System.CommandLine/Suggestions/Suggestions.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Parsing;
-using System.Linq;
 
 namespace System.CommandLine.Suggestions
 {
@@ -11,7 +10,16 @@ namespace System.CommandLine.Suggestions
     {
         public static IEnumerable<string?> Containing(
             this IEnumerable<string?> candidates,
-            string textToMatch) =>
-            candidates.Where(c => c?.ContainsCaseInsensitive(textToMatch) == true);
+            string textToMatch)
+        {
+            foreach (var candidate in candidates)
+            {
+                if (candidate is { } && 
+                    candidate.ContainsCaseInsensitive(textToMatch))
+                {
+                    yield return candidate;
+                }
+            }
+        }
     }
 }

--- a/src/System.CommandLine/Suggestions/Suggestions.cs
+++ b/src/System.CommandLine/Suggestions/Suggestions.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Suggestions
     {
         public static IEnumerable<string?> Containing(
             this IEnumerable<string?> candidates,
-            string? textToMatch) =>
+            string textToMatch) =>
             candidates.Where(c => c?.ContainsCaseInsensitive(textToMatch) == true);
     }
 }

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -83,9 +83,10 @@ namespace System.CommandLine
                     case IIdentifierSymbol identifier when !child.IsHidden:
                         foreach (var alias in identifier.Aliases)
                         {
-                            if (alias is { } s && s.ContainsCaseInsensitive(textToMatch))
+                            if (alias is { } suggestion && 
+                                suggestion.ContainsCaseInsensitive(textToMatch))
                             {
-                                suggestions.Add(s);
+                                suggestions.Add(suggestion);
                             }
                         }
 
@@ -93,9 +94,10 @@ namespace System.CommandLine
                     case IArgument argument:
                         foreach (var suggestion in argument.GetSuggestions(parseResult, textToMatch))
                         {
-                            if (suggestion is { } s && s.ContainsCaseInsensitive(textToMatch))
+                            if (suggestion is { } && 
+                                suggestion.ContainsCaseInsensitive(textToMatch))
                             {
-                                suggestions.Add(s);
+                                suggestions.Add(suggestion);
                             }
                         }
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.CommandLine.Collections;
 using System.CommandLine.Parsing;
-using System.CommandLine.Suggestions;
 using System.Diagnostics;
 using System.Linq;
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -52,11 +52,6 @@ namespace System.CommandLine
 
         private protected void AddArgumentInner(Argument argument)
         {
-            if (argument is null)
-            {
-                throw new ArgumentNullException(nameof(argument));
-            }
-
             argument.AddParent(this);
 
             Children.Add(argument);
@@ -77,34 +72,40 @@ namespace System.CommandLine
         {
             var suggestions = new HashSet<string>();
 
-            foreach (var child in Children)
+            textToMatch ??= "";
+
+            for (var i = 0; i < Children.Count; i++)
             {
+                var child = Children[i];
+
                 switch (child)
                 {
                     case IIdentifierSymbol identifier when !child.IsHidden:
                         foreach (var alias in identifier.Aliases)
                         {
-                            if (alias is string s && s.ContainsCaseInsensitive(textToMatch))
+                            if (alias is { } s && s.ContainsCaseInsensitive(textToMatch))
                             {
                                 suggestions.Add(s);
                             }
                         }
+
                         break;
                     case IArgument argument:
                         foreach (var suggestion in argument.GetSuggestions(parseResult, textToMatch))
                         {
-                            if (suggestion is string s && s.ContainsCaseInsensitive(textToMatch))
+                            if (suggestion is { } s && s.ContainsCaseInsensitive(textToMatch))
                             {
                                 suggestions.Add(s);
                             }
                         }
+
                         break;
                 }
             }
 
             return suggestions
-                .OrderBy(symbol => symbol!.IndexOfCaseInsensitive(textToMatch))
-                .ThenBy(symbol => symbol, StringComparer.OrdinalIgnoreCase);
+                   .OrderBy(symbol => symbol!.IndexOfCaseInsensitive(textToMatch))
+                   .ThenBy(symbol => symbol, StringComparer.OrdinalIgnoreCase);
         }
 
         public override string ToString() => $"{GetType().Name}: {Name}";

--- a/src/System.CommandLine/SymbolExtensions.cs
+++ b/src/System.CommandLine/SymbolExtensions.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.CommandLine.Parsing;
-using System.Linq;
 
 namespace System.CommandLine
 {
     public static class SymbolExtensions
     {
-        internal static IEnumerable<IArgument> Arguments(this ISymbol symbol)
+        internal static IReadOnlyList<IArgument> Arguments(this ISymbol symbol)
         {
             switch (symbol)
             {
@@ -34,14 +32,5 @@ namespace System.CommandLine
         {
             return symbol.GetSuggestions(null, textToMatch);
         }
-
-        public static ParseResult Parse(this ISymbol symbol, string commandLine) =>
-            symbol switch
-            {
-                Argument argument => argument.Parse(commandLine),
-                Command command => command.Parse(commandLine),
-                Option option => option.Parse(commandLine),
-                _ => throw new ArgumentOutOfRangeException(nameof(symbol))
-            };
     }
 }

--- a/src/System.CommandLine/SymbolSetExtensions.cs
+++ b/src/System.CommandLine/SymbolSetExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Collections;
+
+namespace System.CommandLine
+{
+    internal static class SymbolSetExtensions
+    {
+        public static bool HasAnyOfType<T>(this ISymbolSet source)
+        {
+            for (var i = 0; i < source.Count; i++)
+            {
+                if (source[i] is T)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+#nullable disable
+        // requires C# 9.0
+        public static T FirstOrDefaultOfType<T>(this ISymbolSet source)
+        {
+            for (var i = 0; i < source.Count; i++)
+            {
+                if (source[i] is T result)
+                {
+                    return result;
+                }
+            }
+
+            return default;
+        }
+#nullable restore
+    }
+}


### PR DESCRIPTION
The major change in this PR is to redefine `ICommand.Options` and `ICommand.Arguments` to return `IReadOnlyCollection<T>` rather than `IEnumerable<T>`, and then remove some use of LINQ and replace `foreach` loops with `for` loops.

I've removed a test (`Global_options_appear_in_child_command_options_list`) and the behavior it's testing, but I think the change makes reasonable sense. In effect, `Command.Options` and `Command.GlobalOptions` are separate collections, and I think this change makes that clearer. 