### PR TITLE
Fixing confusing variable names in powershell suggest shim

### DIFF
--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1
@@ -1,13 +1,13 @@
 # dotnet suggest shell start
 $availableToComplete = (dotnet-suggest list) | Out-String
-$availableToCompleteArray = $availableToComplete.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries) 
+$availableToCompleteArray = $availableToComplete.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries)
 
 
     Register-ArgumentCompleter -Native -CommandName $availableToCompleteArray -ScriptBlock {
-        param($commandName, $wordToComplete, $cursorPosition)
-        $fullpath = (Get-Command $wordToComplete.CommandElements[0]).Source
+        param($wordToComplete, $commandAst, $cursorPosition)
+        $fullpath = (Get-Command $commandAst.CommandElements[0]).Source
 
-        $arguments = $wordToComplete.Extent.ToString().Replace('"', '\"')
+        $arguments = $commandAst.Extent.ToString().Replace('"', '\"')
         dotnet-suggest get -e $fullpath --position $cursorPosition -- "$arguments" | ForEach-Object {
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1
@@ -12,5 +12,5 @@ $availableToCompleteArray = $availableToComplete.Split([Environment]::NewLine, [
             [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
         }
     }
-$env:DOTNET_SUGGEST_SCRIPT_VERSION = "1.0.0"
+$env:DOTNET_SUGGEST_SCRIPT_VERSION = "1.0.1"
 # dotnet suggest script end


### PR DESCRIPTION
The shim uses incorrect variable names that may confuse readers.

`wordToComplete` is called `commandName`, and `commandAst` is called `wordToComplete`.