### PR TITLE
Run synchronous command handlers on the same thread

### DIFF
--- a/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
@@ -9,6 +9,7 @@ using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -79,6 +80,24 @@ namespace System.CommandLine.Tests.Invocation
 
             firstWasCalled.Should().BeTrue();
             secondWasCalled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Invoke_runs_synchronous_handlers_on_current_thread()
+        {
+            var currentThreadId = Thread.CurrentThread.ManagedThreadId;
+            int? handlerThreadId = null;
+
+            var parser = new CommandLineBuilder()
+                .AddCommand(new Command("command")
+                {
+                    Handler = CommandHandler.Create(() => handlerThreadId = Thread.CurrentThread.ManagedThreadId),
+                })
+                .Build();
+
+            parser.Invoke("command", _console);
+
+            handlerThreadId.Should().Be(currentThreadId);
         }
 
         [Fact]

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -30,13 +30,7 @@ namespace System.CommandLine.Invocation
 
         public int Invoke(IConsole? console = null)
         {
-            var context = new InvocationContext(parseResult, console);
-
-            InvocationMiddleware invocationChain = BuildInvocationChain(context);
-
-            Task.Run(() => invocationChain(context, invocationContext => Task.CompletedTask)).GetAwaiter().GetResult();
-
-            return GetExitCode(context);
+            return InvokeAsync(console).GetAwaiter().GetResult();
         }
 
         private static InvocationMiddleware BuildInvocationChain(InvocationContext context)


### PR DESCRIPTION
Currently, when not using any asynchronous handlers, `InvocationPipeline.InvokeAsync` will run them on the current thread whereas `InvocationPipeline.Invoke` runs them on a different thread. This PR fixes that inconsistency. This makes scenarios like #1322 easier to handle because we can assume the handlers run on the main thread