### PR TITLE
Fix version option validation

### DIFF
--- a/src/System.CommandLine.Tests/VersionOptionTests.cs
+++ b/src/System.CommandLine.Tests/VersionOptionTests.cs
@@ -5,7 +5,6 @@ using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/src/System.CommandLine.Tests/VersionOptionTests.cs
+++ b/src/System.CommandLine.Tests/VersionOptionTests.cs
@@ -70,6 +70,46 @@ namespace System.CommandLine.Tests
                    .Match("*Options:*--version*Show version information*");
         }
 
+        [Fact]
+        public async Task When_the_version_option_is_specified_and_there_are_default_options_then_the_version_is_written_to_standard_out()
+        {
+            var rootCommand = new RootCommand
+            {
+                new Option("-x", getDefaultValue: () => true)
+            };
+            rootCommand.Handler = CommandHandler.Create(() => { });
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseVersionOption()
+                .Build();
+
+            var console = new TestConsole();
+
+            await parser.InvokeAsync("--version", console);
+
+            console.Out.ToString().Should().Be($"{version}{NewLine}");
+        }
+
+        [Fact]
+        public async Task When_the_version_option_is_specified_and_there_are_default_arguments_then_the_version_is_written_to_standard_out()
+        {
+            var rootCommand = new RootCommand
+            {
+                new Argument<bool>("x", getDefaultValue: () => true)
+            };
+            rootCommand.Handler = CommandHandler.Create(() => { });
+
+            var parser = new CommandLineBuilder(rootCommand)
+                .UseVersionOption()
+                .Build();
+
+            var console = new TestConsole();
+
+            await parser.InvokeAsync("--version", console);
+
+            console.Out.ToString().Should().Be($"{version}{NewLine}");
+        }
+
         [Theory]
         [InlineData("--version -x")]
         [InlineData("--version subcommand")]
@@ -117,7 +157,7 @@ namespace System.CommandLine.Tests
                 },
                 new Option("-x")
             };
-            
+
             var parser = new CommandLineBuilder(rootCommand)
                 .UseVersionOption(errorExitCode: 42)
                 .Build();
@@ -156,10 +196,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task Version_not_added_if_it_exists()
         {
-            // Adding an option multiple times can occur two ways in 
-            // real world scenarios - invocation can be invoked twice 
-            // or the author may have their own version switch but 
-            // still want other defaults. 
+            // Adding an option multiple times can occur two ways in
+            // real world scenarios - invocation can be invoked twice
+            // or the author may have their own version switch but
+            // still want other defaults.
             var parser = new CommandLineBuilder()
                          .UseVersionOption()
                          .UseVersionOption()

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -527,14 +527,15 @@ namespace System.CommandLine.Builder
                 parseArgument: result =>
                 {
                     var commandChildren = result.FindResultFor(command)?.Children;
-                    if (commandChildren == null)
+                    if (commandChildren is null)
                     {
                         return true;
                     }
 
                     var versionOptionResult = result.Parent;
-                    foreach (var symbolResult in commandChildren)
+                    for (int i = 0; i < commandChildren.Count; i++)
                     {
+                        var symbolResult = commandChildren[i];
                         if (symbolResult == versionOptionResult)
                         {
                             continue;

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -380,7 +380,7 @@ namespace System.CommandLine.Builder
             return builder.UseHelp(helpOption);
         }
 
-        public static TBuilder UseHelpBuilder<TBuilder>(this TBuilder builder, 
+        public static TBuilder UseHelpBuilder<TBuilder>(this TBuilder builder,
             Func<BindingContext, IHelpBuilder> getHelpBuilder)
             where TBuilder : CommandLineBuilder
         {
@@ -526,7 +526,7 @@ namespace System.CommandLine.Builder
                 description: Resources.Instance.VersionOptionDescription(),
                 parseArgument: result =>
                 {
-                    if (result.FindResultFor(command)?.Children.Count > 1)
+                    if (result.FindResultFor(command)?.Children.Where(IsNotImplicit).Count() > 1)
                     {
                         result.ErrorMessage = Resources.Instance.VersionOptionCannotBeCombinedWithOtherArguments("--version");
                         return false;
@@ -559,6 +559,16 @@ namespace System.CommandLine.Builder
             }, MiddlewareOrderInternal.VersionOption);
 
             return builder;
+
+            static bool IsNotImplicit(SymbolResult symbolResult)
+            {
+                return symbolResult switch
+                {
+                    ArgumentResult argumentResult => !argumentResult.IsImplicit,
+                    OptionResult optionResult => !optionResult.IsImplicit,
+                    _ => true
+                };
+            }
         }
 
         private static bool ShowHelp(

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -526,8 +526,14 @@ namespace System.CommandLine.Builder
                 description: Resources.Instance.VersionOptionDescription(),
                 parseArgument: result =>
                 {
+                    var commandChildren = result.FindResultFor(command)?.Children;
+                    if (commandChildren == null)
+                    {
+                        return true;
+                    }
+
                     var versionOptionResult = result.Parent;
-                    foreach (var symbolResult in result.FindResultFor(command)?.Children)
+                    foreach (var symbolResult in commandChildren)
                     {
                         if (symbolResult == versionOptionResult)
                         {

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -526,10 +526,19 @@ namespace System.CommandLine.Builder
                 description: Resources.Instance.VersionOptionDescription(),
                 parseArgument: result =>
                 {
-                    if (result.FindResultFor(command)?.Children.Where(IsNotImplicit).Count() > 1)
+                    var versionOptionResult = result.Parent;
+                    foreach (var symbolResult in result.FindResultFor(command)?.Children)
                     {
-                        result.ErrorMessage = Resources.Instance.VersionOptionCannotBeCombinedWithOtherArguments("--version");
-                        return false;
+                        if (symbolResult == versionOptionResult)
+                        {
+                            continue;
+                        }
+
+                        if (IsNotImplicit(symbolResult))
+                        {
+                            result.ErrorMessage = Resources.Instance.VersionOptionCannotBeCombinedWithOtherArguments("--version");
+                            return false;
+                        }
                     }
 
                     return true;

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -20,7 +20,7 @@ namespace System.CommandLine.Parsing
 
         public IArgument Argument { get; }
 
-        public bool IsImplicit => PassedOnTokens == null;
+        public bool IsImplicit => Argument.HasDefaultValue && Tokens.Count == 0;
 
         internal IReadOnlyList<Token>? PassedOnTokens { get; private set; }
 

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -20,9 +20,11 @@ namespace System.CommandLine.Parsing
 
         public IArgument Argument { get; }
 
+        public bool IsImplicit => PassedOnTokens == null;
+
         internal IReadOnlyList<Token>? PassedOnTokens { get; private set; }
 
-        internal ArgumentConversionResult GetArgumentConversionResult() => 
+        internal ArgumentConversionResult GetArgumentConversionResult() =>
             _conversionResult ??= Convert(Argument);
 
         public void OnlyTake(int numberOfTokens)
@@ -32,7 +34,7 @@ namespace System.CommandLine.Parsing
                 throw new ArgumentOutOfRangeException(nameof(numberOfTokens), numberOfTokens, "Value must be at least 1.");
             }
 
-            if (PassedOnTokens is {})
+            if (PassedOnTokens is { })
             {
                 throw new InvalidOperationException($"{nameof(OnlyTake)} can only be called once.");
             }
@@ -124,7 +126,7 @@ namespace System.CommandLine.Parsing
                     if (success)
                     {
                         return ArgumentConversionResult.Success(
-                            arg, 
+                            arg,
                             value);
                     }
 

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -20,7 +20,7 @@ namespace System.CommandLine.Parsing
 
         public IArgument Argument { get; }
 
-        public bool IsImplicit => Argument.HasDefaultValue && Tokens.Count == 0;
+        internal bool IsImplicit => Argument.HasDefaultValue && Tokens.Count == 0;
 
         internal IReadOnlyList<Token>? PassedOnTokens { get; private set; }
 


### PR DESCRIPTION
As reported at https://github.com/dotnet/format/issues/1136

The version option validation (introduced in https://github.com/dotnet/command-line-api/pull/1124) treats default options and arguments as if they were passed by the user. This PR adds an IsImplicit property to ArgumentResult and filters implicit argument and option results when validating the version option.