### PR TITLE
Fix 1135

### DIFF
--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -10,6 +10,7 @@ using System.IO;
 using FluentAssertions;
 using Xunit;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace System.CommandLine.Tests.Binding
 {
@@ -627,12 +628,7 @@ namespace System.CommandLine.Tests.Binding
             second.Should().Be(2);
         }
 
-        public class MyModel
-        {
-            public List<string> Abc { get; set; }
-
-            public string AbcDef { get; set; }
-        }
+      
 
         [Fact]
         public void Binder_does_not_match_on_partial_name()
@@ -642,10 +638,10 @@ namespace System.CommandLine.Tests.Binding
                 new Option<List<string>>("--abc")
             };
 
-            MyModel boundValue = default;
+            ClassWithOnePropertyNameThatIsSubstringOfAnother boundValue = default;
 
             command.Handler = CommandHandler.Create(
-                (MyModel s) =>
+                (ClassWithOnePropertyNameThatIsSubstringOfAnother s) =>
                 {
                     boundValue = s;
                 }
@@ -659,6 +655,26 @@ namespace System.CommandLine.Tests.Binding
                       .Which
                       .Should()
                       .Be("1");
+        }
+
+        [Fact] 
+        public async Task Empty_input_is_bound_correctly_to_list_type_properties()
+        {
+            ClassWithListTypePropertiesAndDefaultCtor boundInstance = default;
+            
+            var cmd = new RootCommand
+            {
+                Handler = CommandHandler.Create((ClassWithListTypePropertiesAndDefaultCtor value) =>
+                {
+                    boundInstance = value;
+                })
+            };
+
+            var result = cmd.Parse();
+
+            await result.InvokeAsync();
+
+            boundInstance.Should().NotBeNull();
         }
     }
 }

--- a/src/System.CommandLine.Tests/Binding/TestModels.cs
+++ b/src/System.CommandLine.Tests/Binding/TestModels.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace System.CommandLine.Tests.Binding
@@ -29,21 +30,11 @@ namespace System.CommandLine.Tests.Binding
         public bool BoolOption { get; set; }
     }
 
-    public class ClassWithSettersAndCtorParametersWithDifferentNames
+    public class ClassWithListTypePropertiesAndDefaultCtor
     {
-        public ClassWithSettersAndCtorParametersWithDifferentNames(
-            int i = 123,
-            string s = "the default",
-            bool b = false)
-        {
-            IntOption = i;
-            StringOption = s;
-            BoolOption = b;
-        }
+        public List<string> Strings { get; set; }
 
-        public int IntOption { get; set; }
-        public string StringOption { get; set; }
-        public bool BoolOption { get; set; }
+        public IEnumerable<int> BoolOption { get; set; }
     }
 
     public class ClassWithCtorParameter<T>
@@ -92,7 +83,6 @@ namespace System.CommandLine.Tests.Binding
     {
         public ClassWithMultipleCtor()
         {
-
         }
 
         public ClassWithMultipleCtor(int intProperty)
@@ -101,5 +91,29 @@ namespace System.CommandLine.Tests.Binding
         }
 
         public int IntProperty { get; }
+    }
+
+    public class ClassWithSettersAndCtorParametersWithDifferentNames
+    {
+        public ClassWithSettersAndCtorParametersWithDifferentNames(
+            int i = 123,
+            string s = "the default",
+            bool b = false)
+        {
+            IntOption = i;
+            StringOption = s;
+            BoolOption = b;
+        }
+
+        public int IntOption { get; set; }
+        public string StringOption { get; set; }
+        public bool BoolOption { get; set; }
+    }
+
+    public class ClassWithOnePropertyNameThatIsSubstringOfAnother
+    {
+        public List<string> Abc { get; set; }
+
+        public string AbcDef { get; set; }
     }
 }

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -987,7 +987,7 @@ namespace System.CommandLine.Tests
             {
                 var command = new Command("the-command")
                 {
-                    new Argument<DayOfWeek?>()
+                    new Argument<DayOfWeek?>
                     {
                         Suggestions = { "mon", "tues", "wed", "thur", "fri", "sat", "sun" }
                     }

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -19,7 +19,7 @@ namespace System.CommandLine
         private IArgumentArity? _arity;
         private TryConvertArgument? _convertArguments;
         private Type _argumentType = typeof(string);
-        private List<ISuggestionSource>? _suggestions = null;
+        private SuggestionSourceList? _suggestions = null;
 
         /// <summary>
         /// Initializes a new instance of the Argument class.
@@ -93,13 +93,13 @@ namespace System.CommandLine
         /// <summary>
         /// Gets the list of suggestion sources for the argument.
         /// </summary>
-        public List<ISuggestionSource> Suggestions
+        public SuggestionSourceList Suggestions
         { 
             get
             {
                 if (_suggestions is null)
                 {
-                    _suggestions = new List<ISuggestionSource>
+                    _suggestions = new SuggestionSourceList
                     {
                         SuggestionSource.ForType(ArgumentType)
                     };

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -10,7 +10,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using static System.Environment;

--- a/src/System.CommandLine/SuggestionSourceExtensions.cs
+++ b/src/System.CommandLine/SuggestionSourceExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.CommandLine.Suggestions;
 
 namespace System.CommandLine
@@ -9,7 +8,7 @@ namespace System.CommandLine
     public static class SuggestionSourceExtensions
     {
         public static void Add(
-            this List<ISuggestionSource> suggestionSources,
+            this SuggestionSourceList suggestionSources,
             SuggestDelegate suggest)
         {
             if (suggestionSources is null)
@@ -26,7 +25,7 @@ namespace System.CommandLine
         }
 
         public static void Add(
-            this List<ISuggestionSource> suggestionSources,
+            this SuggestionSourceList suggestionSources,
             params string[] suggestions)
         {
             if (suggestionSources is null)

--- a/src/System.CommandLine/SuggestionSourceList.cs
+++ b/src/System.CommandLine/SuggestionSourceList.cs
@@ -1,0 +1,32 @@
+﻿// // Copyright (c) .NET Foundation and contributors. All rights reserved.
+// // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.CommandLine.Suggestions;
+
+namespace System.CommandLine
+{
+    public class SuggestionSourceList : IReadOnlyList<ISuggestionSource>
+    {
+        private readonly List<ISuggestionSource> _sources = new List<ISuggestionSource>();
+
+        public void Add(ISuggestionSource source)
+        {
+            _sources.Add(source);
+        }
+
+        public IEnumerator<ISuggestionSource> GetEnumerator() => _sources.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Clear()
+        {
+            _sources.Clear();
+        }
+
+        public int Count => _sources.Count;
+
+        public ISuggestionSource this[int index] => _sources[index];
+    }
+}


### PR DESCRIPTION
This PR fixes #1135 and also a `NullReferenceException` that arises when binding no parsed input to a list-type property.