### PR TITLE
Allow abstract command handler invocation

### DIFF
--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -27,7 +27,7 @@ namespace System.CommandLine.Invocation
             _handlerMethodInfo = handlerMethodInfo ?? throw new ArgumentNullException(nameof(handlerMethodInfo));
             _invocationTargetBinder = _handlerMethodInfo.IsStatic
                                           ? null
-                                          : new ModelBinder(_handlerMethodInfo.DeclaringType);
+                                          : new ModelBinder(_handlerMethodInfo.ReflectedType);
             _methodDescriptor = methodDescriptor ?? throw new ArgumentNullException(nameof(methodDescriptor));
         }
 


### PR DESCRIPTION
Use ReflectedType instead of DeclaringType for finding the correct invocation method.
This allow to support abstract command handler without overriding the InvokeAsync method.

