### PR TITLE
[ArPow] Use --work-tree with git apply

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <Exec
-      Command="git apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
+      Command="git --work-tree=$(RepoRoot) apply --ignore-whitespace --whitespace=nowarn &quot;%(SourceBuildPatchFile.FullPath)&quot;"
       WorkingDirectory="$(RepoRoot)"
       Condition="'@(SourceBuildPatchFile)' != ''" />
   </Target>


### PR DESCRIPTION
This makes things work better in a source-tarball build, where there may be a .git directory but it's for a different repo than command-line-api.

cc @dotnet/source-build-contrib 