### PR TITLE
Cleaning up MethodInfoHandler

### DIFF
--- a/src/System.CommandLine/Binding/MethodInfoHandlerDescriptor.cs
+++ b/src/System.CommandLine/Binding/MethodInfoHandlerDescriptor.cs
@@ -24,19 +24,10 @@ namespace System.CommandLine.Binding
 
         public override ICommandHandler GetCommandHandler()
         {
-            if (_invocationTarget is null)
-            {
-                return new ModelBindingCommandHandler(
-                    _handlerMethodInfo,
-                    this);
-            }
-            else
-            {
-                return new ModelBindingCommandHandler(
-                    _handlerMethodInfo,
-                    this,
-                    _invocationTarget);
-            }
+            return new ModelBindingCommandHandler(
+                _handlerMethodInfo,
+                this,
+                _invocationTarget);
         }
 
         public override ModelDescriptor Parent => ModelDescriptor.FromType(_handlerMethodInfo.DeclaringType);

--- a/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine/Invocation/ModelBindingCommandHandler.cs
@@ -22,23 +22,22 @@ namespace System.CommandLine.Invocation
 
         public ModelBindingCommandHandler(
             MethodInfo handlerMethodInfo,
-            IMethodDescriptor methodDescriptor)
+            IMethodDescriptor methodDescriptor,
+            object? invocationTarget)
         {
             _handlerMethodInfo = handlerMethodInfo ?? throw new ArgumentNullException(nameof(handlerMethodInfo));
             _invocationTargetBinder = _handlerMethodInfo.IsStatic
                                           ? null
                                           : new ModelBinder(_handlerMethodInfo.ReflectedType);
             _methodDescriptor = methodDescriptor ?? throw new ArgumentNullException(nameof(methodDescriptor));
+            _invocationTarget = invocationTarget;
         }
 
         public ModelBindingCommandHandler(
             MethodInfo handlerMethodInfo,
-            IMethodDescriptor methodDescriptor,
-            object? invocationTarget)
-            :this(handlerMethodInfo, methodDescriptor )
-        {
-            _invocationTarget = invocationTarget;
-        }
+            IMethodDescriptor methodDescriptor)
+            : this(handlerMethodInfo, methodDescriptor, null)
+        { }
 
         public ModelBindingCommandHandler(
              Delegate handlerDelegate,

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -166,12 +166,10 @@ namespace System.CommandLine.Parsing
         [return: MaybeNull]
         private T ValueForOption<T>(Option option)
         {
-            if (FindResultFor(option) is { } result)
+            if (FindResultFor(option) is { } result &&
+                result.GetValueOrDefault<T>() is { } t)
             {
-                if (result.GetValueOrDefault<T>() is { } t)
-                {
-                    return t;
-                }
+                return t;
             }
 
             return (T)Binder.GetDefaultValue(option.Argument.ArgumentType)!;


### PR DESCRIPTION
This cleans up an conditional check that was not needed. 
The `ModelBindingCommandHandler(MethodInfo, IMethodDescriptor)` is now unused and could be removed. However it is public so I did not remove it to avoid making a breaking change.