### PR TITLE
Remove obsolete wiki reference from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/command-line-api/command-line-api?branchName=main)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=337&branchName=main) [![Join the chat at https://gitter.im/dotnet/command-line-api](https://badges.gitter.im/dotnet/command-line-api.svg)](https://gitter.im/dotnet/command-line-api?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This repository contains the code for the System.CommandLine libraries and the `dotnet-suggest` global tool. For more information, see [our wiki](https://github.com/dotnet/command-line-api/wiki).
+This repository contains the code for the System.CommandLine libraries and the `dotnet-suggest` global tool.
 
 ## Packages
 


### PR DESCRIPTION
No sense in redirecting the users to the wiki which simply redirects the users to the docs folder.  The `## Documentation` section of the readme seems to already do this sufficiently so I just removed the wiki link.