### PR TITLE
Add Arity to Option<T> ctor with multiple aliases

### DIFF
--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -16,8 +16,9 @@ namespace System.CommandLine
 
         public Option(
             string[] aliases,
-            string? description = null) 
-            : base(aliases, description, new Argument<T>())
+            string? description = null,
+            IArgumentArity? arity = null) 
+            : base(aliases, description, new Argument<T> { Arity = arity })
         { }
 
         public Option(


### PR DESCRIPTION
Suggest adding IArgumentArity? arity argument to Option<T>(string[], string?) ctor.

This maintain parity with Option<T>(string, string?, IArgumentArity?) ctor and prevents much frustration when wanting to add a second alias to an Option requires rewriting the ctor altogether in order to keep the ArgumentArity.