### PR TITLE
Simplified usage of BindingContext resolved command handlers

### DIFF
--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -143,6 +143,18 @@ namespace System.CommandLine.Builder
             return builder;
         }
 
+        public static CommandLineBuilder ConfigureBindingContext(
+            this CommandLineBuilder builder,
+            Action<BindingContext> configureBindingContext)
+        {
+            builder.AddMiddleware((context, next) =>
+            {
+                configureBindingContext?.Invoke(context.BindingContext);
+                return next(context);
+            }, default(MiddlewareOrder));
+            return builder;
+        }
+
         public static CommandLineBuilder EnableDirectives(
             this CommandLineBuilder builder,
             bool value = true)

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -282,6 +282,10 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task<int>> action) =>
             HandlerDescriptor.FromDelegate(action).GetCommandHandler();
 
+        public static ICommandHandler FromBindingContext<THandler>()
+            where THandler : ICommandHandler =>
+            Create((InvocationContext context, THandler handler) => handler.InvokeAsync(context));
+
         internal static async Task<int> GetExitCodeAsync(object value, InvocationContext context)
         {
             switch (value)


### PR DESCRIPTION
This PR adds convenience helper methods to simplify the usage of services resolved by the BindingContext.

* Add static helper `FromBindingContext` to `CommandHandler`.
  Creates an `ICommandHandler` where the specified command handler type is filled in at runtime by the BindingContext. This requires that the BindingContext knows how to instantiate the handler type (requires service registration).
* Add a `ConfigureBindingContext` middleware.
  Middleware simply takes an `Action<BindingContext>` parameter. In this callback the developer can call `AddModelBinder` and `AddService`. This simplifies service-registration on the BindingContext.
* Add no-parameter `AddService` instance method on `BindingContext`.
  Simplified service registration for trivial types. Uses a `ModelBinder` to auto-construct the service.

inspired by discussion in #1344.

**/cc** @leonardochaia