### PR TITLE
Add CommandResult extensions for HasOption() and HasArgument()

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -22,7 +22,7 @@ namespace System.CommandLine.Tests
         public void An_option_without_a_long_form_can_be_checked_for_using_a_prefix()
         {
             var option = new Option("--flag");
-            
+
             var result = option.Parse("--flag");
 
             result.FindResultFor(option).Should().NotBeNull();
@@ -213,7 +213,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Long_form_options_can_be_specified_using_equals_delimiter()
         {
-            var option = 
+            var option =
                 new Option("--hello", arity: ArgumentArity.ExactlyOne);
 
             var result = option.Parse("--hello=there");
@@ -631,7 +631,7 @@ namespace System.CommandLine.Tests
             var animalsOption = new Option(new[] { "-a", "--animals" }, arity: ArgumentArity.ZeroOrOne);
 
             var vegetablesOption = new Option(new[] { "-v", "--vegetables" }, arity: ArgumentArity.ZeroOrOne);
-            
+
             var parser = new Parser(
                 new Command("the-command")
                 {
@@ -1032,6 +1032,103 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void HasArgument_returns_expected_result_when_argument_provided()
+        {
+            var stringArgument = new Argument<string>();
+
+            var command = new Command("the-command")
+            {
+                new Command("complete")
+                {
+                    stringArgument,
+                    new Option<int>("--position")
+                }
+            };
+
+            ParseResult result = command.Parse("the-command",
+                                               "complete",
+                                               "--position",
+                                               "7",
+                                               "the-argument");
+
+            CommandResult completeResult = result.CommandResult;
+
+            completeResult.HasArgument(stringArgument).Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasArgument_returns_expected_result_when_argument_not_provided()
+        {
+            var stringArgument = new Argument<string>();
+
+            var command = new Command("the-command")
+            {
+                new Command("complete")
+                {
+                    stringArgument,
+                    new Option<int>("--position")
+                }
+            };
+
+            ParseResult result = command.Parse("the-command",
+                                               "complete",
+                                               "--position",
+                                               "7");
+
+            CommandResult completeResult = result.CommandResult;
+
+            completeResult.HasArgument(stringArgument).Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasOption_returns_expected_result_when_option_provided()
+        {
+            var positionOption = new Option<int>("--position");
+
+            var command = new Command("the-command")
+            {
+                new Command("complete")
+                {
+                    new Argument<string>(),
+                    positionOption
+                }
+            };
+
+            ParseResult result = command.Parse("the-command",
+                                               "complete",
+                                               "--position",
+                                               "7",
+                                               "the-command");
+
+            CommandResult completeResult = result.CommandResult;
+
+            completeResult.HasOption(positionOption).Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasOption_returns_expected_result_when_option_not_provided()
+        {
+            var positionOption = new Option<int>("--position");
+
+            var command = new Command("the-command")
+            {
+                new Command("complete")
+                {
+                    new Argument<string>(),
+                    positionOption
+                }
+            };
+
+            ParseResult result = command.Parse("the-command",
+                                               "complete",
+                                               "the-command");
+
+            CommandResult completeResult = result.CommandResult;
+
+            completeResult.HasOption(positionOption).Should().BeFalse();
+        }
+
+        [Fact]
         public void A_root_command_can_be_omitted_from_the_parsed_args()
         {
             var command = new Command("outer")
@@ -1183,7 +1280,7 @@ namespace System.CommandLine.Tests
         public void When_an_option_with_a_default_value_is_not_matched_then_there_are_no_tokens()
         {
             var option = new Option<string>(
-                "-o", 
+                "-o",
                 () => "the-default");
 
             var command = new Command("command")
@@ -1203,7 +1300,7 @@ namespace System.CommandLine.Tests
         public void When_an_argument_with_a_default_value_is_not_matched_then_there_are_no_tokens()
         {
             var argument = new Argument<string>(
-                "o", 
+                "o",
                 () => "the-default");
 
             var command = new Command("command")
@@ -1761,7 +1858,7 @@ namespace System.CommandLine.Tests
                 : base(values)
             { }
         }
-      
+
         public class CustomCollectionTypeConverter : TypeConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)

--- a/src/System.CommandLine/Parsing/CommandResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/CommandResultExtensions.cs
@@ -6,6 +6,30 @@ namespace System.CommandLine.Parsing
 {
     public static class CommandResultExtensions
     {
+        public static bool HasOption(
+            this CommandResult commandResult,
+            IOption option)
+        {
+            if (commandResult is null)
+            {
+                throw new ArgumentNullException(nameof(commandResult));
+            }
+
+            return commandResult.FindResultFor(option) is { };
+        }
+
+        public static bool HasArgument(
+            this CommandResult commandResult,
+            IArgument argument)
+        {
+            if (commandResult is null)
+            {
+                throw new ArgumentNullException(nameof(commandResult));
+            }
+
+            return commandResult.FindResultFor(argument) is { };
+        }
+
         internal static bool TryGetValueForArgument(
             this CommandResult commandResult,
             IValueDescriptor valueDescriptor,


### PR DESCRIPTION
This adds extension methods similar in spirit to the ones already present in `ParseResultExtensions`. I added these to my local project and decided to upstream them in the hope that they can be useful to others also. :pray: 

The new methods don't have any tests unfortunately, but it could probably easily be added. Feel free to suggest an existing test class/method where tests for these would fit in well and I'll happily add one or more tests for them.