### PR TITLE
use null help builder when console has no width

### DIFF
--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -93,7 +93,7 @@ namespace System.CommandLine
                 {
                     maxWidth = systemConsole.GetWindowWidth();
                 }
-                return new HelpBuilder(context.Console, maxWidth);
+                return maxWidth >= 0 ? new HelpBuilder(context.Console, maxWidth) : new NullHelpBuilder();
             });
             if (configureHelp != null)
             {

--- a/src/System.CommandLine/Help/NullHelpBuilder.cs
+++ b/src/System.CommandLine/Help/NullHelpBuilder.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine.Help
+{
+    public class NullHelpBuilder : IHelpBuilder
+    {
+        public void Write(ICommand command)
+        {
+        }
+    }
+}


### PR DESCRIPTION
fixes https://github.com/dotnet/command-line-api/issues/1306