### PR TITLE
Default empty collections when argument not specified

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.CommandLine.Parsing;
 using System.Linq;
 using FluentAssertions;
@@ -55,7 +56,6 @@ namespace System.CommandLine.Tests
             option.Aliases.Should().Contain("--added");
             option.HasAlias("--added").Should().BeTrue();
         }
-
 
         [Fact]
         public void A_prefixed_alias_can_be_added_to_an_option()
@@ -329,6 +329,17 @@ namespace System.CommandLine.Tests
                 .Select(e => e.Message)
                 .Should()
                 .BeEquivalentTo(new[] { "ERR" });
+        }
+
+        [Fact]
+        public void Option_T_of_IEnumerable_T_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<IEnumerable<string>>("-x");
+
+            var result = option.Parse("");
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -332,7 +332,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Option_of_IEnumerable_defaults_to_empty_when_not_specified()
+        public void Option_of_IEnumerable_of_T_defaults_to_empty_when_not_specified()
         {
             var option = new Option<IEnumerable<string>>("-x");
 
@@ -391,6 +391,32 @@ namespace System.CommandLine.Tests
         public void Option_of_IList_defaults_to_empty_when_not_specified()
         {
             var option = new Option<System.Collections.IList>("-x");
+            var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
+        }
+
+        [Fact]
+        public void Option_of_ICollection_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<System.Collections.ICollection>("-x");
+            var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
+        }
+
+        [Fact]
+        public void Option_of_IEnumerable_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<System.Collections.IEnumerable>("-x");
             var result = option.Parse("");
             result.HasOption(option)
                 .Should()

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -332,6 +332,20 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void Option_of_string_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<string>("-x");
+
+            var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
+        }
+
+        [Fact]
         public void Option_of_IEnumerable_of_T_defaults_to_empty_when_not_specified()
         {
             var option = new Option<IEnumerable<string>>("-x");

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -338,11 +338,15 @@ namespace System.CommandLine.Tests
             {
                 Argument = new Argument
                 {
-                    ArgumentType = typeof(IEnumerable<string>)
+                    ArgumentType = typeof(IEnumerable<string>),
+                    Arity = ArgumentArity.ZeroOrMore
                 }
             };
 
             var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
             result.ValueForOption(option)
                 .Should()
                 .BeEquivalentTo(Enumerable.Empty<string>());
@@ -354,6 +358,9 @@ namespace System.CommandLine.Tests
             var option = new Option<IEnumerable<string>>("-x");
 
             var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse(); 
             result.ValueForOption(option)
                 .Should()
                 .BeEmpty();

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -332,6 +332,23 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void Option_of_IEnumerable_T_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option("-x")
+            {
+                Argument = new Argument
+                {
+                    ArgumentType = typeof(IEnumerable<string>)
+                }
+            };
+
+            var result = option.Parse("");
+            result.ValueForOption(option)
+                .Should()
+                .BeEquivalentTo(Enumerable.Empty<string>());
+        }
+
+        [Fact]
         public void Option_T_of_IEnumerable_T_defaults_to_empty_when_not_specified()
         {
             var option = new Option<IEnumerable<string>>("-x");

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -332,28 +332,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Option_of_IEnumerable_T_defaults_to_empty_when_not_specified()
-        {
-            var option = new Option("-x")
-            {
-                Argument = new Argument
-                {
-                    ArgumentType = typeof(IEnumerable<string>),
-                    Arity = ArgumentArity.ZeroOrMore
-                }
-            };
-
-            var result = option.Parse("");
-            result.HasOption(option)
-                .Should()
-                .BeFalse();
-            result.ValueForOption(option)
-                .Should()
-                .BeEquivalentTo(Enumerable.Empty<string>());
-        }
-
-        [Fact]
-        public void Option_T_of_IEnumerable_T_defaults_to_empty_when_not_specified()
+        public void Option_of_IEnumerable_defaults_to_empty_when_not_specified()
         {
             var option = new Option<IEnumerable<string>>("-x");
 
@@ -361,6 +340,75 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse(); 
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
+        }
+
+        [Fact]
+        public void Option_of_Array_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<string[]>("-x");
+
+            var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
+        }
+
+        [Fact]
+        public void Option_of_List_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<List<string>>("-x");
+
+            var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
+        }
+
+        [Fact]
+        public void Option_of_IList_of_T_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<IList<string>>("-x");
+
+            var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
+        }
+
+        [Fact]
+        public void Option_of_IList_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<System.Collections.IList>("-x");
+            var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
+            result.ValueForOption(option)
+                .Should()
+                .BeEmpty();
+        }
+
+        [Fact]
+        public void Option_of_ICollection_of_T_defaults_to_empty_when_not_specified()
+        {
+            var option = new Option<ICollection<string>>("-x");
+
+            var result = option.Parse("");
+            result.HasOption(option)
+                .Should()
+                .BeFalse();
             result.ValueForOption(option)
                 .Should()
                 .BeEmpty();

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -195,7 +195,11 @@ namespace System.CommandLine.Binding
                       .GetInterfaces()
                       .FirstOrDefault(IsEnumerable);
 
-            return enumerableInterface?.GenericTypeArguments.FirstOrDefault();
+            return enumerableInterface?.GenericTypeArguments switch
+            {
+                { Length: 1 } genericTypeArguments => genericTypeArguments[0],
+                _ => null
+            };
         }
 
         internal static bool IsEnumerable(this Type type)

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -350,6 +350,7 @@ namespace System.CommandLine.Binding
 
         internal static object? GetDefaultValue(Type type)
         {
+            if (type == typeof(string)) return "";
             if (GetItemTypeIfEnumerable(type) is Type itemType)
             {
                 if (type.IsArray)

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -350,6 +350,15 @@ namespace System.CommandLine.Binding
             return default!;
         }
 
+        internal static object? GetDefaultValue(Type type)
+        {
+            if (GetItemTypeIfEnumerable(type) is Type itemType)
+            {
+                return GetEmpty(itemType);
+            }
+            return null;
+        }
+
         private static MethodInfo EnumerableEmptyMethod { get; }
             = typeof(Enumerable).GetMethod(nameof(Enumerable.Empty));
         internal static IEnumerable GetEmpty(Type type)

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -195,7 +195,7 @@ namespace System.CommandLine.Binding
                       .GetInterfaces()
                       .FirstOrDefault(IsEnumerable);
 
-            return enumerableInterface?.GenericTypeArguments[0];
+            return enumerableInterface?.GenericTypeArguments.FirstOrDefault();
         }
 
         internal static bool IsEnumerable(this Type type)
@@ -342,29 +342,55 @@ namespace System.CommandLine.Binding
         [return: MaybeNull]
         internal static T GetDefaultValue<T>()
         {
-            var type = typeof(T);
-            if (GetItemTypeIfEnumerable(type) is Type itemType)
-            {
-                return (T)GetEmpty(itemType);
-            }
-            return default!;
+            return (T)GetDefaultValue(typeof(T));
         }
+
+        private static MethodInfo EnumerableEmptyMethod { get; }
+            = typeof(Enumerable).GetMethod(nameof(Enumerable.Empty));
 
         internal static object? GetDefaultValue(Type type)
         {
             if (GetItemTypeIfEnumerable(type) is Type itemType)
             {
-                return GetEmpty(itemType);
+                if (type.IsArray)
+                {
+                    return CreateEmptyArray(itemType);
+                }
+                if (type.IsGenericType)
+                {
+                    return type.GetGenericTypeDefinition() switch
+                    {
+                        Type enumerable when enumerable == typeof(IEnumerable<>) => GetEmptyEnumerable(itemType),
+                        Type list when list == typeof(List<>) => GetEmptyList(itemType),
+                        Type array when array == typeof(IList<>) || 
+                                        array == typeof(ICollection<>) => CreateEmptyArray(itemType),
+                        _ => null
+                    };
+                }
             }
-            return null;
-        }
+            return type switch
+            {
+                Type nonGeneric 
+                    when nonGeneric == typeof(IList) ||
+                         nonGeneric == typeof(ICollection) ||
+                         nonGeneric == typeof(IEnumerable)
+                    => CreateEmptyArray(typeof(object)),
+                _ => null
+            };
+            
+            static object GetEmptyList(Type itemType)
+            {
+                return Activator.CreateInstance(typeof(List<>).MakeGenericType(itemType));
+            }
 
-        private static MethodInfo EnumerableEmptyMethod { get; }
-            = typeof(Enumerable).GetMethod(nameof(Enumerable.Empty));
-        internal static IEnumerable GetEmpty(Type type)
-        {
-            var genericMethod = EnumerableEmptyMethod.MakeGenericMethod(type);
-            return (IEnumerable)genericMethod.Invoke(null, new object[0]);
+            static IEnumerable GetEmptyEnumerable(Type itemType)
+            {
+                var genericMethod = EnumerableEmptyMethod.MakeGenericMethod(itemType);
+                return (IEnumerable)genericMethod.Invoke(null, new object[0]);
+            }
+
+            static Array CreateEmptyArray(Type itemType)
+                => Array.CreateInstance(itemType, 0);
         }
 
         public static bool TryConvertBoolArgument(ArgumentResult argumentResult, out object? value)

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -147,7 +147,7 @@ namespace System.CommandLine.Parsing
                 return t;
             }
 
-            return ArgumentConverter.GetDefaultValue<T>();
+            return (T)ArgumentConverter.GetDefaultValue(option.Argument.ArgumentType);
         }
 
         [return: MaybeNull]
@@ -159,7 +159,7 @@ namespace System.CommandLine.Parsing
                 return t;
             }
 
-            return default!;
+            return (T)ArgumentConverter.GetDefaultValue(option.Argument.ArgumentType);
         }
 
         [return: MaybeNull]

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.CommandLine.Binding;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
@@ -146,7 +147,7 @@ namespace System.CommandLine.Parsing
                 return t;
             }
 
-            return default;
+            return ArgumentConverter.GetDefaultValue<T>();
         }
 
         [return: MaybeNull]
@@ -158,7 +159,7 @@ namespace System.CommandLine.Parsing
                 return t;
             }
 
-            return default;
+            return default!;
         }
 
         [return: MaybeNull]


### PR DESCRIPTION
Fixes #1140 
Sets up default "empty" values for a variety of known types.
Types handles are:
- array => `Array.Empty`
- string => `String.Empty`
- IEnumerable<T>/IEnumerable => `Enumerable.Emtpy`
- ICollection<T>/ICollection => `Array.Empty`
- IList => `Array.Empty`
- IList<T> => `new List<T>()`;
