### PR TITLE
Fix 1385

### DIFF
--- a/src/System.CommandLine/Parsing/CommandLineStringSplitter.cs
+++ b/src/System.CommandLine/Parsing/CommandLineStringSplitter.cs
@@ -63,11 +63,6 @@ namespace System.CommandLine.Parsing
                             startTokenIndex = pos + 1;
                             seeking = Boundary.QuoteEnd;
                             break;
-
-                        case Boundary.WordEnd:
-                            seeking = Boundary.QuoteEnd;
-                            skipQuoteAtIndex = pos;
-                            break;
                     }
                 }
                 else if (seeking == Boundary.TokenStart)


### PR DESCRIPTION
Fix 1385: Character "\"" should be ignored if seeking == Boundary.WordEnd as this character would be the part of an argument.
E.g. "POST --raw='{\"Id\":1,\"Name\":\"Alice\"}'"