### PR TITLE
Fix user-specific resources not used

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -1642,7 +1642,7 @@ namespace System.CommandLine.Tests.Help
             private readonly string _theTextToAdd;
 
             public CustomHelpBuilderThatAddsTextAfterDefaultText(IConsole console, string theTextToAdd) 
-                : base(console)
+                : base(console, Resources.Instance)
             {
                 _theTextToAdd = theTextToAdd;
             }

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -41,6 +41,7 @@ namespace System.CommandLine.Tests.Help
         {
             return new HelpBuilder(
                 console: _console,
+                Resources.Instance,
                 maxWidth
             );
         }
@@ -136,7 +137,7 @@ namespace System.CommandLine.Tests.Help
             var rootCommand = new RootCommand();
             rootCommand.AddCommand(command);
 
-            new HelpBuilder(_console, LargeMaxWidth).Write(command);
+            new HelpBuilder(_console, Resources.Instance, LargeMaxWidth).Write(command);
 
             var expected =
                 $"Usage:{NewLine}" +
@@ -1632,7 +1633,7 @@ namespace System.CommandLine.Tests.Help
         [InlineData(int.MinValue)]
         public void Constructor_ignores_non_positive_max_width(int maxWidth)
         {
-            var helpBuilder = new HelpBuilder(_console, maxWidth);
+            var helpBuilder = new HelpBuilder(_console, Resources.Instance, maxWidth);
             Assert.Equal(int.MaxValue, helpBuilder.MaxWidth);
         }
 

--- a/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
@@ -288,7 +288,7 @@ namespace System.CommandLine.Tests.Invocation
             Func<BindingContext, IHelpBuilder> helpBuilderFactory = context =>
             {
                 factoryWasCalled = true;
-                return createdHelpBuilder = new HelpBuilder(context.Console);
+                return createdHelpBuilder = new HelpBuilder(context.Console, context.ParseResult.Parser.Configuration.Resources);
             };
 
             var command = new Command("help-command");

--- a/src/System.CommandLine/Binding/BindingContext.cs
+++ b/src/System.CommandLine/Binding/BindingContext.cs
@@ -95,6 +95,7 @@ namespace System.CommandLine.Binding
         internal bool TryBindToScalarValue(
             IValueDescriptor valueDescriptor,
             IValueSource valueSource,
+            Resources resources,
             out BoundValue? boundValue)
         {
             if (valueSource.TryGetValue(valueDescriptor, this, out var value))
@@ -109,7 +110,8 @@ namespace System.CommandLine.Binding
                     var parsed = ArgumentConverter.ConvertObject(
                         valueDescriptor as IArgument ?? new Argument(valueDescriptor.ValueName), 
                         valueDescriptor.ValueType, 
-                        value);
+                        value,
+                        resources);
 
                     if (parsed is SuccessfulArgumentConversionResult successful)
                     {

--- a/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
+++ b/src/System.CommandLine/Binding/FailedArgumentTypeConversionResult.cs
@@ -10,32 +10,34 @@ namespace System.CommandLine.Binding
         internal FailedArgumentTypeConversionResult(
             IArgument argument,
             Type expectedType,
-            string value) :
-            base(argument, FormatErrorMessage(argument, expectedType, value))
+            string value,
+            Resources resources) :
+            base(argument, FormatErrorMessage(argument, expectedType, value, resources))
         {
         }
 
         private static string FormatErrorMessage(
             IArgument argument,
             Type expectedType,
-            string value)
+            string value,
+            Resources resources)
         {
             if (argument is Argument a &&
                 a.Parents.Count == 1)
             {
                 var firstParent = (IIdentifierSymbol) a.Parents[0];
                 var alias = firstParent.Aliases.First();
-
+                
                 switch(firstParent)
                 {
                     case ICommand _:
-                        return Resources.Instance.ArgumentConversionCannotParseForCommand(value, alias, expectedType);
+                        return resources.ArgumentConversionCannotParseForCommand(value, alias, expectedType);
                     case IOption _:
-                        return Resources.Instance.ArgumentConversionCannotParseForOption(value, alias, expectedType);
+                        return resources.ArgumentConversionCannotParseForOption(value, alias, expectedType);
                 }
             }
 
-            return Resources.Instance.ArgumentConversionCannotParse(value, expectedType);
+            return resources.ArgumentConversionCannotParse(value, expectedType);
         }
     }
 }

--- a/src/System.CommandLine/Binding/ModelBinder.cs
+++ b/src/System.CommandLine/Binding/ModelBinder.cs
@@ -115,6 +115,7 @@ namespace System.CommandLine.Binding
             var valueSource = GetValueSource(bindingSources, bindingContext, ValueDescriptor, EnforceExplicitBinding);
             return bindingContext.TryBindToScalarValue(ValueDescriptor,
                                                        valueSource,
+                                                       bindingContext.ParseResult.CommandResult.Resources,
                                                        out var boundValue)
                 ? (true, boundValue?.Value, true)
                 : (false,(object?) null, false);
@@ -263,6 +264,7 @@ namespace System.CommandLine.Binding
             if (bindingContext.TryBindToScalarValue(
                     valueDescriptor,
                     valueSource,
+                    bindingContext.ParseResult.CommandResult.Resources,
                     out var boundValue))
             {
                 return (boundValue, true);

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -34,6 +34,12 @@ namespace System.CommandLine.Builder
 
         public Parser Build()
         {
+            if (HelpOption is not null)
+            {
+                var resources = Resources ?? Resources.Instance;
+                HelpOption.Description = resources.HelpOptionDescription();
+            }
+
             var rootCommand = Command;
 
             var parser = new Parser(

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -29,15 +29,22 @@ namespace System.CommandLine.Builder
         internal Action<IHelpBuilder>? ConfigureHelp { get; set; }
 
         internal HelpOption? HelpOption { get; set; }
+        internal Option<bool>? VersionOption { get; set; }
 
         internal Resources? Resources { get; set; }
 
         public Parser Build()
         {
+            var resources = Resources ?? Resources.Instance;
+
             if (HelpOption is not null)
             {
-                var resources = Resources ?? Resources.Instance;
                 HelpOption.Description = resources.HelpOptionDescription();
+            }
+
+            if (VersionOption is not null)
+            {
+                VersionOption.Description = resources.VersionOptionDescription();
             }
 
             var rootCommand = Command;

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -230,7 +230,7 @@ ERR:
                     string debuggableProcessNames = GetEnvironmentVariable(environmentVariableName);
                     if (string.IsNullOrWhiteSpace(debuggableProcessNames))
                     {
-                        context.Console.Error.WriteLine(Resources.Instance.DebugDirectiveExecutableNotSpecified(environmentVariableName, process.ProcessName));
+                        context.Console.Error.WriteLine(context.Parser.Configuration.Resources.DebugDirectiveExecutableNotSpecified(environmentVariableName, process.ProcessName));
                         context.ExitCode = errorExitCode ?? 1;
                         return;
                     }
@@ -240,7 +240,7 @@ ERR:
                         if (processNames.Contains(process.ProcessName, StringComparer.Ordinal))
                         {
                             var processId = process.Id;
-                            context.Console.Out.WriteLine(Resources.Instance.DebugDirectiveAttachToProcess(processId, process.ProcessName));
+                            context.Console.Out.WriteLine(context.Parser.Configuration.Resources.DebugDirectiveAttachToProcess(processId, process.ProcessName));
                             while (!Debugger.IsAttached)
                             {
                                 await Task.Delay(500);
@@ -248,7 +248,7 @@ ERR:
                         }
                         else
                         {
-                            context.Console.Error.WriteLine(Resources.Instance.DebugDirectiveProcessNotIncludedInEnvironmentVariable(process.ProcessName, environmentVariableName, debuggableProcessNames));
+                            context.Console.Error.WriteLine(context.Parser.Configuration.Resources.DebugDirectiveProcessNotIncludedInEnvironmentVariable(process.ProcessName, environmentVariableName, debuggableProcessNames));
                             context.ExitCode = errorExitCode ?? 1;
                             return;
                         }
@@ -329,7 +329,7 @@ ERR:
                     context.Console.ResetTerminalForegroundColor();
                     context.Console.SetTerminalForegroundRed();
 
-                    context.Console.Error.Write(Resources.Instance.ExceptionHandlerHeader());
+                    context.Console.Error.Write(context.Parser.Configuration.Resources.ExceptionHandlerHeader());
                     context.Console.Error.WriteLine(exception.ToString());
 
                     context.Console.ResetTerminalForegroundColor();
@@ -340,7 +340,7 @@ ERR:
 
         public static CommandLineBuilder UseHelp(this CommandLineBuilder builder)
         {
-            return builder.UseHelp(new HelpOption());
+            return builder.UseHelp(new HelpOption(builder.Resources ?? Resources.Instance));
         }
 
         internal static CommandLineBuilder UseHelp(
@@ -368,7 +368,7 @@ ERR:
             Action<THelpBuilder>? configureHelp)
             where THelpBuilder : IHelpBuilder
         {
-            return builder.UseHelp(new HelpOption(), configureHelp);
+            return builder.UseHelp(new HelpOption(builder.Resources ?? Resources.Instance), configureHelp);
         }
 
         internal static CommandLineBuilder UseHelp<THelpBuilder>(
@@ -528,10 +528,10 @@ ERR:
             {
                 return builder;
             }
-
+            
             var versionOption = new Option<bool>(
                 "--version",
-                description: Resources.Instance.VersionOptionDescription(),
+                description: (builder.Resources ?? Resources.Instance).VersionOptionDescription(),
                 parseArgument: result =>
                 {
                     var commandChildren = result.FindResultFor(command)?.Children;
@@ -551,7 +551,7 @@ ERR:
 
                         if (IsNotImplicit(symbolResult))
                         {
-                            result.ErrorMessage = Resources.Instance.VersionOptionCannotBeCombinedWithOtherArguments("--version");
+                            result.ErrorMessage = (builder.Resources ?? Resources.Instance).VersionOptionCannotBeCombinedWithOtherArguments("--version");
                             return false;
                         }
                     }

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -524,14 +524,13 @@ ERR:
         {
             var command = builder.Command;
 
-            if (command.Children.GetByAlias("--version") != null)
+            if (builder.VersionOption is not null)
             {
                 return builder;
             }
             
             var versionOption = new Option<bool>(
                 "--version",
-                description: (builder.Resources ?? Resources.Instance).VersionOptionDescription(),
                 parseArgument: result =>
                 {
                     var commandChildren = result.FindResultFor(command)?.Children;
@@ -548,10 +547,10 @@ ERR:
                         {
                             continue;
                         }
-
+                        
                         if (IsNotImplicit(symbolResult))
                         {
-                            result.ErrorMessage = (builder.Resources ?? Resources.Instance).VersionOptionCannotBeCombinedWithOtherArguments("--version");
+                            result.ErrorMessage = result.Resources.VersionOptionCannotBeCombinedWithOtherArguments("--version");
                             return false;
                         }
                     }
@@ -561,6 +560,7 @@ ERR:
 
             versionOption.DisallowBinding = true;
 
+            builder.VersionOption = versionOption;
             command.AddOption(versionOption);
 
             builder.AddMiddleware(async (context, next) =>

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -340,7 +340,7 @@ ERR:
 
         public static CommandLineBuilder UseHelp(this CommandLineBuilder builder)
         {
-            return builder.UseHelp(new HelpOption(builder.Resources ?? Resources.Instance));
+            return builder.UseHelp(new HelpOption());
         }
 
         internal static CommandLineBuilder UseHelp(
@@ -368,7 +368,7 @@ ERR:
             Action<THelpBuilder>? configureHelp)
             where THelpBuilder : IHelpBuilder
         {
-            return builder.UseHelp(new HelpOption(builder.Resources ?? Resources.Instance), configureHelp);
+            return builder.UseHelp(new HelpOption(), configureHelp);
         }
 
         internal static CommandLineBuilder UseHelp<THelpBuilder>(

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -230,7 +230,7 @@ ERR:
                     string debuggableProcessNames = GetEnvironmentVariable(environmentVariableName);
                     if (string.IsNullOrWhiteSpace(debuggableProcessNames))
                     {
-                        context.Console.Error.WriteLine(context.Parser.Configuration.Resources.DebugDirectiveExecutableNotSpecified(environmentVariableName, process.ProcessName));
+                        context.Console.Error.WriteLine(context.Resources.DebugDirectiveExecutableNotSpecified(environmentVariableName, process.ProcessName));
                         context.ExitCode = errorExitCode ?? 1;
                         return;
                     }
@@ -240,7 +240,7 @@ ERR:
                         if (processNames.Contains(process.ProcessName, StringComparer.Ordinal))
                         {
                             var processId = process.Id;
-                            context.Console.Out.WriteLine(context.Parser.Configuration.Resources.DebugDirectiveAttachToProcess(processId, process.ProcessName));
+                            context.Console.Out.WriteLine(context.Resources.DebugDirectiveAttachToProcess(processId, process.ProcessName));
                             while (!Debugger.IsAttached)
                             {
                                 await Task.Delay(500);
@@ -248,7 +248,7 @@ ERR:
                         }
                         else
                         {
-                            context.Console.Error.WriteLine(context.Parser.Configuration.Resources.DebugDirectiveProcessNotIncludedInEnvironmentVariable(process.ProcessName, environmentVariableName, debuggableProcessNames));
+                            context.Console.Error.WriteLine(context.Resources.DebugDirectiveProcessNotIncludedInEnvironmentVariable(process.ProcessName, environmentVariableName, debuggableProcessNames));
                             context.ExitCode = errorExitCode ?? 1;
                             return;
                         }
@@ -329,7 +329,7 @@ ERR:
                     context.Console.ResetTerminalForegroundColor();
                     context.Console.SetTerminalForegroundRed();
 
-                    context.Console.Error.Write(context.Parser.Configuration.Resources.ExceptionHandlerHeader());
+                    context.Console.Error.Write(context.Resources.ExceptionHandlerHeader());
                     context.Console.Error.WriteLine(exception.ToString());
 
                     context.Console.ResetTerminalForegroundColor();

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -112,7 +112,7 @@ namespace System.CommandLine
                 maxWidth = systemConsole.GetWindowWidth();
             }
 
-            return new HelpBuilder(context.Console, maxWidth);
+            return new HelpBuilder(context.Console, context.ParseResult.CommandResult.Resources, maxWidth);
         }
 
         private void AddGlobalOptionsToChildren(Command parentCommand)

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -20,10 +20,10 @@ namespace System.CommandLine.Help
         protected Resources Resources { get; }
         public int MaxWidth { get; }
 
-        public HelpBuilder(IConsole console, Resources? resources = null, int maxWidth = int.MaxValue)
+        public HelpBuilder(IConsole console, Resources resources, int maxWidth = int.MaxValue)
         {
             Console = console ?? throw new ArgumentNullException(nameof(console));
-            Resources = resources ?? Resources.Instance;
+            Resources = resources ?? throw new ArgumentNullException(nameof(resources));
             if (maxWidth <= 0) maxWidth = int.MaxValue;
             MaxWidth = maxWidth;
         }

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
+using System.Diagnostics;
 using System.Linq;
 
 namespace System.CommandLine.Help
@@ -16,11 +17,13 @@ namespace System.CommandLine.Help
         private Dictionary<ISymbol, Customization> Customizations { get; } = new();
 
         protected IConsole Console { get; }
+        protected Resources Resources { get; }
         public int MaxWidth { get; }
 
-        public HelpBuilder(IConsole console, int maxWidth = int.MaxValue)
+        public HelpBuilder(IConsole console, Resources? resources = null, int maxWidth = int.MaxValue)
         {
             Console = console ?? throw new ArgumentNullException(nameof(console));
+            Resources = resources ?? Resources.Instance;
             if (maxWidth <= 0) maxWidth = int.MaxValue;
             MaxWidth = maxWidth;
         }
@@ -66,7 +69,7 @@ namespace System.CommandLine.Help
         protected virtual void AddUsage(ICommand command)
         {
             string description = GetUsage(command);
-            WriteHeading(Resources.Instance.HelpUsageTitle(), description);
+            WriteHeading(Resources.HelpUsageTitle(), description);
             Console.Out.WriteLine();
         }
 
@@ -90,7 +93,7 @@ namespace System.CommandLine.Help
 
                     if (displayOptionTitle)
                     {
-                        yield return Resources.Instance.HelpUsageOptionsTitle();
+                        yield return Resources.HelpUsageOptionsTitle();
                         displayOptionTitle = false;
                     }
 
@@ -104,12 +107,12 @@ namespace System.CommandLine.Help
 
                 if (hasCommandWithHelp)
                 {
-                    yield return Resources.Instance.HelpUsageCommandTitle();
+                    yield return Resources.HelpUsageCommandTitle();
                 }
 
                 if (!command.TreatUnmatchedTokensAsErrors)
                 {
-                    yield return Resources.Instance.HelpUsageAdditionalArguments();
+                    yield return Resources.HelpUsageAdditionalArguments();
                 }
             }
         }
@@ -120,7 +123,7 @@ namespace System.CommandLine.Help
 
             if (commandArguments.Length > 0)
             {
-                WriteHeading(Resources.Instance.HelpArgumentsTitle(), null);
+                WriteHeading(Resources.HelpArgumentsTitle(), null);
                 RenderAsColumns(commandArguments);
                 Console.Out.WriteLine();
             }
@@ -167,7 +170,7 @@ namespace System.CommandLine.Help
 
             if (options.Length > 0)
             {
-                WriteHeading(Resources.Instance.HelpOptionsTitle(), null);
+                WriteHeading(Resources.HelpOptionsTitle(), null);
                 RenderAsColumns(options);
                 Console.Out.WriteLine();
             }
@@ -182,7 +185,7 @@ namespace System.CommandLine.Help
 
             if (subcommands.Length > 0)
             {
-                WriteHeading(Resources.Instance.HelpCommandsTitle(), null);
+                WriteHeading(Resources.HelpCommandsTitle(), null);
                 RenderAsColumns(subcommands);
                 Console.Out.WriteLine();
             }
@@ -198,8 +201,8 @@ namespace System.CommandLine.Help
                 return;
             }
 
-            WriteHeading(Resources.Instance.HelpAdditionalArgumentsTitle(),
-                Resources.Instance.HelpAdditionalArgumentsDescription());
+            WriteHeading(Resources.HelpAdditionalArgumentsTitle(),
+                Resources.HelpAdditionalArgumentsDescription());
         }
 
         protected void WriteHeading(string descriptor, string? description)
@@ -424,7 +427,7 @@ namespace System.CommandLine.Help
                 if (symbol is IOption option &&
                     option.IsRequired)
                 {
-                    descriptor += $" {Resources.Instance.HelpOptionsRequired()}";
+                    descriptor += $" {Resources.HelpOptionsRequired()}";
                 }
             }
 
@@ -490,7 +493,7 @@ namespace System.CommandLine.Help
             }
 
             string name = displayArgumentName ?
-                Resources.Instance.HelpArgumentDefaultValueTitle() :
+                Resources.HelpArgumentDefaultValueTitle() :
                 argument.Name;
 
             return $"{name}: {defaultValue}";

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -5,14 +5,14 @@ namespace System.CommandLine.Help
 {
     internal class HelpOption : Option
     {
-        public HelpOption(Resources resources) : base(new[]
+        public HelpOption() : base(new[]
         {
             "-h",
             "/h",
             "--help",
             "-?",
             "/?"
-        }, resources.HelpOptionDescription())
+        })
         {
             DisallowBinding = true;
         }

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -5,14 +5,14 @@ namespace System.CommandLine.Help
 {
     internal class HelpOption : Option
     {
-        public HelpOption() : base(new[]
+        public HelpOption(Resources resources) : base(new[]
         {
             "-h",
             "/h",
             "--help",
             "-?",
             "/?"
-        }, Resources.Instance.HelpOptionDescription())
+        }, resources.HelpOptionDescription())
         {
             DisallowBinding = true;
         }

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -27,6 +27,8 @@ namespace System.CommandLine.Invocation
 
         public Parser Parser => BindingContext.ParseResult.Parser;
 
+        public Resources Resources => Parser.Configuration.Resources;
+
         public ParseResult ParseResult
         {
             get => BindingContext.ParseResult;

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -30,7 +30,7 @@ namespace System.CommandLine.Invocation
                 var suggestions = GetPossibleTokens(result.CommandResult.Command, token).ToList();
                 if (suggestions.Count > 0)
                 {
-                    console.Out.WriteLine(Resources.Instance.SuggestionsTokenNotMatched(token));
+                    console.Out.WriteLine(result.CommandResult.Resources.SuggestionsTokenNotMatched(token));
                     foreach(string suggestion in suggestions)
                     {
                         console.Out.WriteLine(suggestion);

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -217,7 +217,8 @@ namespace System.CommandLine.Parsing
                     if (ArgumentConverter.ConvertObject(
                             argument,
                             argument.ValueType,
-                            CurrentToken.Value) is FailedArgumentTypeConversionResult)
+                            CurrentToken.Value,
+                            _configuration.Resources) is FailedArgumentTypeConversionResult)
                     {
                         return;
                     }


### PR DESCRIPTION
Currently, `System.CommandLine` does only make partial use of the `System.CommandLine.Resources` passed by the user. Instead, it used the default instance (`System.CommandLine.Resources.Instance`).
This commit fixes the occurrences where access is made to the shared instance instead of the user-passed resources.

When using the `CommandLineBuilder` it is possible to set a custom resources instance that can override the localization strings provided by `System.CommandLine`:

```csharp
await new CommandLineBuilder(...)
    .UseResources(new CommandLineResources())
    .UseDefaults()
    .Build()
    .InvokeAsync(args);
```

For example, the following output is expected:

![Image demonstration the expected output of the application when specifying a custom resources instance that overrides the `HelpUsageTile` member](https://user-images.githubusercontent.com/46497296/124475776-6393c080-dda2-11eb-8f27-49e662d00581.png)


But the current implementation ignores the resources instance passed by the user:

![Image demonstration the actual output of the application when specifying a custom resources instance that overrides the `HelpUsageTile` member](https://user-images.githubusercontent.com/46497296/124475613-334c2200-dda2-11eb-8b90-4755f5ff32da.png)

Note that the screenshots above only cover the `string HelpUsageTile()` member but *most* of the strings are not fetched from the user-passed `Resources` instance.

A workaround is possible using the following snippet. The snippet replaces the `Resources` instance (`System.CommandLine.Resources`) with an own implementation (Note that this should be never used as a real solution).

```csharp
var staticInstanceBackingField = typeof(System.CommandLine.Resources).GetField(
    $"<{nameof(Instance)}>k__BackingField",
    BindingFlags.Static | BindingFlags.NonPublic);

var method = new DynamicMethod("Do", null, new[] { typeof(System.CommandLine.Resources), });
var ilGenerator = method.GetILGenerator();

ilGenerator.Emit(OpCodes.Ldarg_0);
ilGenerator.Emit(OpCodes.Stsfld, staticInstanceBackingField!);
ilGenerator.Emit(OpCodes.Ret);

method.CreateDelegate<Action<System.CommandLine.Resources>>()(/* your resources instance */);
```

There should be "only" one public API change in the constructor of the `HelpBuilder` class:

https://github.com/angelobreuer/command-line-api/commit/4330f8f8175da409dd8e859b56edfd2efc8323e8#diff-ed9641de0c4af7c7a4bd4c48a6f1e66d495f8f0887ebbc6e945cb0f2a601b237L96-R96

```diff
- public HelpBuilder(IConsole console, int maxWidth = int.MaxValue)
+ public HelpBuilder(IConsole console, Resources? resources = null, int maxWidth = int.MaxValue)
```

In the case of an implementor wanting to inherit from HelpBuilder and change use a custom factory, it would be probably useful to provide the `Resources` instance more easily in the BindingContext because it seems to be a bit odd to retrieve the instance from `context.ParseResult.CommandResult.Resources`.

I've also provided a repro which can be found under the following link: https://github.com/angelobreuer/SCLResourcesRepro