### PR TITLE
Add GetInvocationContext extension methods for Hosting

### DIFF
--- a/src/System.CommandLine.Hosting.Tests/HostingTests.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+
 using Xunit;
 
 namespace System.CommandLine.Hosting.Tests
@@ -253,6 +254,117 @@ namespace System.CommandLine.Hosting.Tests
             {
                 Service.SomeValue = myArgument;
             }
+        }
+
+        [Fact]
+        public static void GetInvocationContext_returns_non_null_instance()
+        {
+            bool ctxAsserted = false;
+            var parser = new CommandLineBuilder()
+                .UseHost(hostBuilder =>
+                {
+                    InvocationContext ctx = hostBuilder.GetInvocationContext();
+                    ctx.Should().NotBeNull();
+                    ctxAsserted = true;
+                })
+                .Build();
+
+            _ = parser.Invoke(string.Empty);
+            ctxAsserted.Should().BeTrue();
+        }
+
+        [Fact]
+        public static void GetInvocationContext_in_ConfigureServices_returns_non_null_instance()
+        {
+            bool ctxAsserted = false;
+            var parser = new CommandLineBuilder()
+                .UseHost(hostBuilder =>
+                {
+                    hostBuilder.ConfigureServices((hostingCtx, services) =>
+                    {
+                        InvocationContext invocationCtx = hostingCtx.GetInvocationContext();
+                        invocationCtx.Should().NotBeNull();
+                        ctxAsserted = true;
+                    });
+                })
+                .Build();
+
+            _ = parser.Invoke(string.Empty);
+            ctxAsserted.Should().BeTrue();
+        }
+
+        [Fact]
+        public static void GetInvocationContext_returns_same_instance_as_outer_middleware()
+        {
+            InvocationContext ctxCustom = null;
+            InvocationContext ctxHosting = null;
+
+            var parser = new CommandLineBuilder()
+                .UseMiddleware((context, next) =>
+                {
+                    ctxCustom = context;
+                    return next(context);
+                })
+                .UseHost(hostBuilder =>
+                {
+                    ctxHosting = hostBuilder.GetInvocationContext();
+                })
+                .Build();
+
+            _ = parser.Invoke(string.Empty);
+
+            ctxHosting.Should().BeSameAs(ctxCustom);
+        }
+
+        [Fact]
+        public static void GetInvocationContext_in_ConfigureServices_returns_same_instance_as_outer_middleware()
+        {
+            InvocationContext ctxCustom = null;
+            InvocationContext ctxConfigureServices = null;
+
+            var parser = new CommandLineBuilder()
+                .UseMiddleware((context, next) =>
+                {
+                    ctxCustom = context;
+                    return next(context);
+                })
+                .UseHost(hostBuilder =>
+                {
+                    hostBuilder.ConfigureServices((hostingCtx, services) =>
+                    {
+                        ctxConfigureServices = hostingCtx.GetInvocationContext();
+                    });
+                })
+                .Build();
+
+            _ = parser.Invoke(string.Empty);
+
+            ctxConfigureServices.Should().BeSameAs(ctxCustom);
+        }
+
+        [Fact]
+        public static void GetInvocationContext_throws_if_not_within_invocation()
+        {
+            var hostBuilder = new HostBuilder();
+            hostBuilder.Invoking(b =>
+            {
+                _ = b.GetInvocationContext();
+            })
+                .Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public static void GetInvocationContext_in_ConfigureServices_throws_if_not_within_invocation()
+        {
+            new HostBuilder().Invoking(b =>
+            {
+                b.ConfigureServices((hostingCtx, services) =>
+                {
+                    _ = hostingCtx.GetInvocationContext();
+                });
+                _ = b.Build();
+            })
+                .Should().Throw<InvalidOperationException>();
         }
     }
 }

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -116,5 +116,27 @@ namespace System.CommandLine.Hosting
 
             return builder;
         }
+
+        public static InvocationContext GetInvocationContext(this IHostBuilder hostBuilder)
+        {
+            _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));
+
+            if (hostBuilder.Properties.TryGetValue(typeof(InvocationContext), out var ctxObj) &&
+                ctxObj is InvocationContext invocationContext)
+                return invocationContext;
+
+            throw new InvalidOperationException("Host builder has no Invocation Context registered to it.");
+        }
+
+        public static InvocationContext GetInvocationContext(this HostBuilderContext context)
+        {
+            _ = context ?? throw new ArgumentNullException(nameof(context));
+
+            if (context.Properties.TryGetValue(typeof(InvocationContext), out var ctxObj) &&
+                ctxObj is InvocationContext invocationContext)
+                return invocationContext;
+
+            throw new InvalidOperationException("Host builder has no Invocation Context registered to it.");
+        }
     }
 }


### PR DESCRIPTION
Adds convenience extensions methods for obtaining the `InvocationContext` within `IHost` configuration. During a call to `UseHost` the `InvocationContext` is registered to the `IHostBuilder` using the `Properties` dictionary on it.

This PR adds two extension methods `GetInvocationContext` that enable easy and convenient access to the `InvocationContext` from within the Generic .NET Host typical `GetHostBuilder ` and `ConfigureServices` callbacks.

Generally, you'd want to access the `InvocationContext` via DI-resolution of the `IHost`, but while configuring the Host, there are scenarios where you'd require access to the `InvocationContext` before the DI-container is constructed.

One particular scenario this enables is the ability to register different services to DI duing a `ConfigureServices` callback based on which command-line arguments, options and which command was invoked.

The methods both throw an `InvalidOperationException` if the `Properties` if no `InvocationContext` has been registered to the `HostBuilder`.