### PR TITLE
obsolete ParseResult.ValueFor* methods, add GetValueFor* replacements

### DIFF
--- a/docs/src/Binding/GetValueSample.cs
+++ b/docs/src/Binding/GetValueSample.cs
@@ -16,7 +16,7 @@ namespace Binding
 
             var option = new Option<int>("--an-int");
             ParseResult parseResult = option.Parse("--an-int 123");
-            int value = parseResult.ValueForOption(option);
+            int value = parseResult.GetValueForOption(option);
             Console.WriteLine(Format(value));
 
             #endregion

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -118,7 +118,7 @@ namespace System.CommandLine.Suggest
 
         private void Get(ParseResult parseResult, IConsole console)
         {
-            var commandPath = parseResult.ValueForOption(ExecutableOption);
+            var commandPath = parseResult.GetValueForOption(ExecutableOption);
 
             Registration suggestionRegistration;
             if (commandPath.FullName == DotnetMuxer.Path.FullName)
@@ -130,7 +130,7 @@ namespace System.CommandLine.Suggest
                 suggestionRegistration = _suggestionRegistration.FindRegistration(commandPath);
             }
 
-            var position = parseResult.ValueForOption(PositionOption);
+            var position = parseResult.GetValueForOption(PositionOption);
 
             if (suggestionRegistration == null)
             {

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -203,7 +203,7 @@ namespace System.CommandLine.Tests
                 var argument = new Argument<int>(result => int.Parse(result.Tokens.Single().Value));
 
                 argument.Parse("123")
-                        .ValueForArgument(argument)
+                        .GetValueForArgument(argument)
                         .Should()
                         .Be(123);
             }
@@ -214,7 +214,7 @@ namespace System.CommandLine.Tests
                 var argument = new Argument<IEnumerable<int>>(result => result.Tokens.Single().Value.Split(',').Select(int.Parse));
 
                 argument.Parse("1,2,3")
-                        .ValueForArgument(argument)
+                        .GetValueForArgument(argument)
                         .Should()
                         .BeEquivalentTo(new[] { 1, 2, 3 });
             }
@@ -228,7 +228,7 @@ namespace System.CommandLine.Tests
                 });
 
                 argument.Parse("1 2 3")
-                        .ValueForArgument(argument)
+                        .GetValueForArgument(argument)
                         .Should()
                         .BeEquivalentTo(new[] { 1, 2, 3 });
             }
@@ -242,7 +242,7 @@ namespace System.CommandLine.Tests
                 };
 
                 argument.Parse("1 2 3")
-                        .ValueForArgument(argument)
+                        .GetValueForArgument(argument)
                         .Should()
                         .Be(6);
             }
@@ -389,7 +389,7 @@ namespace System.CommandLine.Tests
 
                 var result = argument.Parse("");
 
-                result.ValueForArgument(argument)
+                result.GetValueForArgument(argument)
                       .Should()
                       .Be(123);
             }

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -471,7 +471,7 @@ namespace System.CommandLine.Tests
                 var result = command.Parse("the-command -o not-an-int");
 
                 Action getValue = () => 
-                    result.ValueForOption(option);
+                    result.GetValueForOption(option);
 
                 getValue.Should()
                         .Throw<InvalidOperationException>()

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -39,7 +39,7 @@ namespace System.CommandLine.Tests.Binding
             var file = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "the-file.txt"));
             var result = command.Parse($"{file.FullName}");
 
-            result.ValueForArgument(argument)
+            result.GetValueForArgument(argument)
                   .Name
                   .Should()
                   .Be("the-file.txt");
@@ -59,7 +59,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("");
 
-            result.ValueForArgument(argument)
+            result.GetValueForArgument(argument)
                   .Should()
                   .BeNull();
         }
@@ -350,7 +350,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse(commandLine);
 
-            result.ValueForArgument(argument)
+            result.GetValueForArgument(argument)
                   .Should()
                   .BeEquivalentTo(new[] { "c", "c", "c" });
         }
@@ -456,7 +456,7 @@ namespace System.CommandLine.Tests.Binding
 
             result.Errors.Should().BeEmpty();
 
-            var value = result.ValueForArgument(argument);
+            var value = result.GetValueForArgument(argument);
 
             value.Should().Be(directoryInfo);
         }

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -192,7 +192,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("the-command -x the-argument");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Should()
                   .Be("the-argument");
         }
@@ -209,7 +209,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("the-command -x the-argument");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Should()
                   .Be("the-argument");
         }
@@ -226,7 +226,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("the-command -x");
 
-            Action getValue = () => result.ValueForOption(option);
+            Action getValue = () => result.GetValueForOption(option);
 
             getValue.Should()
                     .Throw<InvalidOperationException>()
@@ -248,7 +248,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("the-command -x");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Should()
                   .BeAssignableTo<IReadOnlyCollection<string>>()
                   .Which
@@ -269,7 +269,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("the-command");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Should()
                   .BeAssignableTo<IReadOnlyCollection<string>>()
                   .Which
@@ -289,7 +289,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("the-command -x");
 
-            Action getValue = () => result.ValueForOption(option);
+            Action getValue = () => result.GetValueForOption(option);
 
             getValue.Should()
                     .Throw<InvalidOperationException>()
@@ -310,7 +310,7 @@ namespace System.CommandLine.Tests.Binding
             };
 
             command.Parse("the-command -x arg1 -x arg2")
-                   .ValueForOption(option)
+                   .GetValueForOption(option)
                    .Should()
                    .BeEquivalentTo(new[] { "arg1", "arg2" });
         }
@@ -326,7 +326,7 @@ namespace System.CommandLine.Tests.Binding
             };
 
             command.Parse("the-command -x arg1")
-                   .ValueForOption(option)
+                   .GetValueForOption(option)
                    .Should()
                    .BeEquivalentTo(new[] { "arg1" });
         }
@@ -368,7 +368,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("-x");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Should()
                   .Be(true);
         }
@@ -385,7 +385,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Should()
                   .Be(false);
         }
@@ -493,7 +493,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option("-x", arity: ArgumentArity.ZeroOrOne);
 
-            var value = option.Parse("-x 123.456").ValueForOption<float>("-x");
+            var value = option.Parse("-x 123.456").GetValueForOption<float>(option);
 
             value.Should().Be(123.456f);
         }
@@ -503,7 +503,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option("-x", arity: ArgumentArity.ZeroOrOne);
 
-            option.Parse("-x").ValueForOption<bool>("-x").Should().BeTrue();
+            option.Parse("-x").GetValueForOption<bool>(option).Should().BeTrue();
         }
 
         [Fact]
@@ -511,8 +511,8 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option("-x", arity: ArgumentArity.ZeroOrOne);
 
-            option.Parse("-x false").ValueForOption<bool>("-x").Should().BeFalse();
-            option.Parse("-x true").ValueForOption<bool>("-x").Should().BeTrue();
+            option.Parse("-x false").GetValueForOption<bool>(option).Should().BeFalse();
+            option.Parse("-x true").GetValueForOption<bool>(option).Should().BeTrue();
         }
 
         [Fact]
@@ -520,7 +520,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option("-x", arity: ArgumentArity.ZeroOrMore);
 
-            var value = option.Parse("-x 1 -x 2 -x 3").ValueForOption<int[]>("-x");
+            var value = option.Parse("-x 1 -x 2 -x 3").GetValueForOption<int[]>(option);
 
             value.Should().BeEquivalentTo(1, 2, 3);
         }
@@ -570,7 +570,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option("-x", arity: ArgumentArity.ZeroOrMore);
 
-            var value = option.Parse("-x 1 -x 2 -x 3").ValueForOption<List<int>>("-x");
+            var value = option.Parse("-x 1 -x 2 -x 3").GetValueForOption<List<int>>(option);
 
             value.Should().BeEquivalentTo(1, 2, 3);
         }
@@ -580,7 +580,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option("-x", arity: ArgumentArity.ZeroOrMore);
 
-            var value = option.Parse("-x 1 -x 2 -x 3").ValueForOption<IEnumerable<int>>("-x");
+            var value = option.Parse("-x 1 -x 2 -x 3").GetValueForOption<IEnumerable<int>>(option);
 
             value.Should().BeEquivalentTo(1, 2, 3);
         }
@@ -592,7 +592,7 @@ namespace System.CommandLine.Tests.Binding
 
             var parseResult = option.Parse("-x Monday");
 
-            var value = parseResult.ValueForOption<DayOfWeek>("-x");
+            var value = parseResult.GetValueForOption(option);
 
             value.Should().Be(DayOfWeek.Monday);
         }

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -20,7 +20,7 @@ namespace System.CommandLine.Tests.Binding
             var file = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "the-file.txt"));
             var result = option.Parse($"--file {file.FullName}");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Name
                   .Should()
                   .Be("the-file.txt");
@@ -73,7 +73,7 @@ namespace System.CommandLine.Tests.Binding
             var file2 = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "file2.txt"));
             var result = option.Parse($"--file {file1.FullName} --file {file2.FullName}");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Select(fi => fi.Name)
                   .Should()
                   .BeEquivalentTo("file1.txt", "file2.txt");
@@ -126,7 +126,7 @@ namespace System.CommandLine.Tests.Binding
             var result = parser.Parse("-x");
 
             result.Errors.Should().BeEmpty();
-            result.ValueForOption(option).Should().Be(true);
+            result.GetValueForOption(option).Should().Be(true);
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.ValueForOption(option).Should().Be(123);
+            result.GetValueForOption(option).Should().Be(123);
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something -x 456");
 
-            result.ValueForOption(option).Should().Be(456);
+            result.GetValueForOption(option).Should().Be(456);
         }
 
         [Theory]
@@ -175,7 +175,7 @@ namespace System.CommandLine.Tests.Binding
 
             command
                 .Parse(commandLine)
-                .ValueForOption(option)
+                .GetValueForOption(option)
                 .Should()
                 .Be(true);
         }
@@ -402,7 +402,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                   .Should()
                   .Be("123");
         }
@@ -418,7 +418,7 @@ namespace System.CommandLine.Tests.Binding
             };
 
             command.Parse("something")
-                   .ValueForOption(option)
+                   .GetValueForOption(option)
                    .Should()
                    .Be(123);
         }
@@ -437,7 +437,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.ValueForOption(option).Should().Be(directoryInfo);
+            result.GetValueForOption(option).Should().Be(directoryInfo);
         }
 
         [Fact]
@@ -473,7 +473,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something -x 456");
 
-            var value = result.ValueForOption(option);
+            var value = result.GetValueForOption(option);
 
             value.Should().Be(456);
         }
@@ -483,7 +483,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option("-x", arity: ArgumentArity.ZeroOrOne);
 
-            var value = option.Parse("-x 123.456").ValueForOption<double>("-x");
+            var value = option.Parse("-x 123.456").GetValueForOption<double>(option);
 
             value.Should().Be(123.456d);
         }
@@ -617,7 +617,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = option.Parse("-x not-an-int");
 
-            Action getValue = () => result.ValueForOption(option);
+            Action getValue = () => result.GetValueForOption(option);
 
             getValue.Should()
                     .Throw<InvalidOperationException>()
@@ -634,7 +634,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = option.Parse("-x not-an-int -x 2");
 
-            Action getValue = () => result.ValueForOption(option);
+            Action getValue = () => result.GetValueForOption(option);
 
             getValue.Should()
                     .Throw<InvalidOperationException>()

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -328,9 +328,9 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
         [Fact]
@@ -343,9 +343,9 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
         [Fact]
@@ -358,9 +358,10 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
         [Fact]
@@ -373,9 +374,10 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
         [Fact]
@@ -388,9 +390,10 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
         [Fact]
@@ -403,9 +406,10 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
         [Fact]
@@ -418,9 +422,10 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
         [Fact]
@@ -433,9 +438,10 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
         [Fact]
@@ -448,9 +454,10 @@ namespace System.CommandLine.Tests
             };
 
             var result = command.Parse("mycommand");
-            result.ValueForArgument(argument)
-                .Should()
-                .BeEmpty();
+
+            result.GetValueForArgument(argument)
+                  .Should()
+                  .BeEmpty();
         }
 
 

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -88,9 +88,9 @@ namespace System.CommandLine.Tests
 
             root.AddCommand(child);
 
-            root.Parse("child --global 123").ValueForOption(option).Should().Be(123);
+            root.Parse("child --global 123").GetValueForOption(option).Should().Be(123);
 
-            child.Parse("--global 123").ValueForOption(option).Should().Be(123);
+            child.Parse("--global 123").GetValueForOption(option).Should().Be(123);
         }
 
         [Fact]
@@ -110,11 +110,11 @@ namespace System.CommandLine.Tests
             
             firstChild.AddCommand(secondChild);
             
-            root.Parse("first second --global 123").ValueForOption(option).Should().Be(123);
+            root.Parse("first second --global 123").GetValueForOption(option).Should().Be(123);
             
-            firstChild.Parse("second --global 123").ValueForOption(option).Should().Be(123);
+            firstChild.Parse("second --global 123").GetValueForOption(option).Should().Be(123);
             
-            secondChild.Parse("--global 123").ValueForOption(option).Should().Be(123);
+            secondChild.Parse("--global 123").GetValueForOption(option).Should().Be(123);
         }
     }
 }

--- a/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CommandHandlerTests.cs
@@ -270,7 +270,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await command.InvokeAsync("command -x 123", _console);
 
-            boundParseResult.ValueForOption(option).Should().Be(123);
+            boundParseResult.GetValueForOption(option).Should().Be(123);
         }
 
         [Fact]
@@ -287,7 +287,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await command.InvokeAsync("command -x 123", _console);
 
-            boundContext.ParseResult.ValueForOption(option).Should().Be(123);
+            boundContext.ParseResult.GetValueForOption(option).Should().Be(123);
         }
 
         [Fact]
@@ -319,7 +319,7 @@ namespace System.CommandLine.Tests.Invocation
 
             await command.InvokeAsync("command -x 123", _console);
 
-            boundContext.ParseResult.ValueForOption(option).Should().Be(123);
+            boundContext.ParseResult.GetValueForOption(option).Should().Be(123);
         }
 
 

--- a/src/System.CommandLine.Tests/OptionTests.MultipleArgumentsPerToken.cs
+++ b/src/System.CommandLine.Tests/OptionTests.MultipleArgumentsPerToken.cs
@@ -116,7 +116,7 @@ namespace System.CommandLine.Tests
 
                     var result = command.Parse(commandLine);
 
-                    var value = result.ValueForOption(option);
+                    var value = result.GetValueForOption(option);
 
                     value.Should().Be("2");
                 }
@@ -164,8 +164,8 @@ namespace System.CommandLine.Tests
                     _output.WriteLine(result.Diagram());
 
                     result.Errors.Should().BeEmpty();
-                    result.ValueForOption(optionY).Should().Be("-x");
-                    result.ValueForOption(optionX).Should().Be("-y");
+                    result.GetValueForOption(optionY).Should().Be("-x");
+                    result.GetValueForOption(optionX).Should().Be("-y");
                 }
             }
 
@@ -179,7 +179,7 @@ namespace System.CommandLine.Tests
 
                     var result = command.Parse("--option 1 2");
 
-                    var value = result.ValueForOption(option);
+                    var value = result.GetValueForOption(option);
 
                     value.Should().BeEquivalentTo(new[] { "1" });
                 }
@@ -204,7 +204,7 @@ namespace System.CommandLine.Tests
 
                     var result = command.Parse("--option 1 --option 2");
 
-                    var value = result.ValueForOption(option);
+                    var value = result.GetValueForOption(option);
 
                     value.Should().BeEquivalentTo(new[] { "1", "2" });
                     result.Errors.Should().BeEmpty();

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -221,9 +221,9 @@ namespace System.CommandLine.Tests
 
             var result = rootCommand.Parse(prefix + "c value-for-c " + prefix + "a value-for-a");
 
-            result.ValueForOption(optionA).Should().Be("value-for-a");
+            result.GetValueForOption(optionA).Should().Be("value-for-a");
             result.HasOption(optionB).Should().BeFalse();
-            result.ValueForOption(optionC).Should().Be("value-for-c");
+            result.GetValueForOption(optionC).Should().Be("value-for-c");
         }
 
         [Fact]
@@ -330,7 +330,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -344,7 +344,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse(); 
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -358,7 +358,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -372,7 +372,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -386,7 +386,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -399,7 +399,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -412,7 +412,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -425,7 +425,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -439,7 +439,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeEmpty();
         }
@@ -466,7 +466,7 @@ namespace System.CommandLine.Tests
 
             var parseResult = option.Parse(parseInput);
 
-            parseResult.ValueForOption(option).Should().Be("value");
+            parseResult.GetValueForOption(option).Should().Be("value");
         }
 
         [Fact]
@@ -479,7 +479,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.ValueForOption(option)
+            result.GetValueForOption(option)
                 .Should()
                 .BeFalse();
         }

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -114,7 +114,7 @@ namespace System.CommandLine.Tests
                     .BeEquivalentSequenceTo("three", "four", "five");
 
                 parseResult
-                    .ValueForOption(verbose)
+                    .GetValueForOption(verbose)
                     .Should()
                     .BeTrue();
             }
@@ -168,7 +168,7 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("-e foo");
 
-                var optionResult = result.ValueForOption(option);
+                var optionResult = result.GetValueForOption(option);
 
                 optionResult.Should().Be("foo");
             }

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -36,12 +36,12 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2 3 4");
 
-                result.ValueForArgument(multipleArityArg)
-                    .Should()
-                    .BeEquivalentSequenceTo("1", "2", "3");
-                result.ValueForArgument(singleArityArg)
-                    .Should()
-                    .BeEquivalentSequenceTo("4");
+                result.GetValueForArgument(multipleArityArg)
+                      .Should()
+                      .BeEquivalentSequenceTo("1", "2", "3");
+                result.GetValueForArgument(singleArityArg)
+                      .Should()
+                      .BeEquivalentSequenceTo("4");
             }
 
             [Fact]
@@ -64,8 +64,8 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2");
 
-                result.ValueForArgument(stringArg).Should().Be("1");
-                result.ValueForArgument(intArg).Should().Be(2);
+                result.GetValueForArgument(stringArg).Should().Be("1");
+                result.GetValueForArgument(intArg).Should().Be(2);
             }
 
             [Theory]
@@ -99,17 +99,17 @@ namespace System.CommandLine.Tests
                 var parseResult = command.Parse(commandLine);
 
                 parseResult
-                    .ValueForArgument(first)
+                    .GetValueForArgument(first)
                     .Should()
                     .Be("one");
 
                 parseResult
-                    .ValueForArgument(second)
+                    .GetValueForArgument(second)
                     .Should()
                     .Be("two");
 
                 parseResult
-                    .ValueForArgument(third)
+                    .GetValueForArgument(third)
                     .Should()
                     .BeEquivalentSequenceTo("three", "four", "five");
 
@@ -190,12 +190,12 @@ namespace System.CommandLine.Tests
 
                 var _ = new AssertionScope();
 
-                result.ValueForArgument(ints)
+                result.GetValueForArgument(ints)
                       .Should()
                       .BeEquivalentTo(new[] { 1, 2, 3 },
                                       options => options.WithStrictOrdering());
 
-                result.ValueForArgument(strings)
+                result.GetValueForArgument(strings)
                       .Should()
                       .BeEquivalentTo(new[] { "one", "two" },
                                       options => options.WithStrictOrdering());
@@ -217,16 +217,17 @@ namespace System.CommandLine.Tests
 
                 var _ = new AssertionScope();
 
-                result.ValueForArgument(ints)
+                result.GetValueForArgument(ints)
                       .Should()
                       .BeEquivalentTo(new[] { 1, 2, 3 },
                                       options => options.WithStrictOrdering());
 
-                result.ValueForArgument(strings)
+                result.GetValueForArgument(strings)
                       .Should()
                       .Be("four");
 
-                result.UnparsedTokens.Should()
+                result.UnparsedTokens
+                      .Should()
                       .ContainSingle()
                       .Which
                       .Should()

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -967,7 +967,7 @@ namespace System.CommandLine.Tests
             ParseResult result = command.Parse("command");
 
             result.HasOption(option).Should().BeTrue();
-            result.ValueForOption(option).Should().Be("the-default");
+            result.GetValueForOption(option).Should().Be("the-default");
         }
 
         [Fact]
@@ -1223,9 +1223,9 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-a -bc");
 
-            result.ValueForOption(optionA).Should().Be("-bc");
-            result.ValueForOption(optionB).Should().BeFalse();
-            result.ValueForOption(optionC).Should().BeFalse();
+            result.GetValueForOption(optionA).Should().Be("-bc");
+            result.GetValueForOption(optionB).Should().BeFalse();
+            result.GetValueForOption(optionC).Should().BeFalse();
         }
 
         [Fact]
@@ -1242,7 +1242,7 @@ namespace System.CommandLine.Tests
 
             _output.WriteLine(result.ToString());
 
-            result.ValueForOption(optionA).Should().Be("subcommand");
+            result.GetValueForOption(optionA).Should().Be("subcommand");
             result.CommandResult.Command.Should().Be(root);
         }
 
@@ -1279,7 +1279,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-x -x");
 
-            result.ValueForOption(optionX).Should().Be("-x");
+            result.GetValueForOption(optionX).Should().Be("-x");
         }
 
         [Fact]
@@ -1298,8 +1298,8 @@ namespace System.CommandLine.Tests
 
             _output.WriteLine(result.Diagram());
 
-            result.ValueForOption(optionX).Should().BeEquivalentTo(new[] { "-x", "-y", "-y" });
-            result.ValueForOption(optionY).Should().BeEquivalentTo(new[] { "-x", "-y", "-x" });
+            result.GetValueForOption(optionX).Should().BeEquivalentTo(new[] { "-x", "-y", "-y" });
+            result.GetValueForOption(optionY).Should().BeEquivalentTo(new[] { "-x", "-y", "-x" });
         }
 
         [Fact]
@@ -1316,7 +1316,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-yxx");
 
-            result.ValueForOption(optionX).Should().Be("x");
+            result.GetValueForOption(optionX).Should().Be("x");
         }
 
         [Fact]
@@ -1359,7 +1359,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-v an-argument");
 
-            result.ValueForOption(option).Should().BeTrue();
+            result.GetValueForOption(option).Should().BeTrue();
         }
 
         [Fact]
@@ -1573,7 +1573,7 @@ namespace System.CommandLine.Tests
 
             var parseResult = option.Parse("--value a;b;c");
 
-            var instance = parseResult.ValueForOption(option);
+            var instance = parseResult.GetValueForOption(option);
 
             instance.Values.Should().BeEquivalentTo("a", "b", "c");
         }
@@ -1585,7 +1585,7 @@ namespace System.CommandLine.Tests
 
             var parseResult = option.Parse("--value a;b;c");
 
-            CollectionWithCustomTypeConverter instance = parseResult.ValueForOption(option);
+            CollectionWithCustomTypeConverter instance = parseResult.GetValueForOption(option);
 
             instance.Should().BeEquivalentTo("a", "b", "c");
         }

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -952,7 +952,7 @@ namespace System.CommandLine.Tests
 
             ParseResult result = command.Parse("command");
 
-            result.ValueForArgument(argument)
+            result.GetValueForArgument(argument)
                   .Should()
                   .Be("default");
         }
@@ -1042,7 +1042,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("the-directory");
 
-            result.ValueForArgument(argument)
+            result.GetValueForArgument(argument)
                   ?.Name
                   .Should()
                   .Be("the-directory");
@@ -1333,8 +1333,8 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("name one two three");
 
-            result.ValueForArgument(nameArg).Should().Be("name");
-            result.ValueForArgument(columnsArg).Should().BeEquivalentTo("one", "two", "three");
+            result.GetValueForArgument(nameArg).Should().Be("name");
+            result.GetValueForArgument(columnsArg).Should().BeEquivalentTo("one", "two", "three");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1201,7 +1201,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse(input);
 
-            var valueForOption = result.ValueForOption(optionX);
+            var valueForOption = result.GetValueForOption(optionX);
 
             valueForOption.Should().Be("-y");
         }
@@ -1262,7 +1262,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse(input);
 
-            var valueForOption = result.ValueForOption(optionX);
+            var valueForOption = result.GetValueForOption(optionX);
 
             valueForOption.Should().Be("-y");
         }
@@ -1376,8 +1376,8 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-x 23 unmatched-token -y 42");
 
-            result.ValueForOption(optionX).Should().Be("23");
-            result.ValueForOption(optionY).Should().Be("42");
+            result.GetValueForOption(optionX).Should().Be("23");
+            result.GetValueForOption(optionY).Should().Be("42");
             result.UnmatchedTokens.Should().BeEquivalentTo("unmatched-token");
         }
 

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -918,8 +918,8 @@ namespace System.CommandLine.Tests
             var result = parser.Parse("");
 
             result.Errors.Should().BeEmpty();
-            result.ValueForOption(optionX).Should().Be(123);
-            result.ValueForOption(optionY).Should().Be(456);
+            result.GetValueForOption(optionX).Should().Be(123);
+            result.GetValueForOption(optionY).Should().Be(456);
         }
     }
 }

--- a/src/System.CommandLine.Tests/ResponseFileTests.cs
+++ b/src/System.CommandLine.Tests/ResponseFileTests.cs
@@ -70,7 +70,7 @@ namespace System.CommandLine.Tests
                 .Parse($"@{responseFile}");
 
             result.HasOption(optionOne).Should().BeTrue();
-            result.ValueForOption(optionTwo).Should().Be(123);
+            result.GetValueForOption(optionTwo).Should().Be(123);
             result.Errors.Should().BeEmpty();
         }
 
@@ -180,7 +180,7 @@ namespace System.CommandLine.Tests
                 }
                 .Parse($"@{responseFile}");
 
-            result.ValueForOption(option).Should().Be(123);
+            result.GetValueForOption(option).Should().Be(123);
             result.Errors.Should().BeEmpty();
         }
 
@@ -294,8 +294,8 @@ namespace System.CommandLine.Tests
 
             var result = parser.Parse($"@{responseFile}");
 
-            result.ValueForOption(optionOne).Should().Be("first value");
-            result.ValueForOption(optionTwo).Should().Be(123);
+            result.GetValueForOption(optionOne).Should().Be("first value");
+            result.GetValueForOption(optionTwo).Should().Be(123);
         }
 
         [Fact]
@@ -355,8 +355,8 @@ namespace System.CommandLine.Tests
             var option2 = new Option<int>("--option2");
 
             var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
-            result.ValueForOption(option1).Should().Be("value1");
-            result.ValueForOption(option2).Should().Be(2);
+            result.GetValueForOption(option1).Should().Be("value1");
+            result.GetValueForOption(option2).Should().Be(2);
         }
 
         [Fact]
@@ -368,8 +368,8 @@ namespace System.CommandLine.Tests
             var option2 = new Option<int>("--option2");
 
             var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
-            result.ValueForOption(option1).Should().Be("value1");
-            result.ValueForOption(option2).Should().Be(2);
+            result.GetValueForOption(option1).Should().Be("value1");
+            result.GetValueForOption(option2).Should().Be(2);
             result.Errors.Should().BeEmpty();
         }
 
@@ -382,8 +382,8 @@ namespace System.CommandLine.Tests
             var option2 = new Option<int>("--option2");
 
             var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
-            result.ValueForOption(option1).Should().Be("value1");
-            result.ValueForOption(option2).Should().Be(2);
+            result.GetValueForOption(option1).Should().Be("value1");
+            result.GetValueForOption(option2).Should().Be(2);
             result.Errors.Should().BeEmpty();
         }
     }

--- a/src/System.CommandLine.Tests/SuggestionTests.cs
+++ b/src/System.CommandLine.Tests/SuggestionTests.cs
@@ -171,12 +171,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_Getsuggestions_can_access_ParseResult()
         {
+            var originOption = new Option<string>("--origin");
+
             var parser = new Parser(
-                new Option<string>("--origin"),
+                originOption,
                 new Option<string>("--clone")
                 .AddSuggestions((parseResult, match) =>
                 {
-                    var opt1Value = parseResult?.ValueForOption<string>("--origin");
+                    var opt1Value = parseResult?.GetValueForOption(originOption);
                     return !string.IsNullOrWhiteSpace(opt1Value) ? new[] { opt1Value } : Array.Empty<string>();
                 }));
 

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Tests
 {
     public class UseHelpTests
     {
-        private readonly TestConsole _console = new TestConsole();
+        private readonly TestConsole _console = new();
 
         [Fact]
         public async Task UseHelp_writes_help_for_the_specified_command()

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -23,7 +23,7 @@ namespace System.CommandLine.Builder
     public static class CommandLineBuilderExtensions
     {
         private static readonly Lazy<string> _assemblyVersion =
-            new Lazy<string>(() =>
+            new(() =>
             {
                 var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
                 var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine.Invocation
             Func<T1, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!));
+                                     context.ParseResult.GetValueFor(symbol1)!));
 
         public static ICommandHandler Create<T1, T2>(
             IValueDescriptor<T1> symbol1,
@@ -24,8 +24,8 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!));
 
         public static ICommandHandler Create<T1, T2, T3>(
             IValueDescriptor<T1> symbol1,
@@ -34,9 +34,9 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4>(
             IValueDescriptor<T1> symbol1,
@@ -46,10 +46,10 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5>(
             IValueDescriptor<T1> symbol1,
@@ -60,11 +60,11 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6>(
             IValueDescriptor<T1> symbol1,
@@ -76,12 +76,12 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7>(
             IValueDescriptor<T1> symbol1,
@@ -94,13 +94,13 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8>(
             IValueDescriptor<T1> symbol1,
@@ -114,14 +114,14 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
             IValueDescriptor<T1> symbol1,
@@ -136,15 +136,15 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!,
-                                     context.ParseResult.ValueFor(symbol9)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!,
+                                     context.ParseResult.GetValueFor(symbol9)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
             IValueDescriptor<T1> symbol1,
@@ -160,16 +160,16 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!,
-                                     context.ParseResult.ValueFor(symbol9)!,
-                                     context.ParseResult.ValueFor(symbol10)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!,
+                                     context.ParseResult.GetValueFor(symbol9)!,
+                                     context.ParseResult.GetValueFor(symbol10)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
             IValueDescriptor<T1> symbol1,
@@ -186,17 +186,17 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!,
-                                     context.ParseResult.ValueFor(symbol9)!,
-                                     context.ParseResult.ValueFor(symbol10)!,
-                                     context.ParseResult.ValueFor(symbol11)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!,
+                                     context.ParseResult.GetValueFor(symbol9)!,
+                                     context.ParseResult.GetValueFor(symbol10)!,
+                                     context.ParseResult.GetValueFor(symbol11)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
             IValueDescriptor<T1> symbol1,
@@ -214,18 +214,18 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!,
-                                     context.ParseResult.ValueFor(symbol9)!,
-                                     context.ParseResult.ValueFor(symbol10)!,
-                                     context.ParseResult.ValueFor(symbol11)!,
-                                     context.ParseResult.ValueFor(symbol12)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!,
+                                     context.ParseResult.GetValueFor(symbol9)!,
+                                     context.ParseResult.GetValueFor(symbol10)!,
+                                     context.ParseResult.GetValueFor(symbol11)!,
+                                     context.ParseResult.GetValueFor(symbol12)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
             IValueDescriptor<T1> symbol1,
@@ -244,19 +244,19 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!,
-                                     context.ParseResult.ValueFor(symbol9)!,
-                                     context.ParseResult.ValueFor(symbol10)!,
-                                     context.ParseResult.ValueFor(symbol11)!,
-                                     context.ParseResult.ValueFor(symbol12)!,
-                                     context.ParseResult.ValueFor(symbol13)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!,
+                                     context.ParseResult.GetValueFor(symbol9)!,
+                                     context.ParseResult.GetValueFor(symbol10)!,
+                                     context.ParseResult.GetValueFor(symbol11)!,
+                                     context.ParseResult.GetValueFor(symbol12)!,
+                                     context.ParseResult.GetValueFor(symbol13)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
             IValueDescriptor<T1> symbol1,
@@ -276,20 +276,20 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!,
-                                     context.ParseResult.ValueFor(symbol9)!,
-                                     context.ParseResult.ValueFor(symbol10)!,
-                                     context.ParseResult.ValueFor(symbol11)!,
-                                     context.ParseResult.ValueFor(symbol12)!,
-                                     context.ParseResult.ValueFor(symbol13)!,
-                                     context.ParseResult.ValueFor(symbol14)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!,
+                                     context.ParseResult.GetValueFor(symbol9)!,
+                                     context.ParseResult.GetValueFor(symbol10)!,
+                                     context.ParseResult.GetValueFor(symbol11)!,
+                                     context.ParseResult.GetValueFor(symbol12)!,
+                                     context.ParseResult.GetValueFor(symbol13)!,
+                                     context.ParseResult.GetValueFor(symbol14)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
             IValueDescriptor<T1> symbol1,
@@ -310,21 +310,21 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!,
-                                     context.ParseResult.ValueFor(symbol9)!,
-                                     context.ParseResult.ValueFor(symbol10)!,
-                                     context.ParseResult.ValueFor(symbol11)!,
-                                     context.ParseResult.ValueFor(symbol12)!,
-                                     context.ParseResult.ValueFor(symbol13)!,
-                                     context.ParseResult.ValueFor(symbol14)!,
-                                     context.ParseResult.ValueFor(symbol15)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!,
+                                     context.ParseResult.GetValueFor(symbol9)!,
+                                     context.ParseResult.GetValueFor(symbol10)!,
+                                     context.ParseResult.GetValueFor(symbol11)!,
+                                     context.ParseResult.GetValueFor(symbol12)!,
+                                     context.ParseResult.GetValueFor(symbol13)!,
+                                     context.ParseResult.GetValueFor(symbol14)!,
+                                     context.ParseResult.GetValueFor(symbol15)!));
 
         public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
             IValueDescriptor<T1> symbol1,
@@ -346,22 +346,22 @@ namespace System.CommandLine.Invocation
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, Task> handle) =>
             new AnonymousCommandHandler(
                 async context => await handle(
-                                     context.ParseResult.ValueFor(symbol1)!,
-                                     context.ParseResult.ValueFor(symbol2)!,
-                                     context.ParseResult.ValueFor(symbol3)!,
-                                     context.ParseResult.ValueFor(symbol4)!,
-                                     context.ParseResult.ValueFor(symbol5)!,
-                                     context.ParseResult.ValueFor(symbol6)!,
-                                     context.ParseResult.ValueFor(symbol7)!,
-                                     context.ParseResult.ValueFor(symbol8)!,
-                                     context.ParseResult.ValueFor(symbol9)!,
-                                     context.ParseResult.ValueFor(symbol10)!,
-                                     context.ParseResult.ValueFor(symbol11)!,
-                                     context.ParseResult.ValueFor(symbol12)!,
-                                     context.ParseResult.ValueFor(symbol13)!,
-                                     context.ParseResult.ValueFor(symbol14)!,
-                                     context.ParseResult.ValueFor(symbol15)!,
-                                     context.ParseResult.ValueFor(symbol16)!));
+                                     context.ParseResult.GetValueFor(symbol1)!,
+                                     context.ParseResult.GetValueFor(symbol2)!,
+                                     context.ParseResult.GetValueFor(symbol3)!,
+                                     context.ParseResult.GetValueFor(symbol4)!,
+                                     context.ParseResult.GetValueFor(symbol5)!,
+                                     context.ParseResult.GetValueFor(symbol6)!,
+                                     context.ParseResult.GetValueFor(symbol7)!,
+                                     context.ParseResult.GetValueFor(symbol8)!,
+                                     context.ParseResult.GetValueFor(symbol9)!,
+                                     context.ParseResult.GetValueFor(symbol10)!,
+                                     context.ParseResult.GetValueFor(symbol11)!,
+                                     context.ParseResult.GetValueFor(symbol12)!,
+                                     context.ParseResult.GetValueFor(symbol13)!,
+                                     context.ParseResult.GetValueFor(symbol14)!,
+                                     context.ParseResult.GetValueFor(symbol15)!,
+                                     context.ParseResult.GetValueFor(symbol16)!));
 
         private class AnonymousCommandHandler : ICommandHandler
         {

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -101,6 +101,9 @@ namespace System.CommandLine.Parsing
         public object? ValueForOption(Option option) =>
             GetValueForOption<object?>(option);
 
+        public object? GetValueForOption(Option option) =>
+            GetValueForOption<object?>(option);
+
         [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForArgument<T>(Argument<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
         public object? ValueForArgument(string alias) =>
             ValueForArgument<object?>(alias);

--- a/src/System.CommandLine/Parsing/ParseResult.cs
+++ b/src/System.CommandLine/Parsing/ParseResult.cs
@@ -85,31 +85,59 @@ namespace System.CommandLine.Parsing
         public IReadOnlyList<string> UnparsedTokens => _unparsedTokens.Select(t => t.Value).ToArray();
 
         [return: MaybeNull]
-        internal T ValueFor<T>(IValueDescriptor<T> symbol) =>
+        internal T GetValueFor<T>(IValueDescriptor<T> symbol) =>
             symbol switch
             {
-                Argument<T> argument => ValueForArgument(argument),
-                Option<T> option => ValueForOption(option),
+                Argument<T> argument => GetValueForArgument(argument),
+                Option<T> option => GetValueForOption(option),
                 _ => throw new ArgumentOutOfRangeException()
             };
 
-
-        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.ValueForOption<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
+        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForOption<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
         public object? ValueForOption(string alias) =>
             ValueForOption<object?>(alias);
         
+        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForOption<T>(Option) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
         public object? ValueForOption(Option option) =>
-            ValueForOption<object?>(option);
+            GetValueForOption<object?>(option);
 
-        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.ValueForArgument<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
+        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForArgument<T>(Argument<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
         public object? ValueForArgument(string alias) =>
             ValueForArgument<object?>(alias);
 
+        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForArgument<T>(Argument) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
          public object? ValueForArgument(Argument argument) =>
-            ValueForArgument<object?>(argument);
+            GetValueForArgument<object?>(argument);
 
+         public object? GetValueForArgument(Argument argument) =>
+            GetValueForArgument<object?>(argument);
+
+         [Obsolete(
+             "This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForArgument<T>(Argument<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
+         [return: MaybeNull]
+         public T ValueForArgument<T>(Argument<T> argument) => 
+             GetValueForArgument(argument);
+       
         [return: MaybeNull]
-        public T ValueForArgument<T>(Argument<T> argument)
+        public T GetValueForArgument<T>(Argument<T> argument)
+        {
+            if (FindResultFor(argument) is { } result &&
+                result.GetValueOrDefault<T>() is { } t)
+            {
+                return t;
+            }
+
+            return (T)Binder.GetDefaultValue(argument.ArgumentType)!;
+        }
+
+        [Obsolete(
+            "This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForArgument<T>(Argument) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
+        [return: MaybeNull]
+        internal T ValueForArgument<T>(Argument argument) => 
+            GetValueForArgument<T>(argument);
+        
+        [return: MaybeNull]
+        public T GetValueForArgument<T>(Argument argument)
         {
             if (FindResultFor(argument) is { } result &&
                 result.GetValueOrDefault<T>() is { } t)
@@ -121,19 +149,7 @@ namespace System.CommandLine.Parsing
         }
 
         [return: MaybeNull]
-        internal T ValueForArgument<T>(Argument argument)
-        {
-            if (FindResultFor(argument) is { } result &&
-                result.GetValueOrDefault<T>() is { } t)
-            {
-                return t;
-            }
-
-            return (T)Binder.GetDefaultValue(argument.ArgumentType)!;
-        }
-
-        [return: MaybeNull]
-        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.ValueForArgument<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
+        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForArgument<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
         public T ValueForArgument<T>(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -151,8 +167,13 @@ namespace System.CommandLine.Parsing
             }
         }
 
+        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForOption<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
         [return: MaybeNull]
-        public T ValueForOption<T>(Option<T> option)
+        public T ValueForOption<T>(Option<T> option) => 
+            GetValueForOption(option);
+
+        [return: MaybeNull]
+        public T GetValueForOption<T>(Option<T> option)
         {
             if (FindResultFor(option) is { } result &&
                 result.GetValueOrDefault<T>() is { } t)
@@ -164,7 +185,7 @@ namespace System.CommandLine.Parsing
         }
 
         [return: MaybeNull]
-        private T ValueForOption<T>(Option option)
+        public T GetValueForOption<T>(Option option)
         {
             if (FindResultFor(option) is { } result &&
                 result.GetValueOrDefault<T>() is { } t)
@@ -175,7 +196,7 @@ namespace System.CommandLine.Parsing
             return (T)Binder.GetDefaultValue(option.Argument.ArgumentType)!;
         }
 
-        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.ValueForOption<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
+        [Obsolete("This method is obsolete and will be removed in a future version. Please use ParseResult.GetValueForOption<T>(Option<T>) instead. For details see https://github.com/dotnet/command-line-api/issues/1127")]
         [return: MaybeNull]
         public T ValueForOption<T>(string alias)
         {
@@ -194,6 +215,7 @@ namespace System.CommandLine.Parsing
             }
         }
 
+        /// <inheritdoc />
         public override string ToString() => $"{nameof(ParseResult)}: {this.Diagram()}";
 
         public ArgumentResult? FindResultFor(IArgument argument) =>


### PR DESCRIPTION
Continuing work on #1127.