### PR TITLE
Suggest output for boolean arguments with --help

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -809,7 +809,7 @@ Arguments:
         [Theory]
         [InlineData(typeof(bool))]
         [InlineData(typeof(bool?))]
-        public void Command_argument_descriptor_is_empty_for_boolean_values(Type type)
+        public void Command_argument_descriptor_includes_suggestions_for_boolean_values(Type type)
         {
             var description = "This is the argument description";
 
@@ -828,7 +828,7 @@ Arguments:
 
             var expected =
                 $"Arguments:{NewLine}" +
-                $"{_indentation}{_columnPadding}{description}";
+                $"{_indentation}<False|True>{_columnPadding}{description}";
 
             _console.Out.ToString().Should().Contain(expected);
         }

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -828,7 +828,7 @@ Arguments:
 
             var expected =
                 $"Arguments:{NewLine}" +
-                $"{_indentation}<False|True>{_columnPadding}{description}";
+                $"{_indentation}<{bool.FalseString}|{bool.TrueString}>{_columnPadding}{description}";
 
             _console.Out.ToString().Should().Contain(expected);
         }

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -526,8 +526,8 @@ namespace System.CommandLine.Help
 
         protected virtual string ArgumentDescriptor(IArgument argument)
         {
-            if (argument.ValueType == typeof(bool) ||
-                argument.ValueType == typeof(bool?))
+            if (argument.Parents.OfType<IOption>().Any()
+                && (argument.ValueType == typeof(bool) || argument.ValueType == typeof(bool?)))
             {
                 return "";
             }


### PR DESCRIPTION
Resolves #1157. While it is extra noise to show `<False|True>` on boolean options, it's good to see it in the help text when a command has a boolean argument.