### PR TITLE
Proposal: Move [options] to the end of the usage in help

### DIFF
--- a/src/System.CommandLine.Tests/Help/Approvals/HelpBuilderTests.Help_describes_default_values_for_complex_root_command_scenario.approved.txt
+++ b/src/System.CommandLine.Tests/Help/Approvals/HelpBuilderTests.Help_describes_default_values_for_complex_root_command_scenario.approved.txt
@@ -2,7 +2,7 @@
   Test description
 
 Usage:
-  the-root-command [options] <the-root-arg-no-description-no-default> [<the-root-arg-no-description-default> <the-root-arg-no-default> [<the-root-arg> [<the-root-arg-enum-default>]]]
+  the-root-command <the-root-arg-no-description-no-default> [<the-root-arg-no-description-default> <the-root-arg-no-default> [<the-root-arg> [<the-root-arg-enum-default>]]] [options]
 
 Arguments:
   <the-root-arg-no-description-no-default>

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -137,7 +137,7 @@ namespace System.CommandLine.Tests.Help
 
             var expected =
                 $"Usage:{NewLine}" +
-                $"{_indentation}{_executableName} [options] the-command {expectedDescriptor}";
+                $"{_indentation}{_executableName} the-command {expectedDescriptor} [options]";
 
             _console.ToString().Should().Contain(expected);
         }
@@ -181,7 +181,7 @@ namespace System.CommandLine.Tests.Help
 
             var expected =
                 $"Usage:{NewLine}" +
-                $"{_indentation}{_executableName} [options] the-command {expectedDescriptor}";
+                $"{_indentation}{_executableName} the-command {expectedDescriptor} [options]";
 
             _console.ToString().Should().Contain(expected);
         }
@@ -202,7 +202,7 @@ namespace System.CommandLine.Tests.Help
 
             var expected =
                 $"Usage:{NewLine}" +
-                $"{_indentation}{_executableName} [options] outer inner inner-er";
+                $"{_indentation}{_executableName} outer inner inner-er [options]";
 
             _console.ToString().Should().Contain(expected);
         }
@@ -231,7 +231,7 @@ namespace System.CommandLine.Tests.Help
 
             var expected =
                 $"Usage:{NewLine}" +
-                $"{_indentation}outer [options] [<outer-args>...] inner [<inner-args>...]";
+                $"{_indentation}outer [<outer-args>...] inner [<inner-args>...] [options]";
 
             _console.ToString().Should().Contain(expected);
         }

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -37,7 +37,7 @@ namespace System.CommandLine.Tests
 
             await result.InvokeAsync(_console);
 
-            _console.Out.ToString().Should().Contain($"{RootCommand.ExecutableName} [options] command subcommand");
+            _console.Out.ToString().Should().Contain($"{RootCommand.ExecutableName} command subcommand [options]");
         }
          
         [Fact]

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -124,17 +124,10 @@ namespace System.CommandLine.Help
                         .RecurseWhileNotNull(c => c.Parents.FirstOrDefaultOfType<ICommand>())
                         .Reverse();
 
-                var displayOptionTitle = command.Options.Any(x => !x.IsHidden);
 
                 foreach (ICommand parentCommand in parentCommands)
                 {
                     yield return parentCommand.Name;
-
-                    if (displayOptionTitle)
-                    {
-                        yield return LocalizationResources.HelpUsageOptionsTitle();
-                        displayOptionTitle = false;
-                    }
 
                     yield return FormatArgumentUsage(parentCommand.Arguments);
                 }
@@ -146,6 +139,14 @@ namespace System.CommandLine.Help
                 if (hasCommandWithHelp)
                 {
                     yield return LocalizationResources.HelpUsageCommandTitle();
+                }
+
+                var displayOptionTitle = command.Options.Any(x => !x.IsHidden);
+                
+                if (displayOptionTitle)
+                {
+                    yield return LocalizationResources.HelpUsageOptionsTitle();
+                    displayOptionTitle = false;
                 }
 
                 if (!command.TreatUnmatchedTokensAsErrors)


### PR DESCRIPTION
This feels like a more natural location where people will typically specify the options (after the command arguments) when typing them.