### PR TITLE
OptionTests: Add test case for issue with multiple arguments

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -505,6 +505,31 @@ namespace System.CommandLine.Tests
                   .BeFalse();
         }
 
+        [Fact]
+        public void HasOption_returns_expected_result_when_multiple_positional_argument_present()
+        {
+            var option = new Option<string>("-e");
+            var command = new Command("the-command") { option };
+
+            command.AddArgument(new Argument
+            {
+                Name = "arg1",
+                Arity = ArgumentArity.ZeroOrOne,
+            });
+
+            command.AddArgument(new Argument
+            {
+                Name = "arg2",
+                Arity = ArgumentArity.ZeroOrMore
+            });
+
+            var result = command.Parse("-e foo");
+
+            var optionResult = result.ValueForOption(option);
+
+            optionResult.Should().Be("foo");
+        }
+
         protected override Symbol CreateSymbol(string name) => new Option(name);
     }
 }


### PR DESCRIPTION
This added test illustrates an issue I'm seeing described here: https://github.com/dotnet/command-line-api/issues/792#issuecomment-832959924

The new test throws a `System.InvalidOperationException: Sequence contains more than one element` exception like this:

```
System.InvalidOperationException: Sequence contains more than one element

System.InvalidOperationException
Sequence contains more than one element
   at System.Linq.ThrowHelper.ThrowMoreThanOneElementException()
   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source)
   at System.CommandLine.Parsing.OptionResult.get_ArgumentConversionResult() in /home/per/git/command-line-api/src/System.CommandLine/Parsing/OptionResult.cs:line 55
   at System.CommandLine.Parsing.OptionResultExtensions.ConvertIfNeeded(OptionResult optionResult, Type type) in /home/per/git/command-line-api/src/System.CommandLine/Parsing/OptionResultExtensions.cs:line 14
   at System.CommandLine.Parsing.OptionResultExtensions.GetValueOrDefault[T](OptionResult optionResult) in /home/per/git/command-line-api/src/System.CommandLine/Parsing/OptionResultExtensions.cs:line 21
   at System.CommandLine.Parsing.ParseResult.ValueForOption[T](Option`1 option) in /home/per/git/command-line-api/src/System.CommandLine/Parsing/ParseResult.cs:line 144
   at System.CommandLine.Tests.OptionTests.HasOption_returns_expected_result_when_multiple_positional_argument_present() in /home/per/git/command-line-api/src/System.CommandLine.Tests/OptionTests.cs:line 528
```

I'm not sure whether this kind of scenario is actually supported or not, but I see two main options here:

- We make it work, and avoid throwing exceptions in this case, _or_
- We validate the given arguments before parsing is started and throw an exception up-front, to indicate to the caller that the program has configured the parser incorrectly.