### PR TITLE
Model binding should follow default values

### DIFF
--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -548,19 +548,79 @@ namespace System.CommandLine.Tests.Binding
         }
 
         [Fact]
-        public async Task Foo()
+        public async Task Bound_array_command_arguments_default_to_an_empty_array_when_not_specified()
         {
-            var rootCommand = new RootCommand("Collection arguments can be null when they are the only argument of a command.")
+            var rootCommand = new RootCommand("Command")
             {
                 new Argument<string[]>("names"),
             };
-            rootCommand.Handler = CommandHandler.Create<string[]>(DoIt);
+            rootCommand.Handler = CommandHandler.Create<string[]>(Handler);
             string[] passedNames = null;
             await rootCommand.InvokeAsync("");
 
             passedNames.Should().BeEmpty();
 
-            int DoIt(string[] names)
+            int Handler(string[] names)
+            {
+                passedNames = names;
+                return 0;
+            }
+        }
+
+        [Fact]
+        public async Task Bound_enumerable_command_arguments_default_to_an_empty_array_when_not_specified()
+        {
+            var rootCommand = new RootCommand("Command")
+            {
+                new Argument<IEnumerable<string>>("names"),
+            };
+            rootCommand.Handler = CommandHandler.Create<IEnumerable<string>>(Handler);
+            IEnumerable<string> passedNames = null;
+            await rootCommand.InvokeAsync("");
+
+            passedNames.Should().BeEmpty();
+
+            int Handler(IEnumerable<string> names)
+            {
+                passedNames = names;
+                return 0;
+            }
+        }
+
+        [Fact]
+        public async Task Bound_array_options_default_to_an_empty_array_when_not_specified()
+        {
+            var rootCommand = new RootCommand("Command")
+            {
+                new Option<string[]>("--names"),
+            };
+            rootCommand.Handler = CommandHandler.Create<string[]>(Handler);
+            string[] passedNames = null;
+            await rootCommand.InvokeAsync("");
+
+            passedNames.Should().BeEmpty();
+
+            int Handler(string[] names)
+            {
+                passedNames = names;
+                return 0;
+            }
+        }
+
+        [Fact]
+        public async Task Bound_enumerable_options_default_to_an_empty_array_when_not_specified()
+        {
+            var rootCommand = new RootCommand("Command")
+            {
+                new Option<IEnumerable<string>>("--names"),
+            };
+            rootCommand.Handler = CommandHandler.Create<IEnumerable<string>>(Handler);
+            IEnumerable<string> passedNames = null;
+            await rootCommand.InvokeAsync("");
+
+            passedNames.Should().BeEmpty();
+
+            int Handler(IEnumerable<string> names)
             {
                 passedNames = names;
                 return 0;
@@ -647,8 +707,6 @@ namespace System.CommandLine.Tests.Binding
             first.Should().Be(1);
             second.Should().Be(2);
         }
-
-      
 
         [Fact]
         public void Binder_does_not_match_on_partial_name()

--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -552,19 +552,17 @@ namespace System.CommandLine.Tests.Binding
         {
             var rootCommand = new RootCommand("Collection arguments can be null when they are the only argument of a command.")
             {
-                //new Argument<string>("id"),
                 new Argument<string[]>("names"),
             };
             rootCommand.Handler = CommandHandler.Create<string[]>(DoIt);
-
+            string[] passedNames = null;
             await rootCommand.InvokeAsync("");
 
-            static int DoIt(string[] names)
+            passedNames.Should().BeEmpty();
+
+            int DoIt(string[] names)
             {
-                if (names == null)
-                    Console.WriteLine("Null!");
-                else
-                    Console.WriteLine("Not null!");
+                passedNames = names;
                 return 0;
             }
         }

--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -548,6 +548,28 @@ namespace System.CommandLine.Tests.Binding
         }
 
         [Fact]
+        public async Task Foo()
+        {
+            var rootCommand = new RootCommand("Collection arguments can be null when they are the only argument of a command.")
+            {
+                //new Argument<string>("id"),
+                new Argument<string[]>("names"),
+            };
+            rootCommand.Handler = CommandHandler.Create<string[]>(DoIt);
+
+            await rootCommand.InvokeAsync("");
+
+            static int DoIt(string[] names)
+            {
+                if (names == null)
+                    Console.WriteLine("Null!");
+                else
+                    Console.WriteLine("Not null!");
+                return 0;
+            }
+        }
+
+        [Fact]
         public void Custom_ModelBinders_specified_via_BindingContext_can_be_used_for_option_binding()
         {
             ClassWithSetter<int> boundInstance = null;

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -19,7 +19,14 @@ namespace System.CommandLine.Parsing
 
                 if (valueDescriptor.ValueName.IsMatch(argument.Name))
                 {
-                    value = commandResult.FindResultFor(argument)?.GetValueOrDefault();
+                    if (commandResult.FindResultFor(argument) is { } argumentResult)
+                    {
+                        value = argumentResult.GetValueOrDefault();
+                    }
+                    else
+                    {
+                        value = valueDescriptor.GetDefaultValue();
+                    }
                     return true;
                 }
             }


### PR DESCRIPTION
Fixes #1233 
Previous fixes for the having unspecified collection values default to non-null were not affecting the model binding. This addresses that difference and now properly calls to get the default value even when there is no ArgumentResult to work with.

