### PR TITLE
Binder.IsMatch now returns false when parameter name and alias match only partially

### DIFF
--- a/src/System.CommandLine/Binding/Binder.cs
+++ b/src/System.CommandLine/Binding/Binder.cs
@@ -8,12 +8,11 @@ namespace System.CommandLine.Binding
         internal static bool IsMatch(this string parameterName, string alias)
         {
             var parameterNameIndex = 0;
+            var aliasIndex = IndexAfterPrefix(alias);
 
-            for (var aliasIndex = IndexAfterPrefix(alias); 
-                aliasIndex < alias.Length && parameterNameIndex < parameterName.Length;
-                aliasIndex++)
+            while (aliasIndex < alias.Length && parameterNameIndex < parameterName.Length)
             {
-                var aliasChar = alias[aliasIndex];
+                var aliasChar = alias[aliasIndex++];
 
                 if (aliasChar == '-')
                 {
@@ -45,7 +44,9 @@ namespace System.CommandLine.Binding
                 parameterNameIndex++;
             }
 
-            return true;
+            //return true;
+            return aliasIndex == alias.Length && parameterNameIndex == parameterName.Length;
+
 
             static int IndexAfterPrefix(string alias)
             {

--- a/src/System.CommandLine/Binding/Binder.cs
+++ b/src/System.CommandLine/Binding/Binder.cs
@@ -44,7 +44,6 @@ namespace System.CommandLine.Binding
                 parameterNameIndex++;
             }
 
-            //return true;
             return aliasIndex == alias.Length && parameterNameIndex == parameterName.Length;
 
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/command-line-api/issues/1195

The current implementation of the `Binder.IsMatch` method returns `true` if parametername and alias match only partially (think of a version of `alias.StartsWith(parameterName) || parameterName.StartsWith(alias)` that accounts for the `|` token). 

This behavior makes option-to-property mappings unreliable and ambiguous with the possible consequences of option values being assigned to wrong properties or exceptions in case the wrong property happens to be of a type that is incompatible with the option value. (I haven't double-checked with constructor argument names or lambda expressions/anonymous methods, but i wouldn't be surprised if they would be affected by the same incorrect partial match issue, too.)

To achieve reliable and unambiguous option-to-property mappings, this pull request modifies the behavior of the `Binder.IsMatch` method so that it returns `false` for partial matches. If the current `Binder.IsMatch` must be maintained, feel free to reject my pull request, however, the project maintainers would then still need to find a solution that achieves reliable and unambiguous option-to-property mapping.