### PR TITLE
Allow disabling textmatch for suggestions

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -716,12 +716,14 @@ namespace System.CommandLine.Tests
                    .BeEquivalentTo(
                        result2,
                        x => x.IgnoringCyclicReferences()
-                             .Excluding(y => y.WhichGetterHas(CSharpAccessModifier.Internal)));
+                             .Excluding(y => y.WhichGetterHas(CSharpAccessModifier.Internal))
+                             .Excluding(y => y.SelectedMemberInfo.Name == "RawInput"));
             result1.Should()
                    .BeEquivalentTo(
                        result3,
                        x => x.IgnoringCyclicReferences()
-                             .Excluding(y => y.WhichGetterHas(CSharpAccessModifier.Internal)));
+                             .Excluding(y => y.WhichGetterHas(CSharpAccessModifier.Internal))
+                             .Excluding(y => y.SelectedMemberInfo.Name == "RawInput"));
         }
 
         [Theory]

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -252,7 +252,7 @@ namespace System.CommandLine.Tests
 
             result.GetSuggestions()
                   .Should()
-                  .NotContain(new[]{"apple", "banana", "cherry"});
+                  .NotContain(new[] { "apple", "banana", "cherry" });
         }
 
         [Fact]
@@ -288,8 +288,8 @@ namespace System.CommandLine.Tests
         {
             var command = new RootCommand("parent")
             {
-                new Command("child"), 
-                new Option("--parent-option"), 
+                new Command("child"),
+                new Option("--parent-option"),
                 new Argument<string>()
             };
 
@@ -370,7 +370,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void When_one_option_has_been_partially_specified_then_nonmatching_siblings_will_not_be_suggested()
+        public void When_one_option_has_been_partially_specified_then_nonmatching_siblings_will_not_be_suggested_by_default()
         {
             var command = new Command("the-command")
             {
@@ -386,6 +386,26 @@ namespace System.CommandLine.Tests
                   .Should()
                   .BeEquivalentTo("--apple",
                                   "--banana");
+        }
+
+        [Fact]
+        public void When_one_option_has_been_partially_specified_then_nonmatching_siblings_can_still_be_suggested_by_disabling_textmatch()
+        {
+            var command = new Command("the-command", enforceTextMatch: false)
+            {
+                new Option("--apple"),
+                new Option("--banana"),
+                new Option("--cherry")
+            };
+
+            var input = "a";
+            var result = command.Parse(input);
+
+            result.GetSuggestions(input.Length)
+                  .Should()
+                  .BeEquivalentTo("--apple",
+                                  "--banana",
+                                  "--cherry");
         }
 
         [Fact]
@@ -473,7 +493,7 @@ namespace System.CommandLine.Tests
         [Theory(Skip = "Needs discussion, Issue #19")]
         [InlineData("outer ")]
         [InlineData("outer -")]
-        public void Option_Getsuggestionsions_are_not_provided_without_matching_prefix(string input)
+        public void Option_Getsuggestion_are_not_provided_without_matching_prefix(string input)
         {
             var command = new Command("outer")
             {
@@ -489,7 +509,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Option_Getsuggestionsions_can_be_based_on_the_proximate_option()
+        public void Option_Getsuggestion_can_be_based_on_the_proximate_option()
         {
             var parser = new Parser(
                 new Command("outer")
@@ -524,7 +544,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Option_Getsuggestionsions_can_be_based_on_the_proximate_option_and_partial_input()
+        public void Command_Getsuggestions_can_be_based_on_the_proximate_command_and_partial_input()
         {
             var parser = new Parser(
                 new Command("outer")
@@ -537,6 +557,22 @@ namespace System.CommandLine.Tests
             ParseResult result = parser.Parse("outer o");
 
             result.GetSuggestions().Should().BeEquivalentTo("one", "two");
+        }
+
+        [Fact]
+        public void Command_Getsuggestions_based_on_proximate_command_can_still_show_nonmatching_suggestions_by_disabling_textmatch()
+        {
+            var parser = new Parser(
+                new Command("outer", enforceTextMatch: false)
+                {
+                    new Command("one", "Command one"),
+                    new Command("two", "Command two"),
+                    new Command("three", "Command three")
+                });
+
+            ParseResult result = parser.Parse("outer o");
+
+            result.GetSuggestions().Should().BeEquivalentTo("one", "two", "three");
         }
 
         [Fact]
@@ -557,12 +593,16 @@ namespace System.CommandLine.Tests
             command.Parse("the-command -t something-else").Errors.Should().BeEmpty();
         }
 
-        [Fact]
-        public void Command_argument_suggestions_can_be_provided_using_a_delegate()
+        [Theory]
+        [InlineData(true, new[] { "animal", "mineral" })]
+        [InlineData(false, new[] { "animal", "mineral", "vegetable" })]
+        public void Command_argument_suggestions_can_be_provided_using_a_delegate(
+            bool enforceTextMatch,
+            string[] expectedSuggestions)
         {
             var command = new Command("the-command")
             {
-                new Command("one")
+                new Command("one", enforceTextMatch: enforceTextMatch)
                 {
                     new Argument
                         {
@@ -575,15 +615,19 @@ namespace System.CommandLine.Tests
             command.Parse("the-command one m")
                    .GetSuggestions()
                    .Should()
-                   .BeEquivalentTo("animal", "mineral");
+                   .BeEquivalentTo(expectedSuggestions);
         }
 
-        [Fact]
-        public void Option_argument_suggestions_can_be_provided_using_a_delegate()
+        [Theory]
+        [InlineData(true, new[] { "animal", "mineral" })]
+        [InlineData(false, new[] { "animal", "mineral", "vegetable" })]
+        public void Option_argument_suggestions_can_be_provided_using_a_delegate(
+            bool enforceTextMatch,
+            string[] expectedSuggestions)
         {
             var command = new Command("the-command")
             {
-                new Option<string>("-x")
+                new Option<string>("-x", enforceTextMatch: enforceTextMatch)
                     .AddSuggestions((_, __) => new [] { "vegetable", "mineral", "animal" })
             };
 
@@ -592,17 +636,21 @@ namespace System.CommandLine.Tests
             parseResult
                    .GetSuggestions()
                    .Should()
-                   .BeEquivalentTo("animal", "mineral");
+                   .BeEquivalentTo(expectedSuggestions);
         }
 
-        [Fact]
-        public void When_caller_does_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_option()
+        [Theory]
+        [InlineData(true, new[] { "two-b" })]
+        [InlineData(false, new[] { "two-a", "two-b", "two-c" })]
+        public void When_caller_does_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_option(
+            bool enforceTextMatchForTwo,
+            string[] expectedSuggestionsForTwo)
         {
             var command = new Command("outer")
             {
                 new Option("one", arity: ArgumentArity.ExactlyOne)
                     .FromAmong("one-a", "one-b", "one-c"),
-                new Option("two", arity: ArgumentArity.ExactlyOne)
+                new Option("two", arity: ArgumentArity.ExactlyOne, enforceTextMatch: enforceTextMatchForTwo)
                     .FromAmong("two-a", "two-b", "two-c"),
                 new Option("three", arity: ArgumentArity.ExactlyOne)
                     .FromAmong("three-a", "three-b", "three-c")
@@ -612,35 +660,43 @@ namespace System.CommandLine.Tests
                          .AddCommand(command)
                          .Build();
 
-            var result = parser.Parse("outer two b" );
+            var result = parser.Parse("outer two b");
+            result.GetSuggestions().Should().BeEquivalentTo(expectedSuggestionsForTwo);
 
-            result.GetSuggestions()
-                  .Should()
-                  .BeEquivalentTo("two-b");
+            var result2 = parser.Parse("outer three c");
+            result2.GetSuggestions().Should().BeEquivalentTo("three-c");
         }
 
-        [Fact]
-        public void When_caller_does_not_do_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_option()
+        [Theory]
+        [InlineData(true, new[] { "two-b" })]
+        [InlineData(false, new[] { "two-a", "two-b", "two-c" })]
+        public void When_caller_does_not_do_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_option(
+            bool enforceTextMatchForTwo,
+            string[] expectedSuggestionsForTwo)
         {
             var command = new Command("outer")
             {
                 new Option("one", arity: ArgumentArity.ExactlyOne)
                     .FromAmong("one-a", "one-b", "one-c"),
-                new Option("two", arity: ArgumentArity.ExactlyOne)
+                new Option("two", arity: ArgumentArity.ExactlyOne, enforceTextMatch: enforceTextMatchForTwo)
                     .FromAmong("two-a", "two-b", "two-c"),
                 new Option("three", arity: ArgumentArity.ExactlyOne)
                     .FromAmong("three-a", "three-b", "three-c")
             };
 
             var result = command.Parse("outer two b");
+            result.GetSuggestions().Should().BeEquivalentTo(expectedSuggestionsForTwo);
 
-            result.GetSuggestions()
-                  .Should()
-                  .BeEquivalentTo("two-b");
+            var result2 = command.Parse("outer three c");
+            result2.GetSuggestions().Should().BeEquivalentTo("three-c");
         }
 
-        [Fact]
-        public void When_caller_does_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_command()
+        [Theory]
+        [InlineData(true, new[] { "two-b" })]
+        [InlineData(false, new[] { "two-a", "two-b", "two-c" })]
+        public void When_caller_does_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_command(
+            bool enforceTextMatchForTwo,
+            string[] expectedSuggestionsForTwo)
         {
             var outer = new Command("outer")
             {
@@ -651,7 +707,54 @@ namespace System.CommandLine.Tests
                         Arity = ArgumentArity.ExactlyOne
                     }.FromAmong("one-a", "one-b", "one-c")
                 },
-                new Command("two")
+                new Command("two", enforceTextMatch: enforceTextMatchForTwo)
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("two-a", "two-b", "two-c")
+                },
+                new Command("three")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("three-a", "three-b", "three-c")
+                }
+            };
+
+            var parser = new CommandLineBuilder()
+             .AddCommand(outer)
+             .Build();
+
+            var result = parser.Parse("outer two b");
+            result.GetSuggestions()
+                      .Should()
+                      .BeEquivalentTo(expectedSuggestionsForTwo);
+
+            var result2 = parser.Parse("outer three a");
+            result2.GetSuggestions()
+                      .Should()
+                      .BeEquivalentTo("three-a");
+        }
+
+        [Theory]
+        [InlineData(true, new[] { "two-b" })]
+        [InlineData(false, new[] { "two-a", "two-b", "two-c" })]
+        public void When_caller_does_not_do_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_command(
+            bool enforceTextMatchForTwo,
+            string[] expectedSuggestionsForTwo)
+        {
+            var outer = new Command("outer")
+            {
+                new Command("one")
+                {
+                    new Argument
+                    {
+                        Arity = ArgumentArity.ExactlyOne
+                    }.FromAmong("one-a", "one-b", "one-c")
+                },
+                new Command("two", enforceTextMatch: enforceTextMatchForTwo)
                 {
                     new Argument
                     {
@@ -668,51 +771,24 @@ namespace System.CommandLine.Tests
             };
 
             var result = outer.Parse("outer two b");
-
             result.GetSuggestions()
                   .Should()
-                  .BeEquivalentTo("two-b");
-        }
+                  .BeEquivalentTo(expectedSuggestionsForTwo);
 
-        [Fact]
-        public void When_caller_does_not_do_the_tokenizing_then_argument_suggestions_are_based_on_the_proximate_command()
-        {
-            var outer = new Command("outer")
-            {
-                new Command("one")
-                {
-                    new Argument
-                    {
-                        Arity = ArgumentArity.ExactlyOne
-                    }.FromAmong("one-a", "one-b", "one-c")
-                },
-                new Command("two")
-                {
-                    new Argument
-                    {
-                        Arity = ArgumentArity.ExactlyOne
-                    }.FromAmong("two-a", "two-b", "two-c")
-                },
-                new Command("three")
-                {
-                    new Argument
-                    {
-                        Arity = ArgumentArity.ExactlyOne
-                    }.FromAmong("three-a", "three-b", "three-c")
-                }
-            };
-
-            ParseResult result = outer.Parse("outer two b");
-
-            result.GetSuggestions()
+            var result2 = outer.Parse("outer three a");
+            result2.GetSuggestions()
                   .Should()
-                  .BeEquivalentTo("two-b");
+                  .BeEquivalentTo("three-a");
         }
 
-        [Fact]
-        public void Arguments_of_type_enum_provide_enum_values_as_suggestions()
+        [Theory]
+        [InlineData(true, new[] { "CreateNew", "Create", "OpenOrCreate" })]
+        [InlineData(false, new[] { "CreateNew", "Create", "Open", "OpenOrCreate", "Truncate", "Append" })]
+        public void Arguments_of_type_enum_provide_enum_values_as_suggestions(
+            bool enforceTextMatch,
+            string[] expectedSuggestions)
         {
-            var command = new Command("the-command")
+            var command = new Command("the-command", enforceTextMatch: enforceTextMatch)
             {
                 new Argument<FileMode>()
             };
@@ -720,7 +796,7 @@ namespace System.CommandLine.Tests
             var suggestions = command.Parse("the-command create")
                                      .GetSuggestions();
 
-            suggestions.Should().BeEquivalentTo("CreateNew", "Create", "OpenOrCreate");
+            suggestions.Should().BeEquivalentTo(expectedSuggestions);
         }
 
         [Fact]
@@ -914,7 +990,7 @@ namespace System.CommandLine.Tests
 
                 textToMatch.Should().Be("");
             }
-  
+
             [Fact]
             public void When_position_is_unspecified_in_array_command_line_and_final_token_matches_an_argument_then_it_returns_empty()
             {
@@ -979,7 +1055,7 @@ namespace System.CommandLine.Tests
                 var suggestions = command.Parse("the-command s")
                                          .GetSuggestions();
 
-                suggestions.Should().BeEquivalentTo("sat", "sun","tues");
+                suggestions.Should().BeEquivalentTo("sat", "sun", "tues");
             }
 
             [Fact]

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -32,7 +32,7 @@ namespace System.CommandLine
         /// Initializes a new instance of the Argument class.
         /// </summary>
         /// <param name="name">The name of the argument.</param>
-        public Argument(string name)
+        public Argument(string name, bool enforceTextMatch = true)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -40,6 +40,7 @@ namespace System.CommandLine
             }
 
             Name = name!;
+            EnforceTextMatch = enforceTextMatch;
         }
 
         internal HashSet<string>? AllowedValues { get; private set; }
@@ -211,11 +212,13 @@ namespace System.CommandLine
         /// <inheritdoc />
         public override IEnumerable<string> GetSuggestions(ParseResult? parseResult = null, string? textToMatch = null)
         {
-            return Suggestions
+            var suggestions = Suggestions
                    .SelectMany(source => source.GetSuggestions(parseResult, textToMatch))
                    .Distinct()
-                   .OrderBy(c => c, StringComparer.OrdinalIgnoreCase)
-                   .Containing(textToMatch ?? "");
+                   .OrderBy(c => c, StringComparer.OrdinalIgnoreCase);
+            return EnforceTextMatch
+                ? suggestions.Containing(textToMatch ?? "")
+                : suggestions;
         }
 
         /// <inheritdoc />

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -11,9 +11,10 @@ namespace System.CommandLine
         /// <summary>
         /// Initializes a new instance of the Argument class.
         /// </summary>
-        public Argument()
+        public Argument(bool enforceTextMatch = true)
         {
             ArgumentType = typeof(T);
+            EnforceTextMatch = enforceTextMatch;
         }
 
         /// <summary>
@@ -23,7 +24,8 @@ namespace System.CommandLine
         /// <param name="description">The description of the argument, shown in help.</param>
         public Argument(
             string name, 
-            string? description = null) : base(name)
+            string? description = null,
+            bool enforceTextMatch = true) : base(name, enforceTextMatch)
         {
             ArgumentType = typeof(T);
             Description = description;
@@ -39,7 +41,8 @@ namespace System.CommandLine
         public Argument(
             string name, 
             Func<T> getDefaultValue, 
-            string? description = null) : this(name)
+            string? description = null,
+            bool enforceTextMatch = true) : this(name, description, enforceTextMatch)
         {
             if (getDefaultValue is null)
             {
@@ -47,8 +50,6 @@ namespace System.CommandLine
             }
 
             SetDefaultValueFactory(() => getDefaultValue());
-
-            Description = description;
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="getDefaultValue">The delegate to invoke to return the default value.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="getDefaultValue"/> is null.</exception>
-        public Argument(Func<T> getDefaultValue) : this()
+        public Argument(Func<T> getDefaultValue, bool enforceTextMatch = true) : this()
         {
             if (getDefaultValue is null)
             {
@@ -64,6 +65,7 @@ namespace System.CommandLine
             }
 
             SetDefaultValueFactory(() => getDefaultValue());
+            EnforceTextMatch = enforceTextMatch;
         }
 
         /// <summary>
@@ -78,7 +80,8 @@ namespace System.CommandLine
             string? name,
             ParseArgument<T> parse, 
             bool isDefault = false,
-            string? description = null) : this()
+            string? description = null,
+            bool enforceTextMatch = true) : this()
         {
             if (!string.IsNullOrWhiteSpace(name))
             {
@@ -112,6 +115,7 @@ namespace System.CommandLine
             };
 
             Description = description;
+            EnforceTextMatch = enforceTextMatch;
         }
 
         /// <summary>
@@ -119,7 +123,8 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="parse">A custom argument parser.</param>
         /// <param name="isDefault"><c>true</c> to use the <paramref name="parse"/> result as default value.</param>
-        public Argument(ParseArgument<T> parse, bool isDefault = false) : this(null, parse, isDefault)
+        public Argument(ParseArgument<T> parse, bool isDefault = false, bool enforceTextMatch = true)
+            : this(null, parse, isDefault, enforceTextMatch: enforceTextMatch)
         {
         }
     }

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -30,8 +30,9 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="name">The name of the command.</param>
         /// <param name="description">The description of the command, shown in help.</param>
-        public Command(string name, string? description = null) : base(name, description)
+        public Command(string name, string? description = null, bool enforceTextMatch = true) : base(name, description)
         {
+            EnforceTextMatch = enforceTextMatch;
         }
 
         /// <summary>

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -20,8 +20,9 @@ namespace System.CommandLine
             string? description = null,
             Type? argumentType = null,
             Func<object?>? getDefaultValue = null,
-            IArgumentArity? arity = null)
-            : this(new[] { alias }, description, argumentType, getDefaultValue, arity)
+            IArgumentArity? arity = null,
+            bool enforceTextMatch = true)
+            : this(new[] { alias }, description, argumentType, getDefaultValue, arity, enforceTextMatch)
         { }
 
         public Option(
@@ -29,14 +30,16 @@ namespace System.CommandLine
             string? description = null,
             Type? argumentType = null,
             Func<object?>? getDefaultValue = null,
-            IArgumentArity? arity = null)
-            : this(aliases, description, CreateArgument(argumentType, getDefaultValue, arity))
+            IArgumentArity? arity = null,
+            bool enforceTextMatch = true)
+            : this(aliases, description, CreateArgument(argumentType, getDefaultValue, arity), enforceTextMatch)
         { }
 
         internal Option(
             string[] aliases,
             string? description,
-            Argument? argument)
+            Argument? argument,
+            bool enforceTextMatch = true)
             : base(description)
         {
             if (aliases is null)
@@ -59,6 +62,8 @@ namespace System.CommandLine
             {
                 AddArgumentInner(argument);
             }
+
+            EnforceTextMatch = enforceTextMatch;
         }
 
         private static Argument? CreateArgument(Type? argumentType, Func<object?>? getDefaultValue, IArgumentArity? arity)

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -9,46 +9,62 @@ namespace System.CommandLine
     {
         public Option(
             string alias,
-            string? description = null) 
-            : base(new[] { alias }, description, new Argument<T>())
+            string? description = null,
+            bool enforceTextMatch = true) 
+            : base(new[] { alias }, description, new Argument<T>(), enforceTextMatch)
         { }
 
         public Option(
             string[] aliases,
-            string? description = null) 
-            : base(aliases, description, new Argument<T>())
+            string? description = null,
+            bool enforceTextMatch = true) 
+            : base(aliases, description, new Argument<T>(), enforceTextMatch)
         { }
 
         public Option(
             string alias,
             ParseArgument<T> parseArgument,
             bool isDefault = false,
-            string? description = null) 
-            : base(new[] { alias }, description, 
-                  new Argument<T>(parseArgument ?? throw new ArgumentNullException(nameof(parseArgument)), isDefault))
+            string? description = null,
+            bool enforceTextMatch = true) 
+            : base(new[] { alias },
+                  description, 
+                  new Argument<T>(parseArgument ?? throw new ArgumentNullException(nameof(parseArgument)),isDefault),
+                  enforceTextMatch)
         { }
 
         public Option(
             string[] aliases,
             ParseArgument<T> parseArgument,
             bool isDefault = false,
-            string? description = null) 
-            : base(aliases, description, new Argument<T>(parseArgument ?? throw new ArgumentNullException(nameof(parseArgument)), isDefault))
+            string? description = null,
+            bool enforceTextMatch = true) 
+            : base(aliases,
+                  description,
+                  new Argument<T>(parseArgument ?? throw new ArgumentNullException(nameof(parseArgument)), isDefault),
+                  enforceTextMatch)
         { }
 
         public Option(
             string alias,
             Func<T> getDefaultValue,
-            string? description = null) 
-            : base(new[] { alias }, description, 
-                  new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))))
+            string? description = null,
+            bool enforceTextMatch = true) 
+            : base(new[] { alias },
+                  description, 
+                  new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))),
+                  enforceTextMatch)
         { }
 
         public Option(
             string[] aliases,
             Func<T> getDefaultValue,
-            string? description = null) 
-            : base(aliases, description, new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))))
+            string? description = null,
+            bool enforceTextMatch = true) 
+            : base(aliases,
+                  description,
+                  new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))),
+                  enforceTextMatch)
         { }
     }
 }

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -78,7 +78,7 @@ namespace System.CommandLine.Parsing
 
         public IReadOnlyList<Token> Tokens { get; }
 
-        internal string? RawInput { get; }
+        public string? RawInput { get; }
 
         public IReadOnlyList<string> UnmatchedTokens => _unmatchedTokens.Select(t => t.Value).ToArray();
 

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -14,6 +14,7 @@ namespace System.CommandLine
     {
         private string? _name;
         private readonly SymbolSet _parents = new SymbolSet();
+        private bool _enforceTextMatch = true;
 
         private protected Symbol()
         {
@@ -39,6 +40,12 @@ namespace System.CommandLine
         /// Represents the parent symbols.
         /// </summary>
         public ISymbolSet Parents => _parents;
+
+        private protected bool EnforceTextMatch
+        {
+            get => _enforceTextMatch;
+            set => _enforceTextMatch = value;
+        }
 
         internal void AddParent(Symbol symbol)
         {
@@ -72,7 +79,14 @@ namespace System.CommandLine
         {
             var suggestions = new HashSet<string>();
 
-            textToMatch ??= "";
+            if (EnforceTextMatch)
+            {
+                textToMatch ??= "";
+            }
+            else
+            {
+                textToMatch = "";
+            }
 
             for (var i = 0; i < Children.Count; i++)
             {


### PR DESCRIPTION
Allow client code to selectively disable input text matching, which would otherwise filter out any suggestions that do not contain the matched text.