### PR TITLE
Localizing remaining string resources

### DIFF
--- a/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
@@ -1,10 +1,10 @@
-﻿using System.CommandLine.Builder;
-using System.CommandLine.Invocation;
+﻿using FluentAssertions;
+using System.CommandLine.Builder;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Xunit;
+using static System.Environment;
 
 namespace System.CommandLine.Tests.Invocation
 {
@@ -27,7 +27,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await result.InvokeAsync(_console);
 
-            _console.Out.ToString().Should().Contain("'niof' was not matched. Did you mean 'info'?");
+            _console.Out.ToString().Should().Contain($"'niof' was not matched. Did you mean one of the following?{NewLine}info");
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await result.InvokeAsync(_console);
 
-            _console.Out.ToString().Should().Contain("'sertor' was not matched. Did you mean 'restore'?");
+            _console.Out.ToString().Should().Contain($"'sertor' was not matched. Did you mean one of the following?{NewLine}restore");
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await result.InvokeAsync(_console);
 
-            _console.Out.ToString().Should().Contain("'een' was not matched. Did you mean 'seen', or 'been'?");
+            _console.Out.ToString().Should().Contain($"'een' was not matched. Did you mean one of the following?{NewLine}seen{NewLine}been");
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await result.InvokeAsync(_console);
 
-            _console.Out.ToString().Should().Contain("'een' was not matched. Did you mean 'been'?");
+            _console.Out.ToString().Should().Contain($"'een' was not matched. Did you mean one of the following?{NewLine}been");
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await result.InvokeAsync(_console);
 
-            _console.Out.ToString().Should().Contain("'een' was not matched. Did you mean 'been'?");
+            _console.Out.ToString().Should().Contain($"'een' was not matched. Did you mean one of the following?{NewLine}been");
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await result.InvokeAsync(_console);
 
-            _console.Out.ToString().Should().Contain("'-all' was not matched. Did you mean '-call'?");
+            _console.Out.ToString().Should().Contain($"'-all' was not matched. Did you mean one of the following?{NewLine}-call");
         }
     }
 }

--- a/src/System.CommandLine.Tests/ResourceLocalizationTests.cs
+++ b/src/System.CommandLine.Tests/ResourceLocalizationTests.cs
@@ -10,12 +10,12 @@ using Xunit;
 
 namespace System.CommandLine.Tests
 {
-    public class ValidationMessageLocalizationTests
+    public class ResourceLocalizationTests
     {
         [Fact]
         public void Default_validation_messages_can_be_replaced_in_order_to_add_localization_support()
         {
-            var messages = new FakeValidationMessages("the-message");
+            var messages = new FakeResources("the-message");
 
             var command = new Command("the-command")
             {
@@ -24,7 +24,7 @@ namespace System.CommandLine.Tests
                     Arity = ArgumentArity.ExactlyOne
                 }
             };
-            var parser = new Parser(new CommandLineConfiguration(new[] { command }, validationMessages: messages));
+            var parser = new Parser(new CommandLineConfiguration(new[] { command }, resources: messages));
             var result = parser.Parse("the-command");
 
             result.Errors
@@ -36,7 +36,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Default_validation_messages_can_be_replaced_using_CommandLineBuilder_in_order_to_add_localization_support()
         {
-            var messages = new FakeValidationMessages("the-message");
+            var messages = new FakeResources("the-message");
 
             var parser = new CommandLineBuilder(new Command("the-command")
                          {
@@ -45,7 +45,7 @@ namespace System.CommandLine.Tests
                                  Arity = ArgumentArity.ExactlyOne
                              }
                          })
-                         .UseValidationMessages(messages)
+                         .UseResources(messages)
                          .Build();
 
             var result = parser.Parse("the-command");
@@ -56,11 +56,11 @@ namespace System.CommandLine.Tests
                   .Contain("the-message");
         }
 
-        public class FakeValidationMessages : Resources
+        public class FakeResources : Resources
         {
             private readonly string message;
 
-            public FakeValidationMessages(string message)
+            public FakeResources(string message)
             {
                 this.message = message;
             }

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -71,14 +71,14 @@ namespace System.CommandLine
 
                 return new MissingArgumentConversionResult(
                     argument,
-                    symbolResult.ValidationMessages.RequiredArgumentMissing(symbolResult));
+                    symbolResult.Resources.RequiredArgumentMissing(symbolResult));
             }
 
             if (tokenCount > maximumNumberOfValues)
             {
                 return new TooManyArgumentsConversionResult(
                     argument,
-                    symbolResult!.ValidationMessages.ExpectsOneArgument(symbolResult));
+                    symbolResult!.Resources.ExpectsOneArgument(symbolResult));
             }
 
             return null;

--- a/src/System.CommandLine/ArgumentExtensions.cs
+++ b/src/System.CommandLine/ArgumentExtensions.cs
@@ -48,7 +48,7 @@ namespace System.CommandLine
                                       symbol.Tokens
                                             .Select(t => t.Value)
                                             .Where(filePath => !File.Exists(filePath))
-                                            .Select(symbol.ValidationMessages.FileDoesNotExist)
+                                            .Select(symbol.Resources.FileDoesNotExist)
                                             .FirstOrDefault());
             return argument;
         }
@@ -59,7 +59,7 @@ namespace System.CommandLine
                                       symbol.Tokens
                                             .Select(t => t.Value)
                                             .Where(filePath => !Directory.Exists(filePath))
-                                            .Select(symbol.ValidationMessages.DirectoryDoesNotExist)
+                                            .Select(symbol.Resources.DirectoryDoesNotExist)
                                             .FirstOrDefault());
             return argument;
         }
@@ -70,7 +70,7 @@ namespace System.CommandLine
                                       symbol.Tokens
                                             .Select(t => t.Value)
                                             .Where(filePath => !Directory.Exists(filePath) && !File.Exists(filePath))
-                                            .Select(symbol.ValidationMessages.FileOrDirectoryDoesNotExist)
+                                            .Select(symbol.Resources.FileOrDirectoryDoesNotExist)
                                             .FirstOrDefault());
             return argument;
         }
@@ -84,7 +84,7 @@ namespace System.CommandLine
                     a => a.Tokens
                           .Select(t => t.Value)
                           .Where(filePath => !File.Exists(filePath))
-                          .Select(a.ValidationMessages.FileDoesNotExist)
+                          .Select(a.Resources.FileDoesNotExist)
                           .FirstOrDefault());
             }
             else if (typeof(IEnumerable<DirectoryInfo>).IsAssignableFrom(typeof(T)))
@@ -93,7 +93,7 @@ namespace System.CommandLine
                     a => a.Tokens
                           .Select(t => t.Value)
                           .Where(filePath => !Directory.Exists(filePath))
-                          .Select(a.ValidationMessages.DirectoryDoesNotExist)
+                          .Select(a.Resources.DirectoryDoesNotExist)
                           .FirstOrDefault());
             }
             else
@@ -102,7 +102,7 @@ namespace System.CommandLine
                     a => a.Tokens
                           .Select(t => t.Value)
                           .Where(filePath => !Directory.Exists(filePath) && !File.Exists(filePath))
-                          .Select(a.ValidationMessages.FileOrDirectoryDoesNotExist)
+                          .Select(a.Resources.FileOrDirectoryDoesNotExist)
                           .FirstOrDefault());
             }
 
@@ -127,7 +127,7 @@ namespace System.CommandLine
 
                     if (invalidCharactersIndex >= 0)
                     {
-                        return symbol.ValidationMessages.InvalidCharactersInPath(token.Value[invalidCharactersIndex]);
+                        return symbol.Resources.InvalidCharactersInPath(token.Value[invalidCharactersIndex]);
                     }
                 }
 
@@ -152,7 +152,7 @@ namespace System.CommandLine
 
                     if (invalidCharactersIndex >= 0)
                     {
-                        return symbol.ValidationMessages.InvalidCharactersInFileName(token.Value[invalidCharactersIndex]);
+                        return symbol.Resources.InvalidCharactersInFileName(token.Value[invalidCharactersIndex]);
                     }
                 }
 

--- a/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
+++ b/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
@@ -23,23 +23,19 @@ namespace System.CommandLine.Binding
             if (argument is Argument a &&
                 a.Parents.Count == 1)
             {
-                // TODO: (FailedArgumentTypeConversionResult) localize
-
                 var firstParent = (IIdentifierSymbol) a.Parents[0];
-
-                var symbolType =
-                    firstParent switch {
-                        ICommand _ => "command",
-                        IOption _ => "option",
-                        _ => null
-                        };
-
                 var alias = firstParent.Aliases.First();
 
-                return $"Cannot parse argument '{value}' for {symbolType} '{alias}' as expected type {expectedType}.";
+                switch(firstParent)
+                {
+                    case ICommand _:
+                        return Resources.Instance.ArgumentConversionCannotParseForCommand(value, alias, expectedType);
+                    case IOption _:
+                        return Resources.Instance.ArgumentConversionCannotParseForOption(value, alias, expectedType);
+                }
             }
 
-            return $"Cannot parse argument '{value}' as expected type {expectedType}.";
+            return Resources.Instance.ArgumentConversionCannotParse(value, expectedType);
         }
     }
 }

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -30,7 +30,7 @@ namespace System.CommandLine.Builder
 
         internal HelpOption? HelpOption { get; set; }
 
-        internal Resources? ValidationMessages { get; set; }
+        internal Resources? Resources { get; set; }
 
         public Parser Build()
         {
@@ -41,7 +41,7 @@ namespace System.CommandLine.Builder
                     new[] { rootCommand },
                     enablePosixBundling: EnablePosixBundling,
                     enableDirectives: EnableDirectives,
-                    validationMessages: ValidationMessages,
+                    resources: Resources,
                     responseFileHandling: ResponseFileHandling,
                     middlewarePipeline: _middlewareList.OrderBy(m => m.order)
                                                        .Select(m => m.middleware)

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -222,9 +222,7 @@ namespace System.CommandLine.Builder
                     string debuggableProcessNames = GetEnvironmentVariable(environmentVariableName);
                     if (string.IsNullOrWhiteSpace(debuggableProcessNames))
                     {
-                        context.Console.Error.WriteLine("Debug directive specified, but no process names are listed as allowed for debug.");
-                        context.Console.Error.WriteLine($"Add your process name to the '{environmentVariableName}' environment variable.");
-                        context.Console.Error.WriteLine($"The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{environmentVariableName}={process.ProcessName}'");
+                        context.Console.Error.WriteLine(Resources.Instance.DebugDirectiveExecutableNotSpecified(environmentVariableName, process.ProcessName));
                         context.ExitCode = errorExitCode ?? 1;
                         return;
                     }
@@ -234,9 +232,7 @@ namespace System.CommandLine.Builder
                         if (processNames.Contains(process.ProcessName, StringComparer.Ordinal))
                         {
                             var processId = process.Id;
-
-                            context.Console.Out.WriteLine($"Attach your debugger to process {processId} ({process.ProcessName}).");
-                            var startTime = DateTime.Now;
+                            context.Console.Out.WriteLine(Resources.Instance.DebugDirectiveAttachToProcess(processId, process.ProcessName));
                             while (!Debugger.IsAttached)
                             {
                                 await Task.Delay(500);
@@ -244,7 +240,7 @@ namespace System.CommandLine.Builder
                         }
                         else
                         {
-                            context.Console.Error.WriteLine($"Process name '{process.ProcessName}' is not included in the list of debuggable process names in the {environmentVariableName} environment variable ('{debuggableProcessNames}')");
+                            context.Console.Error.WriteLine(Resources.Instance.DebugDirectiveProcessNotIncludedInEnvironmentVariable(process.ProcessName, environmentVariableName, debuggableProcessNames));
                             context.ExitCode = errorExitCode ?? 1;
                             return;
                         }
@@ -325,7 +321,7 @@ namespace System.CommandLine.Builder
                     context.Console.ResetTerminalForegroundColor();
                     context.Console.SetTerminalForegroundRed();
 
-                    context.Console.Error.Write("Unhandled exception: ");
+                    context.Console.Error.Write(Resources.Instance.ExceptionHandlerHeader());
                     context.Console.Error.WriteLine(exception.ToString());
 
                     context.Console.ResetTerminalForegroundColor();
@@ -527,12 +523,12 @@ namespace System.CommandLine.Builder
 
             var versionOption = new Option<bool>(
                 "--version",
-                description: "Show version information",
+                description: Resources.Instance.VersionOptionDescription(),
                 parseArgument: result =>
                 {
                     if (result.FindResultFor(command)?.Children.Count > 1)
                     {
-                        result.ErrorMessage = "--version option cannot be combined with other arguments.";
+                        result.ErrorMessage = Resources.Instance.VersionOptionCannotBeCombinedWithOtherArguments("--version");
                         return false;
                     }
 

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -189,11 +189,11 @@ namespace System.CommandLine.Builder
 
                         await dotnetSuggestProcess.CompleteAsync();
 
-                        return $"{dotnetSuggestProcess.StartInfo.FileName} exited with code {dotnetSuggestProcess.ExitCode}{NewLine}OUT:{NewLine}{stdOut}{NewLine}ERR:{NewLine}{stdErr}";
+                        return Resources.Instance.DotnetSuggestExitMessage(dotnetSuggestProcess.StartInfo.FileName, dotnetSuggestProcess.ExitCode, stdOut.ToString(), stdErr.ToString());
                     }
                     catch (Exception exception)
                     {
-                        return $"Exception during registration:{NewLine}{exception}";
+                        return Resources.Instance.DotnetSuggestExceptionOccurred(exception);
                     }
                     finally
                     {

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -506,11 +506,11 @@ namespace System.CommandLine.Builder
             return builder;
         }
 
-        public static CommandLineBuilder UseValidationMessages(
+        public static CommandLineBuilder UseResources(
             this CommandLineBuilder builder,
             Resources validationMessages)
         {
-            builder.ValidationMessages = validationMessages;
+            builder.Resources = validationMessages;
             return builder;
         }
 

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -25,7 +25,7 @@ namespace System.CommandLine
         /// <param name="symbols">The symbols to parse.</param>
         /// <param name="enablePosixBundling"><c>true</c> to enable POSIX bundling; otherwise, <c>false</c>.</param>
         /// <param name="enableDirectives"><c>true</c> to enable directive parsing; otherwise, <c>false</c>.</param>
-        /// <param name="validationMessages">Provide custom validation messages.</param>
+        /// <param name="resources">Provide custom validation messages.</param>
         /// <param name="responseFileHandling">One of the enumeration values that specifies how response files (.rsp) are handled.</param>
         /// <param name="middlewarePipeline">Provide a custom middleware pipeline.</param>
         /// <param name="helpBuilderFactory">Provide a custom help builder.</param>
@@ -35,7 +35,7 @@ namespace System.CommandLine
             IReadOnlyList<Symbol> symbols,
             bool enablePosixBundling = true,
             bool enableDirectives = true,
-            Resources? validationMessages = null,
+            Resources? resources = null,
             ResponseFileHandling responseFileHandling = ResponseFileHandling.ParseArgsAsLineSeparated,
             IReadOnlyCollection<InvocationMiddleware>? middlewarePipeline = null,
             Func<BindingContext, IHelpBuilder>? helpBuilderFactory = null,
@@ -83,7 +83,7 @@ namespace System.CommandLine
 
             EnablePosixBundling = enablePosixBundling;
             EnableDirectives = enableDirectives;
-            ValidationMessages = validationMessages ?? Resources.Instance;
+            Resources = resources ?? Resources.Instance;
             ResponseFileHandling = responseFileHandling;
             Middleware = middlewarePipeline ?? new List<InvocationMiddleware>();
             HelpBuilderFactory = helpBuilderFactory ?? (context => 
@@ -146,9 +146,9 @@ namespace System.CommandLine
         public bool EnablePosixBundling { get; }
 
         /// <summary>
-        /// Gets the validation messages.
+        /// Gets the localizable resources.
         /// </summary>
-        public Resources ValidationMessages { get; }
+        public Resources Resources { get; }
 
         internal Func<BindingContext, IHelpBuilder> HelpBuilderFactory { get; }
 

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -27,11 +27,14 @@ namespace System.CommandLine.Invocation
             for (var i = 0; i < result.UnmatchedTokens.Count; i++)
             {
                 var token = result.UnmatchedTokens[i];
-                string suggestions = string.Join(", or ", GetPossibleTokens(result.CommandResult.Command, token).Select(x => $"'{x}'"));
-
-                if (suggestions.Length > 0)
+                var suggestions = GetPossibleTokens(result.CommandResult.Command, token).ToList();
+                if (suggestions.Count > 0)
                 {
-                    console.Out.WriteLine($"'{token}' was not matched. Did you mean {suggestions}?");
+                    console.Out.WriteLine(Resources.Instance.SuggestionsTokenNotMatched(token));
+                    foreach(string suggestion in suggestions)
+                    {
+                        console.Out.WriteLine(suggestion);
+                    }
                 }
             }
         }

--- a/src/System.CommandLine/OptionExtensions.cs
+++ b/src/System.CommandLine/OptionExtensions.cs
@@ -49,7 +49,7 @@ namespace System.CommandLine
                     a.Tokens
                      .Select(t => t.Value)
                      .Where(filePath => !File.Exists(filePath))
-                     .Select(a.ValidationMessages.FileDoesNotExist)
+                     .Select(a.Resources.FileDoesNotExist)
                      .FirstOrDefault());
 
             return option;
@@ -62,7 +62,7 @@ namespace System.CommandLine
                     a.Tokens
                      .Select(t => t.Value)
                      .Where(filePath => !Directory.Exists(filePath))
-                     .Select(a.ValidationMessages.DirectoryDoesNotExist)
+                     .Select(a.Resources.DirectoryDoesNotExist)
                      .FirstOrDefault());
 
             return option;
@@ -75,7 +75,7 @@ namespace System.CommandLine
                     a.Tokens
                      .Select(t => t.Value)
                      .Where(filePath => !Directory.Exists(filePath) && !File.Exists(filePath))
-                     .Select(a.ValidationMessages.FileOrDirectoryDoesNotExist)
+                     .Select(a.Resources.FileOrDirectoryDoesNotExist)
                      .FirstOrDefault());
 
             return option;

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -61,7 +61,7 @@ namespace System.CommandLine.Parsing
                 for (var i = 0; i < unmatchedTokens.Count; i++)
                 {
                     var token = unmatchedTokens[i];
-                    _errors.Add(new ParseError(parser.Configuration.ValidationMessages.UnrecognizedCommandOrArgument(token.Value)));
+                    _errors.Add(new ParseError(parser.Configuration.Resources.UnrecognizedCommandOrArgument(token.Value)));
                 }
             }
         }

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -52,7 +52,7 @@ namespace System.CommandLine.Parsing
             _rootCommandResult = new RootCommandResult(
                 rootCommandNode.Command,
                 rootCommandNode.Token);
-            _rootCommandResult.ValidationMessages = _parser.Configuration.ValidationMessages;
+            _rootCommandResult.Resources = _parser.Configuration.Resources;
 
             _innermostCommandResult = _rootCommandResult;
         }
@@ -290,7 +290,7 @@ namespace System.CommandLine.Parsing
             _errors.Insert(
                 0,
                 new ParseError(
-                    _innermostCommandResult.ValidationMessages.RequiredCommandWasNotProvided(),
+                    _innermostCommandResult.Resources.RequiredCommandWasNotProvided(),
                     _innermostCommandResult));
         }
 

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -346,7 +346,7 @@ namespace System.CommandLine.Parsing
                 }
                 catch (FileNotFoundException)
                 {
-                    var message = configuration.ValidationMessages
+                    var message = configuration.Resources
                                                .ResponseFileNotFound(filePath);
 
                     errorList.Add(
@@ -354,7 +354,7 @@ namespace System.CommandLine.Parsing
                 }
                 catch (IOException e)
                 {
-                    var message = configuration.ValidationMessages
+                    var message = configuration.Resources
                                                .ErrorReadingResponseFile(filePath, e);
 
                     errorList.Add(

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -8,7 +8,7 @@ namespace System.CommandLine.Parsing
     public abstract class SymbolResult
     {
         private protected readonly List<Token> _tokens = new List<Token>();
-        private Resources? _validationMessages;
+        private Resources? _resources;
         private readonly Dictionary<IArgument, ArgumentResult> _defaultArgumentValues = new Dictionary<IArgument, ArgumentResult>();
 
         private protected SymbolResult(
@@ -53,10 +53,10 @@ namespace System.CommandLine.Parsing
             return value;
         }
 
-        protected internal Resources ValidationMessages
+        protected internal Resources Resources
         {
-            get => _validationMessages ??= Parent?.ValidationMessages ?? Resources.Instance;
-            set => _validationMessages = value;
+            get => _resources ??= Parent?.Resources ?? Resources.Instance;
+            set => _resources = value;
         }
 
         internal void AddToken(Token token) => _tokens.Add(token);
@@ -92,7 +92,7 @@ namespace System.CommandLine.Parsing
                     if (!argument.AllowedValues.Contains(token.Value))
                     {
                         return new ParseError(
-                            ValidationMessages
+                            Resources
                                 .UnrecognizedArgument(token.Value, argument.AllowedValues),
                             this);
                     }

--- a/src/System.CommandLine/Properties/Resources.Designer.cs
+++ b/src/System.CommandLine/Properties/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; as expected type {1}..
+        /// </summary>
+        internal static string ArgumentConversionCannotParse {
+            get {
+                return ResourceManager.GetString("ArgumentConversionCannotParse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; for command &apos;{1}&apos; as expected type {2}..
+        /// </summary>
+        internal static string ArgumentConversionCannotParseForCommand {
+            get {
+                return ResourceManager.GetString("ArgumentConversionCannotParseForCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; for option &apos;{1}&apos; as expected type {2}..
+        /// </summary>
+        internal static string ArgumentConversionCannotParseForOption {
+            get {
+                return ResourceManager.GetString("ArgumentConversionCannotParseForOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Command &apos;{0}&apos; expects no more than {1} arguments, but {2} were provided..
         /// </summary>
         internal static string CommandExpectsFewerArguments {
@@ -131,6 +158,29 @@ namespace System.CommandLine.Properties {
         internal static string DirectoryDoesNotExist {
             get {
                 return ResourceManager.GetString("DirectoryDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exception during registration:
+        ///{0}.
+        /// </summary>
+        internal static string DotnetSuggestExceptionOccurred {
+            get {
+                return ResourceManager.GetString("DotnetSuggestExceptionOccurred", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} exited with code {1}
+        ///OUT:
+        ///{2}
+        ///ERR:
+        ///{3}.
+        /// </summary>
+        internal static string DotnetSuggestExitMessage {
+            get {
+                return ResourceManager.GetString("DotnetSuggestExitMessage", resourceCulture);
             }
         }
         

--- a/src/System.CommandLine/Properties/Resources.Designer.cs
+++ b/src/System.CommandLine/Properties/Resources.Designer.cs
@@ -97,6 +97,35 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attach your debugger to process {0} ({1})..
+        /// </summary>
+        internal static string DebugDirectiveAttachToProcess {
+            get {
+                return ResourceManager.GetString("DebugDirectiveAttachToProcess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Debug directive specified, but no process names are listed as allowed for debug.
+        ///Add your process name to the &apos;{0}&apos; environment variable.
+        ///The value of the variable should be the name of the processes, separated by a semi-colon &apos;;&apos;, for example &apos;{0}={1}&apos;.
+        /// </summary>
+        internal static string DebugDirectiveExecutableNotSpecified {
+            get {
+                return ResourceManager.GetString("DebugDirectiveExecutableNotSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Process name &apos;{0}&apos; is not included in the list of debuggable process names in the {1} environment variable (&apos;{2}&apos;).
+        /// </summary>
+        internal static string DebugDirectiveProcessNotIncludedInEnvironmentVariable {
+            get {
+                return ResourceManager.GetString("DebugDirectiveProcessNotIncludedInEnvironmentVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Directory does not exist: {0}.
         /// </summary>
         internal static string DirectoryDoesNotExist {
@@ -111,6 +140,15 @@ namespace System.CommandLine.Properties {
         internal static string ErrorReadingResponseFile {
             get {
                 return ResourceManager.GetString("ErrorReadingResponseFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unhandled exception: .
+        /// </summary>
+        internal static string ExceptionHandlerHeader {
+            get {
+                return ResourceManager.GetString("ExceptionHandlerHeader", resourceCulture);
             }
         }
         
@@ -187,15 +225,6 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Character not allowed in a file name: {0}.
-        /// </summary>
-        internal static string InvalidCharactersInFileName {
-            get {
-                return ResourceManager.GetString("InvalidCharactersInFileName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to (REQUIRED).
         /// </summary>
         internal static string HelpOptionsRequired {
@@ -246,6 +275,15 @@ namespace System.CommandLine.Properties {
         internal static string HelpUsageTile {
             get {
                 return ResourceManager.GetString("HelpUsageTile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Character not allowed in a file name: {0}.
+        /// </summary>
+        internal static string InvalidCharactersInFileName {
+            get {
+                return ResourceManager.GetString("InvalidCharactersInFileName", resourceCulture);
             }
         }
         
@@ -313,6 +351,15 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; was not matched. Did you mean one of the following?.
+        /// </summary>
+        internal static string SuggestionsTokenNotMatched {
+            get {
+                return ResourceManager.GetString("SuggestionsTokenNotMatched", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Argument &apos;{0}&apos; not recognized. Must be one of:{1}.
         /// </summary>
         internal static string UnrecognizedArgument {
@@ -327,6 +374,24 @@ namespace System.CommandLine.Properties {
         internal static string UnrecognizedCommandOrArgument {
             get {
                 return ResourceManager.GetString("UnrecognizedCommandOrArgument", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} option cannot be combined with other arguments..
+        /// </summary>
+        internal static string VersionOptionCannotBeCombinedWithOtherArguments {
+            get {
+                return ResourceManager.GetString("VersionOptionCannotBeCombinedWithOtherArguments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show version information.
+        /// </summary>
+        internal static string VersionOptionDescription {
+            get {
+                return ResourceManager.GetString("VersionOptionDescription", resourceCulture);
             }
         }
     }

--- a/src/System.CommandLine/Properties/Resources.resx
+++ b/src/System.CommandLine/Properties/Resources.resx
@@ -207,4 +207,27 @@
   <data name="HelpCommandsTitle" xml:space="preserve">
     <value>Commands:</value>
   </data>
+  <data name="DebugDirectiveAttachToProcess" xml:space="preserve">
+    <value>Attach your debugger to process {0} ({1}).</value>
+  </data>
+  <data name="DebugDirectiveExecutableNotSpecified" xml:space="preserve">
+    <value>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</value>
+  </data>
+  <data name="DebugDirectiveProcessNotIncludedInEnvironmentVariable" xml:space="preserve">
+    <value>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</value>
+  </data>
+  <data name="ExceptionHandlerHeader" xml:space="preserve">
+    <value>Unhandled exception: </value>
+  </data>
+  <data name="SuggestionsTokenNotMatched" xml:space="preserve">
+    <value>'{0}' was not matched. Did you mean one of the following?</value>
+  </data>
+  <data name="VersionOptionCannotBeCombinedWithOtherArguments" xml:space="preserve">
+    <value>{0} option cannot be combined with other arguments.</value>
+  </data>
+  <data name="VersionOptionDescription" xml:space="preserve">
+    <value>Show version information</value>
+  </data>
 </root>

--- a/src/System.CommandLine/Properties/Resources.resx
+++ b/src/System.CommandLine/Properties/Resources.resx
@@ -230,4 +230,24 @@ The value of the variable should be the name of the processes, separated by a se
   <data name="VersionOptionDescription" xml:space="preserve">
     <value>Show version information</value>
   </data>
+  <data name="ArgumentConversionCannotParse" xml:space="preserve">
+    <value>Cannot parse argument '{0}' as expected type {1}.</value>
+  </data>
+  <data name="ArgumentConversionCannotParseForCommand" xml:space="preserve">
+    <value>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</value>
+  </data>
+  <data name="ArgumentConversionCannotParseForOption" xml:space="preserve">
+    <value>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</value>
+  </data>
+  <data name="DotnetSuggestExceptionOccurred" xml:space="preserve">
+    <value>Exception during registration:
+{0}</value>
+  </data>
+  <data name="DotnetSuggestExitMessage" xml:space="preserve">
+    <value>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</value>
+  </data>
 </root>

--- a/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.de.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.de.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.de.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.de.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.es.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.es.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.es.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.es.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.it.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.it.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.it.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.it.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
@@ -142,6 +142,11 @@
         <target state="new">Response file not found '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="SuggestionsTokenNotMatched">
+        <source>'{0}' was not matched. Did you mean one of the following?</source>
+        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
         <target state="new">Argument '{0}' not recognized. Must be one of:{1}</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentConversionCannotParse">
+        <source>Cannot parse argument '{0}' as expected type {1}.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForCommand">
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ArgumentConversionCannotParseForOption">
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
         <source>Command '{0}' expects no more than {1} arguments, but {2} were provided.</source>
         <target state="new">Command '{0}' expects no more than {1} arguments, but {2} were provided.</target>
@@ -22,14 +37,58 @@
         <target state="new">Required argument missing for command: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DebugDirectiveAttachToProcess">
+        <source>Attach your debugger to process {0} ({1}).</source>
+        <target state="new">Attach your debugger to process {0} ({1}).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveExecutableNotSpecified">
+        <source>Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</source>
+        <target state="new">Debug directive specified, but no process names are listed as allowed for debug.
+Add your process name to the '{0}' environment variable.
+The value of the variable should be the name of the processes, separated by a semi-colon ';', for example '{0}={1}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DebugDirectiveProcessNotIncludedInEnvironmentVariable">
+        <source>Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</source>
+        <target state="new">Process name '{0}' is not included in the list of debuggable process names in the {1} environment variable ('{2}')</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: {0}</source>
         <target state="new">Directory does not exist: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetSuggestExceptionOccurred">
+        <source>Exception during registration:
+{0}</source>
+        <target state="new">Exception during registration:
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DotnetSuggestExitMessage">
+        <source>{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</source>
+        <target state="new">{0} exited with code {1}
+OUT:
+{2}
+ERR:
+{3}</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
         <target state="new">Error reading response file '{0}': {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionHandlerHeader">
+        <source>Unhandled exception: </source>
+        <target state="new">Unhandled exception: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
@@ -155,6 +214,16 @@
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'</source>
         <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
+        <source>{0} option cannot be combined with other arguments.</source>
+        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Show version information</source>
+        <target state="new">Show version information</target>
         <note />
       </trans-unit>
     </body>

--- a/src/System.CommandLine/Resources.cs
+++ b/src/System.CommandLine/Resources.cs
@@ -126,12 +126,21 @@ namespace System.CommandLine
         public virtual string DebugDirectiveProcessNotIncludedInEnvironmentVariable(string processName, string environmentVariableName, string processNames)
             => GetResourceString(Properties.Resources.DebugDirectiveProcessNotIncludedInEnvironmentVariable, processName, environmentVariableName, processNames);
 
-        /*
-         * Cannot parse argument '{0}' for {1} '{2}' as expected type {3}.
-Cannot parse argument '{0}' as expected type {1}.
-{0} exited with code {1}{2}OUT:{3}{4}{5}ERR:{6}{7}
-Exception during registration:{0}{1}
-        */
+        public virtual string DotnetSuggestExceptionOccurred(Exception exception)
+            => GetResourceString(Properties.Resources.DotnetSuggestExceptionOccurred, exception);
+
+        public virtual string DotnetSuggestExitMessage(string dotnetSuggestName, int exitCode, string standardOut, string standardError)
+            => GetResourceString(Properties.Resources.DotnetSuggestExitMessage, dotnetSuggestName, exitCode, standardOut, standardError);
+
+        public virtual string ArgumentConversionCannotParse(string value, Type expectedType)
+            => GetResourceString(Properties.Resources.ArgumentConversionCannotParse, value, expectedType);
+
+        public virtual string ArgumentConversionCannotParseForCommand(string value, string commandAlias, Type expectedType)
+            => GetResourceString(Properties.Resources.ArgumentConversionCannotParseForCommand, value, commandAlias, expectedType);
+
+        public virtual string ArgumentConversionCannotParseForOption(string value, string optionAlias, Type expectedType)
+            => GetResourceString(Properties.Resources.ArgumentConversionCannotParseForOption, value, optionAlias, expectedType);
+
         protected virtual string GetResourceString(string resourceString, params object[] formatArguments)
         {
             if (resourceString is null)

--- a/src/System.CommandLine/Resources.cs
+++ b/src/System.CommandLine/Resources.cs
@@ -105,6 +105,33 @@ namespace System.CommandLine
         public virtual string HelpAdditionalArgumentsDescription() =>
             GetResourceString(Properties.Resources.HelpAdditionalArgumentsDescription);
 
+        public virtual string SuggestionsTokenNotMatched(string token)
+            => GetResourceString(Properties.Resources.SuggestionsTokenNotMatched, token);
+
+        public virtual string VersionOptionDescription()
+            => GetResourceString(Properties.Resources.VersionOptionDescription);
+
+        public virtual string VersionOptionCannotBeCombinedWithOtherArguments(string optionAlias)
+            => GetResourceString(Properties.Resources.VersionOptionCannotBeCombinedWithOtherArguments, optionAlias);
+
+        public virtual string ExceptionHandlerHeader()
+            => GetResourceString(Properties.Resources.ExceptionHandlerHeader);
+
+        public virtual string DebugDirectiveExecutableNotSpecified(string environmentVariableName, string processName)
+            => GetResourceString(Properties.Resources.DebugDirectiveExecutableNotSpecified, environmentVariableName, processName);
+
+        public virtual string DebugDirectiveAttachToProcess(int processId, string processName)
+            => GetResourceString(Properties.Resources.DebugDirectiveAttachToProcess, processId, processName);
+
+        public virtual string DebugDirectiveProcessNotIncludedInEnvironmentVariable(string processName, string environmentVariableName, string processNames)
+            => GetResourceString(Properties.Resources.DebugDirectiveProcessNotIncludedInEnvironmentVariable, processName, environmentVariableName, processNames);
+
+        /*
+         * Cannot parse argument '{0}' for {1} '{2}' as expected type {3}.
+Cannot parse argument '{0}' as expected type {1}.
+{0} exited with code {1}{2}OUT:{3}{4}{5}ERR:{6}{7}
+Exception during registration:{0}{1}
+        */
         protected virtual string GetResourceString(string resourceString, params object[] formatArguments)
         {
             if (resourceString is null)


### PR DESCRIPTION
Fixes #1125

Renamed `ValidationMessages` to `Resources`
I believe this is all of the remaining use facing strings that had not been previously localized.