### PR TITLE
Ensure longer option is parsed when aliases are prefixed

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -371,6 +371,15 @@ namespace System.CommandLine.Tests
             option.Aliases.Should().Contain("name");
         }
 
+        [Fact]
+        public void When_aliases_overlap_the_longer_alias_is_chosen()
+        {
+            var option = new Option<string>(new[] { "-o", "-option" });
+
+            var parseResult = option.Parse("-option value");
+            parseResult.ValueForOption(option).Should().Be("value");
+        }
+
         protected override Symbol CreateSymbol(string name) => new Option(name);
     }
 }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -205,9 +205,7 @@ namespace System.CommandLine.Parsing
                 }
 
                 // don't unbundle if this is a known option
-                if (knownTokens.Values
-                    .Where(token => token.Type.Equals(TokenType.Option))
-                    .Any(token => token.Value.Equals(arg)))
+                if (knownTokens.ContainsKey(arg))
                 {
                     return false;
                 }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -204,6 +204,14 @@ namespace System.CommandLine.Parsing
                     return false;
                 }
 
+                // don't unbundle if this is a known option
+                if (knownTokens.Values
+                    .Where(token => token.Type.Equals(TokenType.Option))
+                    .Any(token => token.Value.Equals(arg)))
+                {
+                    return false;
+                }
+
                 var (prefix, alias) = arg.SplitPrefix();
 
                 return prefix == "-" &&


### PR DESCRIPTION
Fixes https://github.com/dotnet/command-line-api/issues/1175