### PR TITLE
Ensure longer option is parsed with argument delimiters

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -371,15 +371,14 @@ namespace System.CommandLine.Tests
             option.Aliases.Should().Contain("name");
         }
 
-        [Fact]
-        public void When_aliases_overlap_the_longer_alias_is_chosen()
+        [Theory]
+        [InlineData("-option value")]
+        [InlineData("-option:value")]
+        public void When_aliases_overlap_the_longer_alias_is_chosen(string parseInput)
         {
             var option = new Option<string>(new[] { "-o", "-option" });
 
-            var parseResult = option.Parse("-option value");
-            parseResult.ValueForOption(option).Should().Be("value");
-
-            parseResult = option.Parse("-option:value");
+            var parseResult = option.Parse(parseInput);
             parseResult.ValueForOption(option).Should().Be("value");
         }
 

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -378,6 +378,9 @@ namespace System.CommandLine.Tests
 
             var parseResult = option.Parse("-option value");
             parseResult.ValueForOption(option).Should().Be("value");
+
+            parseResult = option.Parse("-option:value");
+            parseResult.ValueForOption(option).Should().Be("value");
         }
 
         protected override Symbol CreateSymbol(string name) => new Option(name);

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -205,7 +205,10 @@ namespace System.CommandLine.Parsing
                 }
 
                 // don't unbundle if this is a known option
-                if (knownTokens.ContainsKey(arg))
+                if (knownTokens.ContainsKey(arg) ||
+                    knownTokens
+                        .SelectMany(token => _argumentDelimiters.Select(delimiter => token.Key + delimiter))
+                        .Any(token => arg.Contains(token)))
                 {
                     return false;
                 }


### PR DESCRIPTION
Follow up from https://github.com/dotnet/command-line-api/pull/1177, which did not apply the exact matching behavior to options specifying arguments after delimiters. 