### PR TITLE
fix #1238

### DIFF
--- a/src/System.CommandLine.Hosting.Tests/HostingTests.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingTests.cs
@@ -110,6 +110,7 @@ namespace System.CommandLine.Hosting.Tests
                 {
                     Handler = CommandHandler.Create<IHost>(Execute),
                 })
+                .EnableLegacyDoubleDashBehavior()
                 .UseHost(host =>
                 {
                     var invocation = (InvocationContext)host.Properties[typeof(InvocationContext)];
@@ -147,6 +148,7 @@ namespace System.CommandLine.Hosting.Tests
                 {
                     Handler = CommandHandler.Create<IHost>(Execute),
                 })
+                .EnableLegacyDoubleDashBehavior()
                 .UseHost(args =>
                 {
                     var host = new HostBuilder();

--- a/src/System.CommandLine.Suggest.Tests/SuggestionDispatcherTests.cs
+++ b/src/System.CommandLine.Suggest.Tests/SuggestionDispatcherTests.cs
@@ -30,8 +30,7 @@ namespace System.CommandLine.Suggest.Tests
                 ? @"C:\Windows\System32\net.exe"
                 : "/bin/net";
 
-        private static Registration CurrentExeRegistrationPair()
-            => new Registration(CurrentExeFullPath());
+        private static Registration CurrentExeRegistrationPair() => new(CurrentExeFullPath());
 
         private static string CurrentExeFullPath() => Path.GetFullPath(_currentExeName);
 

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -63,6 +63,7 @@ namespace System.CommandLine.Suggest
             };
 
             Parser = new CommandLineBuilder(root)
+                     .EnableLegacyDoubleDashBehavior()
                      .UseVersionOption()
                      .UseHelp()
                      .UseParseDirective()

--- a/src/System.CommandLine.Tests/ParserTests.DoubleDash.cs
+++ b/src/System.CommandLine.Tests/ParserTests.DoubleDash.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using System.CommandLine.Tests.Utility;
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public partial class ParserTests
+    {
+        public class DoubleDash
+        {
+            [Fact]
+            public void When_legacy_behavior_is_enabled_then_the_portion_of_the_command_line_following_a_double_dasare_treated_as_unparsed_tokens()
+            {
+                var result = new CommandLineBuilder(new RootCommand { new Option("-o") })
+                             .EnableLegacyDoubleDashBehavior()
+                             .Build()
+                             .Parse("-o \"some stuff\" -- x y z");
+
+                result.UnparsedTokens
+                      .Should()
+                      .BeEquivalentSequenceTo("x", "y", "z");
+            }
+
+            [Fact]
+            public void When_legacy_behavior_is_enabled_then_a_double_dash_specifies_that_tokens_matching_options_will_be_treated_as_unparsed_tokens()
+            {
+                var optionO = new Option(new[] { "-o" });
+                var optionX = new Option(new[] { "-x" });
+                var optionY = new Option(new[] { "-y" });
+                var optionZ = new Option(new[] { "-z" });
+                var rootCommand = new RootCommand
+                {
+                    optionO,
+                    optionX,
+                    optionY,
+                    optionZ
+                };
+                var result = new CommandLineBuilder(rootCommand)
+                             .EnableLegacyDoubleDashBehavior()
+                             .Build()
+                             .Parse("-o \"some stuff\" -- -x -y -z -o:foo");
+
+                result.HasOption(optionO).Should().BeTrue();
+                result.HasOption(optionX).Should().BeFalse();
+                result.HasOption(optionY).Should().BeFalse();
+                result.HasOption(optionZ).Should().BeFalse();
+
+                result.UnparsedTokens
+                      .Should()
+                      .BeEquivalentSequenceTo("-x",
+                                              "-y",
+                                              "-z",
+                                              "-o:foo");
+            }
+
+            [Fact]
+            public void When_legacy_behavior_is_disabled_then_a_double_dash_specifies_that_further_command_line_args_will_be_treated_as_arguments()
+            {
+                var option = new Option<string[]>(new[] { "-o", "--one" });
+                var argument = new Argument<string[]>();
+                var rootCommand = new RootCommand
+                {
+                    option,
+                    argument
+                };
+
+                var result = new CommandLineBuilder(rootCommand)
+                             .EnableLegacyDoubleDashBehavior(false)
+                             .Build()
+                             .Parse("-o \"some stuff\" -- -o --one -x -y -z -o:foo");
+
+                result.HasOption(option).Should().BeTrue();
+
+                result.GetValueForOption(option).Should().BeEquivalentTo("some stuff");
+
+                result.GetValueForArgument(argument).Should().BeEquivalentSequenceTo("-o", "--one", "-x", "-y", "-z", "-o:foo");
+
+                result.UnparsedTokens.Should().BeEmpty();
+            }
+
+            [Fact]
+            public void When_legacy_behavior_is_disabled_then_a_second_double_dash_is_parsed_as_an_argument()
+            {
+                var argument = new Argument<string[]>();
+                var rootCommand = new RootCommand
+                {
+                    argument
+                };
+
+                var result = new CommandLineBuilder(rootCommand)
+                             .EnableLegacyDoubleDashBehavior(false)
+                             .Build()
+                             .Parse("a b c -- -- d");
+
+                var strings = result.GetValueForArgument(argument);
+
+                strings.Should().BeEquivalentSequenceTo("a", "b", "c", "--", "d");
+            }
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.CommandLine.Parsing;
 using System.CommandLine.Tests.Utility;
 using FluentAssertions;
 using FluentAssertions.Execution;

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -94,36 +94,6 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void A_double_dash_delimiter_specifies_that_no_further_command_line_args_will_be_treated_as_options()
-        {
-            var option = new Option(new[] { "-o", "--one" });
-            var result = new Parser(option)
-                .Parse("-o \"some stuff\" -- -x -y -z -o:foo");
-
-            result.HasOption(option)
-                  .Should()
-                  .BeTrue();
-
-            result.UnparsedTokens
-                  .Should()
-                  .BeEquivalentSequenceTo("-x",
-                                          "-y",
-                                          "-z",
-                                          "-o:foo");
-        }
-
-        [Fact]
-        public void The_portion_of_the_command_line_following_a_double_dash_is_accessible_as_UnparsedTokens()
-        {
-            var result = new Parser(new Option("-o"))
-                .Parse("-o \"some stuff\" -- x y z");
-
-            result.UnparsedTokens
-                  .Should()
-                  .BeEquivalentSequenceTo("x", "y", "z");
-        }
-
-        [Fact]
         public void Short_form_options_can_be_specified_using_equals_delimiter()
         {
             var option = new Option<string>("-x") { Arity = ArgumentArity.ExactlyOne };

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -36,6 +36,12 @@ namespace System.CommandLine.Builder
         public bool EnablePosixBundling { get; set; } = true;
 
         /// <summary>
+        /// Determines the behavior when parsing a double dash (<c>--</c>) in a command line.
+        /// </summary>
+        /// <remarks>When set to <see langword="true"/>, all tokens following <c>--</c> will be placed into the <see cref="ParseResult.UnparsedTokens"/> collection. When set to <see langword="false"/>, all tokens following <c>--</c> will be treated as command arguments, even if they match an existing option.</remarks>
+        public bool EnableLegacyDoubleDashBehavior { get; set; }
+
+        /// <summary>
         /// Configures the parser's handling of response files. When enabled, a command line token beginning with <c>@</c> that is a valid file path will be expanded as though inserted into the command line. 
         /// </summary>
         public ResponseFileHandling ResponseFileHandling { get; set; }
@@ -64,6 +70,7 @@ namespace System.CommandLine.Builder
                     Command,
                     enablePosixBundling: EnablePosixBundling,
                     enableDirectives: EnableDirectives,
+                    enableLegacyDoubleDashBehavior: EnableLegacyDoubleDashBehavior,
                     resources: LocalizationResources,
                     responseFileHandling: ResponseFileHandling,
                     middlewarePipeline: _middlewareList.OrderBy(m => m.order)

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -130,6 +130,18 @@ namespace System.CommandLine.Builder
         }
 
         /// <summary>
+        /// Determines the behavior when parsing a double dash (<c>--</c>) in a command line.
+        /// </summary>
+        /// <remarks>When set to <see langword="true"/>, all tokens following <c>--</c> will be placed into the <see cref="ParseResult.UnparsedTokens"/> collection. When set to <see langword="false"/>, all tokens following <c>--</c> will be treated as command arguments, even if they match an existing option.</remarks>
+        public static CommandLineBuilder EnableLegacyDoubleDashBehavior(
+            this CommandLineBuilder builder,
+            bool value = true)
+        {
+            builder.EnableLegacyDoubleDashBehavior = value;
+            return builder;
+        }
+
+        /// <summary>
         /// Enables the parser to recognize and expand POSIX-style bundled options.
         /// </summary>
         /// <param name="builder">A command line builder.</param>

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Parsing
         private readonly TokenizeResult _tokenizeResult;
         private readonly CommandLineConfiguration _configuration;
         private int _index;
-        private readonly Dictionary<IArgument, int> _argumentCounts = new Dictionary<IArgument, int>();
+        private readonly Dictionary<IArgument, int> _argumentCounts = new();
 
         public ParseOperation(
             TokenizeResult tokenizeResult,
@@ -23,18 +23,15 @@ namespace System.CommandLine.Parsing
 
         private Token CurrentToken => _tokenizeResult.Tokens[_index];
 
-        public List<ParseError> Errors { get; } = new List<ParseError>();
+        public List<ParseError> Errors { get; } = new();
 
         public RootCommandNode? RootCommandNode { get; private set; }
 
-        public List<Token> UnmatchedTokens { get; } = new List<Token>();
+        public List<Token> UnmatchedTokens { get; } = new();
 
-        public List<Token> UnparsedTokens { get; } = new List<Token>();
+        public List<Token> UnparsedTokens { get; } = new();
 
-        private void Advance()
-        {
-            _index++;
-        }
+        private void Advance() => _index++;
 
         private void IncrementCount(IArgument argument)
         {
@@ -108,7 +105,8 @@ namespace System.CommandLine.Parsing
         {
             while (More())
             {
-                if (CurrentToken.Type == TokenType.EndOfArguments)
+                if (_configuration.EnableLegacyDoubleDashBehavior &&
+                    CurrentToken.Type == TokenType.DoubleDash)
                 {
                     return;
                 }
@@ -276,7 +274,7 @@ namespace System.CommandLine.Parsing
 
             while (More())
             {
-                if (CurrentToken.Type == TokenType.EndOfArguments)
+                if (CurrentToken.Type == TokenType.DoubleDash)
                 {
                     foundEndOfArguments = true;
                 }

--- a/src/System.CommandLine/Parsing/TokenType.cs
+++ b/src/System.CommandLine/Parsing/TokenType.cs
@@ -30,13 +30,13 @@ namespace System.CommandLine.Parsing
         /// A double dash (<c>--</c>) token, which changes the meaning of subsequent tokens.
         /// </summary>
         /// <see cref="CommandLineConfiguration.EnableLegacyDoubleDashBehavior"/>
-        EndOfArguments,
+        DoubleDash,
 
         /// <summary>
-        /// A token following <see cref="EndOfArguments"/>.
+        /// A token following <see cref="DoubleDash"/> when <see cref="CommandLineConfiguration.EnableLegacyDoubleDashBehavior"/> is set to <see langword="true"/>.
         /// </summary>
         /// <see cref="CommandLineConfiguration.EnableLegacyDoubleDashBehavior"/>
-        Operand,
+        Unparsed,
         
         /// <summary>
         /// A directive token.


### PR DESCRIPTION
This fixes #1238. The old behavior can be opted into using `EnableLegacyDoubleDashBehavior`.

