### PR TITLE
Add missing overload on Option<T> with multiple aliases and arity

### DIFF
--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -16,8 +16,9 @@ namespace System.CommandLine
 
         public Option(
             string[] aliases,
-            string? description = null) 
-            : base(aliases, description, new Argument<T>())
+            string? description = null,
+            IArgumentArity? arity = null)
+            : base(aliases, description, new Argument<T>() { Arity = arity })
         { }
 
         public Option(


### PR DESCRIPTION
Seems like an oversight that this wasn't there already, and it makes it impossible to have a typed option with a given arity and multiple aliases, unless you declare it as a variable and invoke `AddAlias` explicilty.

Discovered while trying to figure out how to fix https://github.com/dotnet/command-line-api/issues/1265