### PR TITLE
Added foreground color reset to DirectoryTableView sample

### DIFF
--- a/samples/RenderingPlayground/DirectoryTableView.cs
+++ b/samples/RenderingPlayground/DirectoryTableView.cs
@@ -41,7 +41,7 @@ namespace RenderingPlayground
 
             Add(tableView);
 
-            Formatter.AddFormatter<DateTime>(d => $"{d:d} {ForegroundColorSpan.DarkGray()}{d:t}");
+            Formatter.AddFormatter<DateTime>(d => $"{d:d} {ForegroundColorSpan.DarkGray()}{d:t}{ForegroundColorSpan.Reset()}");
         }
 
         TextSpan Span(FormattableString formattableString)


### PR DESCRIPTION
Since the foreground color wasn't being reset, it would cause subsequent characters to use the same format. Before the change, the date in the second column is always gray, and the command prompt is gray after the process exits with ctrl+c:

![without_reset](https://user-images.githubusercontent.com/5421969/126232881-ddd1021a-8ef9-442b-951b-bb816512c8bf.jpg)

With the change, only the time is gray as intended, and the prompt is the default color after exiting:

![with_reset](https://user-images.githubusercontent.com/5421969/126232894-c0711686-5519-4b77-bcf3-cdbc8a91ce2a.jpg)
