### PR TITLE
Avoid build failures when .NET 462 targeting pack is missing

### DIFF
--- a/src/System.CommandLine.Hosting.Tests/System.CommandLine.Hosting.Tests.csproj
+++ b/src/System.CommandLine.Hosting.Tests/System.CommandLine.Hosting.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'!='net5.0'">

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="5.2.2" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />
   </ItemGroup>


### PR DESCRIPTION
These two test projects multitarget net462 on Windows, but if the
targeting pack is missing, the build will fail. This can be avoided
by installing the reference assemblies package, which will automatically
provide the right dependencies according to the TFM.

Rather than depending on Microsoft.NETFramework.ReferenceAssemblies.net462,
this adds the metapackage, which will automatically pick the right dependency
if the projects are ever updated (i.e. to net472, which sounds like it would
be a good idea.

Fixes #1252