### PR TITLE
GridView preserve column width definition after sorting for size calculation

### DIFF
--- a/src/System.CommandLine.Rendering.Tests/Views/GridViewTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/Views/GridViewTests.cs
@@ -60,6 +60,33 @@ namespace System.CommandLine.Rendering.Tests.Views
         [Theory]
         [InlineData(OutputMode.Ansi)]
         [InlineData(OutputMode.NonAnsi)]
+        public void Column_width_definition_is_preserved_even_defintion_is_mixed_for_subsequent_columns(OutputMode outputMode)
+        {
+            var grid = new GridView();
+            grid.SetColumns(ColumnDefinition.Fixed(10), ColumnDefinition.Star(1), ColumnDefinition.Fixed(10), ColumnDefinition.SizeToContent());
+            grid.SetChild(new ContentView("The quick"), 0, 0);
+            grid.SetChild(new ContentView("brown fox"), 1, 0);
+            grid.SetChild(new ContentView("jumped"), 2, 0);
+            grid.SetChild(new ContentView("over the sleepy"), 3, 0);
+
+            var terminal = new TestTerminal();
+            var renderer = new ConsoleRenderer(terminal, outputMode);
+            grid.Render(renderer, new Region(0, 0, 115, 1));
+
+            terminal.Events.Should().BeEquivalentSequenceTo(
+                new TestTerminal.CursorPositionChanged(new Point(0, 0)),
+                new TestTerminal.ContentWritten("The quick "),
+                new TestTerminal.CursorPositionChanged(new Point(10, 0)),
+                new TestTerminal.ContentWritten("brown fox" + new string(' ', 71)),
+                new TestTerminal.CursorPositionChanged(new Point(90, 0)),
+                new TestTerminal.ContentWritten("jumped    "),
+                new TestTerminal.CursorPositionChanged(new Point(100, 0)),
+                new TestTerminal.ContentWritten("over the sleepy"));
+        }
+
+        [Theory]
+        [InlineData(OutputMode.Ansi)]
+        [InlineData(OutputMode.NonAnsi)]
         public void Star_grid_lays_out_in_even_grid(OutputMode outputMode)
         {
             var grid = new GridView();

--- a/src/System.CommandLine.Rendering/Views/GridView.cs
+++ b/src/System.CommandLine.Rendering/Views/GridView.cs
@@ -126,7 +126,7 @@ namespace System.CommandLine.Rendering.Views
             int availableWidth = maxSize.Width;
             int? totalWidthForStarSizing = null;
 
-            foreach (var (column, columnIndex) in _columns.OrderBy(x => GetProcessOrder(x.SizeMode)).Select((x, i) => (x, i)))
+            foreach (var (column, columnIndex) in _columns.Select((definition, columnIndex) => (definition, columnIndex)).OrderBy(t => GetProcessOrder(t.definition.SizeMode)))
             {
                 int availableHeight = maxSize.Height;
 


### PR DESCRIPTION
Fix column width definition, after calculation of width in a mixed size mode, the column width was not according to definition but according to sorting (first all fixed column sizes, size to content, star size) 