### PR TITLE
Honor user defined order of commands, subcommands and options

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -1275,14 +1275,14 @@ Arguments:
         {
             var command = new RootCommand
             {
-                new Option(new[] { "-z", "-a", "--zzz", "--aaa" })
+                new Option(new[] { "--aaa", "--zzz", "-z", "-a" })
             };
 
             _helpBuilder.Write(command);
 
             _console
                 .Out
-                .ToString().Should().Contain("-a, -z, --aaa, --zzz");
+                .ToString().Should().Contain("-z, -a, --aaa, --zzz");
         }
 
         [Fact]
@@ -1324,7 +1324,7 @@ Arguments:
 
             output
                 .Should()
-                .Be("-a, -z, --aaa, --zzz    from a to z");
+                .Be("-z, -a, --zzz, --aaa    from a to z");
         }
 
         #endregion Options

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -555,7 +555,6 @@ namespace System.CommandLine.Help
                              .Aliases
                              .Select(r => r.SplitPrefix())
                              .OrderBy(r => r.prefix, StringComparer.OrdinalIgnoreCase)
-                             .ThenBy(r => r.alias, StringComparer.OrdinalIgnoreCase)
                              .GroupBy(t => t.alias)
                              .Select(t => t.First())
                              .Select(t => $"{t.prefix}{t.alias}");

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -7,11 +7,11 @@ namespace System.CommandLine.Help
     {
         public HelpOption() : base(new[]
         {
+            "-?",
+            "/?",
             "-h",
             "/h",
-            "--help",
-            "-?",
-            "/?"
+            "--help"
         }, Resources.Instance.HelpOptionDescription())
         {
             DisallowBinding = true;


### PR DESCRIPTION
Currently, `HelpBuilder` sorts help items, which results in the following behavior:

*Example 1*

```cs
new CommandEx(new[] { "migrations", "mig" })
```

```
Commands:
  mig, migrations    Commands to manage migrations.
```

*Example 2*

```cs
new CommandEx(new[] { "health-checks", "hc" })
new CommandEx(new[] { "mini-profiler", "mp" })
```

```
mini-profiler, mp                Generates the MiniProfiler script
hc, health-checks <from> <to>    Generates the HealthChecks script [from: '0' (the initial database), to: the last migration]
```

---

User defined order should be respected; otherwise, the aliases (`hc`) can be shown before the main command (`health-checks`). Also, multiple commands can result in odd ordering: `mini-profiler, mp` and `hc, health-checks` (main/alias, alias/main; see Example 2).

---

For completeness:
```cs
public CommandEx(string[] aliases, string description)
    : base(aliases.First(), description)
{
    foreach (var alias in aliases.Skip(1))
    {
        AddAlias(alias);
    }
}
```