### PR TITLE
Fix #1188, #1195

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -220,7 +220,7 @@ namespace System.CommandLine.DragonFruit.Tests
             var options = handlerMethod.BuildOptions();
 
             options.Should()
-                   .NotContain(o => o.ArgumentType == type);
+                   .NotContain(o => o.ValueType == type);
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.CommandLine.Binding;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
@@ -624,6 +625,40 @@ namespace System.CommandLine.Tests.Binding
 
             first.Should().Be(1);
             second.Should().Be(2);
+        }
+
+        public class MyModel
+        {
+            public List<string> Abc { get; set; }
+
+            public string AbcDef { get; set; }
+        }
+
+        [Fact]
+        public void Binder_does_not_match_on_partial_name()
+        {
+            var command = new RootCommand
+            {
+                new Option<List<string>>("--abc")
+            };
+
+            MyModel boundValue = default;
+
+            command.Handler = CommandHandler.Create(
+                (MyModel s) =>
+                {
+                    boundValue = s;
+                }
+            );
+
+            command.Invoke(new[] { "--abc", "1" });
+
+            boundValue.Abc
+                      .Should()
+                      .ContainSingle()
+                      .Which
+                      .Should()
+                      .Be("1");
         }
     }
 }

--- a/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.cs
@@ -37,9 +37,6 @@ namespace System.CommandLine.Tests.Binding
             var command = new Command("the-command")
                           {
                               new Option("--value", argumentType: type)
-                              {
-                                  ArgumentName = "value"
-                              }
                           };
 
             var console = new TestConsole();
@@ -72,9 +69,6 @@ namespace System.CommandLine.Tests.Binding
             var command = new Command("the-command")
                           {
                               new Option("--value", argumentType: type)
-                              {
-                                  ArgumentName = "value"
-                              }
                           };
 
             var console = new TestConsole();
@@ -107,9 +101,6 @@ namespace System.CommandLine.Tests.Binding
             var command = new Command("the-command")
                           {
                               new Option("--value", argumentType: type)
-                              {
-                                  ArgumentName = "value"
-                              }
                           };
 
             var console = new TestConsole();
@@ -118,26 +109,6 @@ namespace System.CommandLine.Tests.Binding
                 new InvocationContext(command.Parse(commandLine), console));
 
             console.Out.ToString().Should().Be($"ClassWithCtorParameter<{type.Name}>: {expectedValue}");
-        }
-
-        [Fact]
-        public void When_name_is_not_among_aliases_then_binder_will_bind_option_by_name()
-        {
-            var rootCommand = new RootCommand
-            {
-                new Option<string[]>("-n")
-                {
-                    ArgumentName = "name"
-                }
-            };
-
-            string[] receivedHeaders = null;
-
-            rootCommand.Handler = CommandHandler.Create((string[] name) => receivedHeaders = name);
-
-            rootCommand.Invoke("-n one -n two");
-
-            receivedHeaders.Should().BeEquivalentTo("one", "two");
         }
 
         [Theory]
@@ -190,9 +161,6 @@ namespace System.CommandLine.Tests.Binding
             var command = new Command("command")
                           {
                               new Option("-x", argumentType: parameterType)
-                              {
-                                  ArgumentName = "value"
-                              }
                           };
 
             command.Handler = handler;

--- a/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBindingCommandHandlerTests.cs
@@ -173,7 +173,7 @@ namespace System.CommandLine.Tests.Binding
         }
 
         [Theory]
-        [InlineData(typeof(string), null)]
+        [InlineData(typeof(string), "")]
         [InlineData(typeof(FileInfo), null)]
         [InlineData(typeof(int), 0)]
         [InlineData(typeof(int?), null)]
@@ -365,7 +365,7 @@ namespace System.CommandLine.Tests.Binding
 
             testConsole.Error.ToString().Should().BeEmpty();
 
-            received.Should().BeNull();
+            received.Should().BeEmpty();
         }
 
         [Theory]

--- a/src/System.CommandLine.Tests/Binding/ParameterDescriptorTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ParameterDescriptorTests.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Tests.Binding
     public class ParameterDescriptorTests
     {
         [Theory]
-        [InlineData(typeof(string), null)]
+        [InlineData(typeof(string), "")]
         [InlineData(typeof(int), 0)]
         [InlineData(typeof(int?), null)]
         public void GetDefaultValue_returns_the_default_for_the_type(Type type, object defaultValue)

--- a/src/System.CommandLine.Tests/Binding/PropertyDescriptorTests.cs
+++ b/src/System.CommandLine.Tests/Binding/PropertyDescriptorTests.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Tests.Binding
     public class PropertyDescriptorTests
     {
         [Theory]
-        [InlineData(typeof(string), null)]
+        [InlineData(typeof(string), "")]
         [InlineData(typeof(int), 0)]
         [InlineData(typeof(int?), null)]
         public void GetDefaultValue_returns_the_default_for_the_type(Type type, object defaultValue)

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
@@ -42,27 +42,23 @@ namespace System.CommandLine.Tests.Help
                 ),
                 new Option<string>(aliases: new string[] {"--the-root-option-no-default-arg", "-tronda"}) {
                     Description = "the-root-option-no-default-description",
-                    ArgumentName = "the-root-option-arg-no-default-arg",
-                    ArgumentDescription = "the-root-option-arg-no-default-description",
+                    ArgumentHelpName = "the-root-option-arg-no-default-arg",
                     IsRequired = true
                 },
                 new Option<string>(aliases: new string[] {"--the-root-option-default-arg", "-troda"}, () => "the-root-option-arg-value") 
                 {
                     Description = "the-root-option-default-arg-description",
-                    ArgumentName = "the-root-option-arg",
-                    ArgumentDescription = "the-root-option-arg-description"
+                    ArgumentHelpName = "the-root-option-arg",
                 },
                 new Option<FileAccess>(aliases: new string[] {"--the-root-option-enum-arg", "-troea"}, () => FileAccess.Read) 
                 {
                     Description = "the-root-option-description",
-                    ArgumentName = "the-root-option-arg",
-                    ArgumentDescription = "the-root-option-arg-description"
+                    ArgumentHelpName = "the-root-option-arg",
                 },
                 new Option<FileAccess>(aliases: new string[] {"--the-root-option-required-enum-arg", "-trorea"}, () => FileAccess.Read) 
                 {
                     Description = "the-root-option-description",
-                    ArgumentName = "the-root-option-arg",
-                    ArgumentDescription = "the-root-option-arg-description",
+                    ArgumentHelpName = "the-root-option-arg",
                     IsRequired = true
                 },
                 new Option(aliases: new string[] {"--the-root-option-multi-line-description", "-tromld"}) {
@@ -74,6 +70,5 @@ namespace System.CommandLine.Tests.Help
             GetHelpBuilder(LargeMaxWidth).Write(command);
             Approvals.Verify(_console.Out.ToString());
         }
-
     }
 }

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -1162,30 +1162,6 @@ Arguments:
         }
 
         [Fact]
-        public void Options_section_does_not_contain_hidden_argument()
-        {
-            var command = new Command("the-command", "Does things.");
-            var opt1 = new Option<int>("option1")
-            {
-                ArgumentName = "the-hidden",
-                ArgumentIsHidden = true,
-            };
-            var opt2 = new Option<int>("option2")
-            {
-                ArgumentName = "the-visible",
-                ArgumentIsHidden = false
-            };
-            command.AddOption(opt1);
-            command.AddOption(opt2);
-
-            _helpBuilder.Write(command);
-            var help = _console.Out.ToString();
-
-            help.Should().NotContain("the-hidden");
-            help.Should().Contain("the-visible");
-        }
-
-        [Fact]
         public void Required_options_are_indicated()
         {
             var command = new RootCommand
@@ -1327,27 +1303,6 @@ Arguments:
             var help = _console.Out.ToString();
 
             help.Should().Contain($"[default: the-arg-value]");
-        }
-
-        [Fact]
-        public void Help_should_not_contain_default_value_for_hidden_argument_defined_for_option()
-        {
-            var command = new Command("the-command", "command help")
-            {
-                new Option(new[] { "-arg"}, getDefaultValue: () => "the-arg-value")
-                {
-                    ArgumentName = "the-arg",
-                    ArgumentIsHidden = true
-                }
-            };
-
-            HelpBuilder helpBuilder = GetHelpBuilder(LargeMaxWidth);
-
-            helpBuilder.Write(command);
-
-            var help = _console.Out.ToString();
-
-            help.Should().NotContain($"[default: the-arg-value]");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -514,7 +514,7 @@ namespace System.CommandLine.Tests.Help
             {
                 new Option("-v", "Sets the verbosity.", arity: ArgumentArity.ExactlyOne)
                 {
-                    ArgumentName = "argument for options"
+                    ArgumentHelpName = "argument for options"
                 }
             };
 
@@ -530,7 +530,7 @@ namespace System.CommandLine.Tests.Help
             {
                 new Option(new[] { "-v", "--verbosity" }, arity: ArgumentArity.ExactlyOne)
                 {
-                    ArgumentName = "LEVEL",
+                    ArgumentHelpName = "LEVEL",
                     Description = "Sets the verbosity."
                 }
             };
@@ -1188,7 +1188,7 @@ Arguments:
                 new Option<string>(new[] {"-r", "--required" })
                 {
                     IsRequired = true,
-                    ArgumentName = "ARG"
+                    ArgumentHelpName = "ARG"
                 }
             };
 
@@ -1292,7 +1292,7 @@ Arguments:
             {
                 new Option(new[] { "-arg"}, getDefaultValue: () => "the-arg-value")
                 {
-                    ArgumentName = "the-arg"
+                    ArgumentHelpName = "the-arg"
                 }
             };
 

--- a/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
@@ -142,7 +142,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await command.InvokeAsync("command", _console);
 
-            boundName.Should().Be(null);
+            boundName.Should().Be("");
             boundAge.Should().Be(0);
         }
 

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -235,7 +235,7 @@ namespace System.CommandLine.Tests
         {
             var command = new Option("--alias", arity: ArgumentArity.ZeroOrOne);
 
-            command.ArgumentName.Should().Be("alias");
+            command.ArgumentHelpName.Should().Be("alias");
         }
 
         [Fact]
@@ -243,10 +243,10 @@ namespace System.CommandLine.Tests
         {
             var option = new Option("-alias", arity: ArgumentArity.ZeroOrOne)
             {
-                ArgumentName = "arg"
+                ArgumentHelpName = "arg"
             };
 
-            option.ArgumentName.Should().Be("arg");
+            option.ArgumentHelpName.Should().Be("arg");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -460,6 +460,21 @@ namespace System.CommandLine.Tests
             parseResult.ValueForOption(option).Should().Be("value");
         }
 
+        [Fact]
+        public void Option_of_boolean_defaults_to_false_when_not_specified()
+        {
+            var option = new Option<bool>("-x");
+
+            var result = option.Parse("");
+
+            result.HasOption(option)
+                  .Should()
+                  .BeFalse();
+            result.ValueForOption(option)
+                  .Should()
+                  .BeFalse();
+        }
+
         protected override Symbol CreateSymbol(string name) => new Option(name);
     }
 }

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -153,12 +153,9 @@ namespace System.CommandLine.Tests
         public void When_an_option_has_a_default_value_it_will_still_be_suggested()
         {
             var parser = new Parser(
-                new Option<string[]>("--apple", "kinds of apples")
-                {
-                    ArgumentName = "cortland"
-                },
-                new Option<string[]>("--banana", "kinds of bananas"),
-                new Option<string>("--cherry", "kinds of cherries"));
+                new Option<string>("--apple", getDefaultValue: () => "cortland"),
+                new Option<string>("--banana"),
+                new Option<string>("--cherry"));
 
             var result = parser.Parse("");
 

--- a/src/System.CommandLine.Tests/Utility/ConsoleAssertions.cs
+++ b/src/System.CommandLine.Tests/Utility/ConsoleAssertions.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 using FluentAssertions.Primitives;
 
 namespace System.CommandLine.Tests.Utility

--- a/src/System.CommandLine/Binding/BoundValue.cs
+++ b/src/System.CommandLine/Binding/BoundValue.cs
@@ -10,12 +10,6 @@ namespace System.CommandLine.Binding
             IValueDescriptor valueDescriptor,
             IValueSource valueSource)
         {
-            if (value != null &&
-                !valueDescriptor.ValueType.IsInstanceOfType(value))
-            {
-                throw new ArgumentException($"Value {value} ({value.GetType()}) must be an instance of type {valueDescriptor.ValueType}");
-            }
-
             Value = value;
             ValueDescriptor = valueDescriptor;
             ValueSource = valueSource;
@@ -53,5 +47,4 @@ namespace System.CommandLine.Binding
                 valueSource);
         }
     }
-
 }

--- a/src/System.CommandLine/Binding/ParameterDescriptor.cs
+++ b/src/System.CommandLine/Binding/ParameterDescriptor.cs
@@ -44,7 +44,7 @@ namespace System.CommandLine.Binding
 
         public object? GetDefaultValue() =>
             _parameterInfo.DefaultValue is DBNull
-                ? ValueType.GetDefaultValueForType()
+                ? Binder.GetDefaultValue(ValueType)
                 : _parameterInfo.DefaultValue;
 
         public override string ToString() => $"{ValueType.Name} {ValueName}";

--- a/src/System.CommandLine/Binding/PropertyDescriptor.cs
+++ b/src/System.CommandLine/Binding/PropertyDescriptor.cs
@@ -27,7 +27,7 @@ namespace System.CommandLine.Binding
 
         public bool HasDefaultValue => false;
 
-        public object? GetDefaultValue() => ValueType.GetDefaultValueForType();
+        public object? GetDefaultValue() => Binder.GetDefaultValue(ValueType);
 
         public void SetValue(object? instance, object? value)
         {

--- a/src/System.CommandLine/Binding/TypeDefaultValueSource.cs
+++ b/src/System.CommandLine/Binding/TypeDefaultValueSource.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine.Binding
             BindingContext? bindingContext,
             out object? boundValue)
         {
-            boundValue = valueDescriptor.ValueType.GetDefaultValueForType();
+            boundValue = Binder.GetDefaultValue(valueDescriptor.ValueType);
             return true;
         }
     }

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -515,6 +515,8 @@ namespace System.CommandLine.Builder
                     return true;
                 });
 
+            versionOption.DisallowBinding = true;
+
             command.AddOption(versionOption);
 
             builder.AddMiddleware(async (context, next) =>

--- a/src/System.CommandLine/DebugAssert.cs
+++ b/src/System.CommandLine/DebugAssert.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System.CommandLine
+{
+    internal static class DebugAssert
+    {
+        [Conditional("DEBUG")]
+        public static void ThrowIf(bool condition, string message)
+        {
+            if (condition)
+            {
+                Throw(message);
+            }
+        }
+        
+        [Conditional("DEBUG")]
+        public static void Throw(string message)
+        {
+            throw new Exception(message);
+        }
+    }
+}

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -20,7 +20,6 @@ namespace System.CommandLine.Help
         internal override Argument Argument
         {
             get => Argument.None;
-            set { }
         }
 
         public override bool Equals(object obj)

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -12,19 +12,15 @@ namespace System.CommandLine.Help
             "--help",
             "-?",
             "/?"
-        }, Resources.Instance.HelpOptionDescription() )
+        }, Resources.Instance.HelpOptionDescription())
         {
+            DisallowBinding = true;
         }
 
         internal override Argument Argument
         {
             get => Argument.None;
             set { }
-        }
-
-        protected bool Equals(HelpOption other)
-        {
-            return other != null;
         }
 
         public override bool Equals(object obj)

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -122,6 +122,8 @@ namespace System.CommandLine
 
         private IEnumerable<Argument> Arguments => Children.OfType<Argument>();
 
+        internal bool DisallowBinding { get; set; } 
+
         public override string Name
         {
             get => base.Name;

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -112,14 +112,6 @@ namespace System.CommandLine
             set => Argument.Description = value;
         }
 
-        public bool ArgumentIsHidden
-        {
-            get => Argument.IsHidden;
-            set => Argument.IsHidden = value;
-        }
-
-        public Type ArgumentType => Argument.ArgumentType;
-
         private IEnumerable<Argument> Arguments => Children.OfType<Argument>();
 
         internal bool DisallowBinding { get; set; } 
@@ -173,7 +165,7 @@ namespace System.CommandLine
 
         string IValueDescriptor.ValueName => Name;
 
-        Type IValueDescriptor.ValueType => Argument.ArgumentType;
+        public Type ValueType => Argument.ArgumentType;
 
         bool IValueDescriptor.HasDefaultValue => Argument.HasDefaultValue;
 

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -85,8 +85,6 @@ namespace System.CommandLine
             return rv;
         }
 
-        private protected virtual Argument GetDefaultArgument() => Argument.None;
-
         internal virtual Argument Argument
         {
             get => Arguments.FirstOrDefault() ?? Argument.None;

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -88,28 +88,14 @@ namespace System.CommandLine
         internal virtual Argument Argument
         {
             get => Arguments.FirstOrDefault() ?? Argument.None;
-            set
-            {
-                for (var i = 0; i < Children.Arguments.Count; i++)
-                {
-                    Children.Remove(Children.Arguments[i]);
-                }
-
-                AddArgumentInner(value);
-            }
+            set => AddArgumentInner(value); // FIX: delete?
         }
 
         //TODO: Guard against Argument.None?
-        public string ArgumentName
+        public string ArgumentHelpName
         {
             get => Argument.Name;
             set => Argument.Name = value;
-        }
-
-        public string? ArgumentDescription
-        {
-            get => Argument.Description;
-            set => Argument.Description = value;
         }
 
         private IEnumerable<Argument> Arguments => Children.OfType<Argument>();

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -52,11 +52,6 @@ namespace System.CommandLine
             : base(aliases, description, new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))))
         { }
 
-        private protected override Argument GetDefaultArgument()
-        {
-            return new Argument<T> { Arity = ArgumentArity.Zero };
-        }
-
         internal override Argument Argument
         {
             set

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -51,19 +51,5 @@ namespace System.CommandLine
             string? description = null) 
             : base(aliases, description, new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))))
         { }
-
-        internal override Argument Argument
-        {
-            set
-            {
-                if (!(value is Argument<T>))
-                {
-
-                    throw new ArgumentException($"{nameof(Argument)} must be of type {typeof(Argument<T>)} but was {value?.GetType().ToString() ?? "null"}");
-                }
-
-                base.Argument = value;
-            }
-        }
     }
 }

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -37,9 +37,10 @@ namespace System.CommandLine.Parsing
 
             for (var i = 0; i < options.Count; i++)
             {
-                var option = options[i];
+                var option = (Option) options[i];
 
-                if (valueDescriptor.ValueName.IsMatch(option))
+                if (!option.DisallowBinding &&
+                    valueDescriptor.ValueName.IsMatch(option))
                 {
                     var optionResult = commandResult.FindResultFor(option);
 

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -147,7 +147,7 @@ namespace System.CommandLine.Parsing
                 return t;
             }
 
-            return (T)ArgumentConverter.GetDefaultValue(option.Argument.ArgumentType);
+            return (T)Binder.GetDefaultValue(option.Argument.ArgumentType);
         }
 
         [return: MaybeNull]
@@ -159,7 +159,7 @@ namespace System.CommandLine.Parsing
                 return t;
             }
 
-            return (T)ArgumentConverter.GetDefaultValue(option.Argument.ArgumentType);
+            return (T)Binder.GetDefaultValue(option.Argument.ArgumentType);
         }
 
         [return: MaybeNull]

--- a/src/System.CommandLine/TypeExtensions.cs
+++ b/src/System.CommandLine/TypeExtensions.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.CommandLine
 {


### PR DESCRIPTION
Fixes: #1188, #1195.

This also touches a couple of properties from `Option` that were hoisted as part of #1148:

* Removes `Option.ArgumentIsHidden`
* Removes `Option.ArgumentType` and makes the equivalent interface member, `IValueSource.ValueType`, public.