### PR TITLE
Hosting di inject commandhandler

### DIFF
--- a/src/System.CommandLine.Hosting.Tests/HostingHandlerTest.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingHandlerTest.cs
@@ -113,6 +113,27 @@ namespace System.CommandLine.Hosting.Tests
             service.StringValue.Should().Be("TEST");
         }
 
+        [Fact]
+        public static void Throws_When_Injected_HandlerType_is_not_ICommandHandler()
+        {
+            new object().Invoking(_ =>
+            {
+                var handlerWrapper = HostedCommandHandler.CreateFromHost(
+                    typeof(MyNonCommandHandler));
+            }).Should().ThrowExactly<ArgumentException>(
+                because: $"{typeof(MyNonCommandHandler)} does not implement {typeof(ICommandHandler)}"
+            );
+        }
+
+        [Fact]
+        public static void Throws_When_Injected_HandlerType_is_null()
+        {
+            new object().Invoking(_ =>
+            {
+                var handlerWrapper = HostedCommandHandler.CreateFromHost(null);
+            }).Should().ThrowExactly<ArgumentNullException>();
+        }
+
         public class MyCommand : Command
         {
             public MyCommand() : base(name: "mycommand")
@@ -178,6 +199,11 @@ namespace System.CommandLine.Hosting.Tests
             public int Value { get; set; }
 
             public string StringValue { get; set; }
+        }
+
+        public class MyNonCommandHandler
+        {
+            public static int DoSomething() => 0;
         }
     }
 }

--- a/src/System.CommandLine.Hosting.Tests/HostingHandlerTest.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingHandlerTest.cs
@@ -1,16 +1,15 @@
 ﻿using System.CommandLine.Binding;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
-using System.CommandLine.IO;
 using System.CommandLine.Parsing;
-using System.Linq;
 using System.Threading.Tasks;
+
 using FluentAssertions;
 
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
+
 using Xunit;
 
 
@@ -18,44 +17,51 @@ namespace System.CommandLine.Hosting.Tests
 {
     public static class HostingHandlerTest
     {
-
         [Fact]
         public static async Task Constructor_Injection_Injects_Service()
         {
             var service = new MyService();
 
             var parser = new CommandLineBuilder(
-                new MyCommand()
+                new MyCommand { Handler = HostedCommandHandler.CreateFromHost<MyCommand.MyHandler>() }
                 )
-                .UseHost((builder) => {
-                    builder.ConfigureServices(services =>
+                .UseHost((builder) =>
+                {
+                    builder.ConfigureServices((context, services) =>
                     {
+                        services.AddTransient<MyCommand.MyHandler>();
+                        services.AddOptions<MyCommand.MyOptions>()
+                            .BindCommandLine();
                         services.AddTransient(x => service);
-                    })
-                    .UseCommandHandler<MyCommand, MyCommand.MyHandler>();
+                    });
                 })
                 .Build();
 
-            var result = await parser.InvokeAsync(new string[] { "--int-option", "54"});
+            var result = await parser.InvokeAsync(new string[] { "--int-option", "54" });
 
             service.Value.Should().Be(54);
+            result.Should().Be(54);
         }
 
         [Fact]
         public static async Task Parameter_is_available_in_property()
         {
-            var parser = new CommandLineBuilder(new MyCommand())
+            var parser = new CommandLineBuilder(
+                new MyCommand { Handler = HostedCommandHandler.CreateFromHost<MyCommand.MyHandler>() }
+                )
                 .UseHost(host =>
                 {
                     host.ConfigureServices(services =>
                     {
+                        services.AddTransient<MyCommand.MyHandler>();
+                        services.AddOptions<MyCommand.MyOptions>()
+                            .BindCommandLine();
                         services.AddTransient<MyService>();
-                    })
-                    .UseCommandHandler<MyCommand, MyCommand.MyHandler>();
+                    });
                 })
                 .Build();
 
-            var result = await parser.InvokeAsync(new string[] { "--int-option", "54"});
+            var result = await parser.InvokeAsync(new string[] { "--int-option", "54" });
 
             result.Should().Be(54);
         }
@@ -65,20 +71,30 @@ namespace System.CommandLine.Hosting.Tests
         {
             var root = new RootCommand();
 
-            root.AddCommand(new MyCommand());
-            root.AddCommand(new MyOtherCommand());
+            root.AddCommand(new MyCommand
+            { 
+                Handler = HostedCommandHandler.CreateFromHost<MyCommand.MyHandler>() 
+            });
+            root.AddCommand(new MyOtherCommand
+            {
+                Handler = HostedCommandHandler.CreateFromHost<MyOtherCommand.MyHandler>() 
+            });
             var parser = new CommandLineBuilder(root)
                 .UseHost(host =>
                 {
                     host.ConfigureServices(services =>
                     {
+                        services.AddTransient<MyCommand.MyHandler>();
+                        services.AddOptions<MyCommand.MyOptions>()
+                            .BindCommandLine();
+                        services.AddTransient<MyOtherCommand.MyHandler>();
+                        services.AddOptions<MyOtherCommand.MyOptions>()
+                            .BindCommandLine();
                         services.AddTransient<MyService>(_ => new MyService()
                         {
                             Action = () => 100
                         });
-                    })
-                    .UseCommandHandler<MyCommand, MyCommand.MyHandler>()
-                    .UseCommandHandler<MyOtherCommand, MyOtherCommand.MyHandler>();
+                    });
                 })
                 .Build();
 
@@ -96,15 +112,20 @@ namespace System.CommandLine.Hosting.Tests
         {
             var service = new MyService();
             var cmd = new RootCommand();
-            cmd.AddCommand(new MyOtherCommand());
+            cmd.AddCommand(new MyOtherCommand
+            {
+                Handler = HostedCommandHandler.CreateFromHost<MyOtherCommand.MyHandler>() 
+            });
             var parser = new CommandLineBuilder(cmd)
                 .UseHost(host =>
                 {
                     host.ConfigureServices(services =>
                     {
+                        services.AddTransient<MyOtherCommand.MyHandler>();
+                        services.AddOptions<MyOtherCommand.MyOptions>()
+                            .BindCommandLine();
                         services.AddSingleton<MyService>(service);
-                    })
-                    .UseCommandHandler<MyOtherCommand, MyOtherCommand.MyHandler>();
+                    });
                 })
                 .Build();
 
@@ -141,22 +162,27 @@ namespace System.CommandLine.Hosting.Tests
                 AddOption(new Option<int>("--int-option")); // or nameof(Handler.IntOption).ToKebabCase() if you don't like the string literal
             }
 
+            public class MyOptions
+            {
+                public int IntOption { get; set; } // bound from option
+                public IConsole Console { get; set; } // bound from DI
+            }
+
             public class MyHandler : ICommandHandler
             {
                 private readonly MyService service;
+                private readonly MyOptions options;
 
-                public MyHandler(MyService service)
+                public MyHandler(MyService service, IOptions<MyOptions> options)
                 {
                     this.service = service;
+                    this.options = options.Value;
                 }
-
-                public int IntOption { get; set; } // bound from option
-                public IConsole Console { get; set; } // bound from DI
 
                 public Task<int> InvokeAsync(InvocationContext context)
                 {
-                    service.Value = IntOption;
-                    return Task.FromResult(IntOption);
+                    service.Value = options.IntOption;
+                    return Task.FromResult(options.IntOption);
                 }
             }
         }
@@ -169,24 +195,29 @@ namespace System.CommandLine.Hosting.Tests
                 AddArgument(new Argument<string>("One"));
             }
 
+            public class MyOptions
+            {
+                public int IntOption { get; set; } // bound from option
+                public IConsole Console { get; set; } // bound from DI
+                public string One { get; set; }
+            }
+
             public class MyHandler : ICommandHandler
             {
                 private readonly MyService service;
+                private readonly MyOptions options;
 
-                public MyHandler(MyService service)
+                public MyHandler(MyService service, IOptions<MyOptions> options)
                 {
                     this.service = service;
+                    this.options = options.Value;
                 }
 
-                public int IntOption { get; set; } // bound from option
-                public IConsole Console { get; set; } // bound from DI
-
-                public string One { get; set; }
 
                 public Task<int> InvokeAsync(InvocationContext context)
                 {
-                    service.Value = IntOption;
-                    service.StringValue = One;
+                    service.Value = options.IntOption;
+                    service.StringValue = options.One;
                     return Task.FromResult(service.Action?.Invoke() ?? 0);
                 }
             }

--- a/src/System.CommandLine.Hosting/HostedCommandHandler.cs
+++ b/src/System.CommandLine.Hosting/HostedCommandHandler.cs
@@ -1,0 +1,68 @@
+using System.CommandLine.Hosting;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace System.CommandLine.Invocation
+{
+    /// <summary>
+    /// Proviveds helper methods to initialize a command handler that uses
+    /// Dependency Injection from the .NET Generic Host to materialize
+    /// the handler.
+    /// </summary>
+    /// <seealso cref="CommandHandler"/>
+    public static class HostedCommandHandler
+    {
+        private class HostedCommandHandlerWrapper<THostedCommandHandler> : ICommandHandler
+            where THostedCommandHandler : ICommandHandler
+        {
+            public Task<int> InvokeAsync(InvocationContext context)
+            {
+                var host = context.GetHost();
+                var handler = host.Services.GetRequiredService<THostedCommandHandler>();
+                return handler.InvokeAsync(context);
+            }
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ICommandHandler"/> instance that when invoked
+        /// will forward the <see cref="InvocationContext"/> to an instance of
+        /// <paramref name="commandHandlerType"/> obtained from the DI-container
+        /// of the .NET Generic Host used in the invocation pipeline.
+        /// </summary>
+        /// <param name="commandHandlerType">A command handler service type implementing <see cref="ICommandHandler"/> that has been registered with the .NET Generic Host DI-container.</param>
+        /// <returns>A wrapper object that implements the <see cref="ICommandHandler"/> interface by forwarding the call to <see cref="ICommandHandler.InvokeAsync(InvocationContext)"/> to the implementation of <typeparamref name="TCommandHandler"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="commandHandlerType"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="commandHandlerType"/> does not implement the <see cref="ICommandHandler"/> interface type.</exception>
+        public static ICommandHandler CreateFromHost(Type commandHandlerType)
+        {
+            _ = commandHandlerType ?? throw new ArgumentNullException(nameof(commandHandlerType));
+            Type wrapperHandlerType;
+            try
+            {
+                wrapperHandlerType = typeof(HostedCommandHandlerWrapper<>)
+                    .MakeGenericType(commandHandlerType);
+            }
+            catch (ArgumentException argExcept)
+            {
+                throw new ArgumentException(
+                    paramName: nameof(commandHandlerType),
+                    message: $"{commandHandlerType} does not implement the {typeof(ICommandHandler)} interface.",
+                    innerException: argExcept);
+            }
+            return (ICommandHandler)Activator.CreateInstance(wrapperHandlerType);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ICommandHandler"/> instance that when invoked
+        /// will forward the <see cref="InvocationContext"/> to an instance of
+        /// <typeparamref name="TCommandHandler"/> obtained from the DI-container
+        /// of the .NET Generic Host used in the invocation pipeline.
+        /// </summary>
+        /// <typeparam name="TCommandHandler">A command handler service type that has been registered with the .NET Generic Host DI-container.</typeparam>
+        /// <returns>A wrapper object that implements the <see cref="ICommandHandler"/> interface by forwarding the call to <see cref="ICommandHandler.InvokeAsync(InvocationContext)"/> to the implementation of <typeparamref name="TCommandHandler"/>.</returns>
+        public static ICommandHandler CreateFromHost<TCommandHandler>()
+            where TCommandHandler : ICommandHandler =>
+            new HostedCommandHandlerWrapper<TCommandHandler>();
+    }
+}

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -82,41 +82,6 @@ namespace System.CommandLine.Hosting
             });
         }
 
-        public static IHostBuilder UseCommandHandler<TCommand, THandler>(this IHostBuilder builder)
-            where TCommand : Command
-            where THandler : ICommandHandler
-        {
-            return builder.UseCommandHandler(typeof(TCommand), typeof(THandler));
-        }
-
-        public static IHostBuilder UseCommandHandler(this IHostBuilder builder, Type commandType, Type handlerType)
-        {
-            if (!typeof(Command).IsAssignableFrom(commandType))
-            {
-                throw new ArgumentException($"{nameof(commandType)} must be a type of {nameof(Command)}", nameof(handlerType));
-            }
-
-            if (!typeof(ICommandHandler).IsAssignableFrom(handlerType))
-            {
-                throw new ArgumentException($"{nameof(handlerType)} must implement {nameof(ICommandHandler)}", nameof(handlerType));
-            }
-
-            if (builder.Properties[typeof(InvocationContext)] is InvocationContext invocation 
-                && invocation.ParseResult.CommandResult.Command is Command command
-                && command.GetType() == commandType)
-            {
-                invocation.BindingContext.AddService(handlerType, c => c.GetService<IHost>().Services.GetService(handlerType));
-                builder.ConfigureServices(services =>
-                {
-                    services.AddTransient(handlerType);
-                });
-
-                command.Handler = CommandHandler.Create(handlerType.GetMethod(nameof(ICommandHandler.InvokeAsync)));
-            }
-
-            return builder;
-        }
-
         public static InvocationContext GetInvocationContext(this IHostBuilder hostBuilder)
         {
             _ = hostBuilder ?? throw new ArgumentNullException(nameof(hostBuilder));


### PR DESCRIPTION
Following the discussion in #1344 we have detected flaws in the implementation of the `UseCommandHandler` extension methods.

This PR adds a new helper class `HostedCommandHandler` which works similarly to `CommandHandler` by creating instances of `ICommandHandler` that forward the call to `InvokeAsync(InvocationContext)` to a handler instance constructed by the .NET Generic Host DI-system. 

`UseCommandHandler` is removed by this PR.

Test have also been updated to use the `HostedCommandHandler` instead of `UseCommandHandler`.

The test have also been adjusted to better reflect design principles using the .NET Generic Host. In particular this involves having options-classes that hold the values bound from command-line. The handlers get an injected `IOptions<T>` instance from which they read bound command-line argument values.

**/cc** @leonardochaia, @Gronex

A minimalistic example of using DI-bound handlers would look like this:

``` C#
public static class Program
{
    public static Task<int> Main(string[] args)
    {
        var rootCommand = new RootCommand
        {
            Handler = HostedCommandHandler.CreateFromHost<MyCommandHandler>()
        };
        var parser = new CommandLineBuilder(rootCommand)
            .UseHost(CreateHostBuilder)
            .Build();
        return parser.InvokeAsync(args);
    }

    public static IHostBuilder CreateHostBuilder(string[] args) =>
        Host.CreateDefaultBuilder(args)
            .ConfigureServices(services =>
            {
                services.AddTransient<MyCommandHandler>();
                services.AddOptions<MyAppOptions>()
                    .BindCommandLine()
                    ;
            })
            ;
}

class MyCommandHandler : ICommandHandler
{
    private readonly MyAppOptions options;

    public MyCommandHandler(IOptions<MyAppOptions> options) : base()
    {
        this.options = options.Value;
    }

    public Task<int> InvokeAsync(InvocationContext context)
    {
        /* Do something here */
    }
}

class MyAppOptions { /* Add properties here which match Options/Arguments from command line */ }
```

closes #1344 