### PR TITLE
Fix #1294

### DIFF
--- a/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
+++ b/src/System.CommandLine.Tests/Binding/ModelBinderTests.cs
@@ -493,9 +493,8 @@ namespace System.CommandLine.Tests.Binding
         public void Option_argument_is_bound_to_longest_constructor()
         {
             var option = new Option<int>("--int-property");
-            var parser = new Parser(option);
 
-            var bindingContext = new BindingContext(parser.Parse("--int-property 42"));
+            var bindingContext = new BindingContext(option.Parse("--int-property 42"));
             var binder = new ModelBinder<ClassWithMultipleCtor>();
             var instance = binder.CreateInstance(bindingContext) as ClassWithMultipleCtor;
 

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -121,9 +121,8 @@ namespace System.CommandLine.Tests.Binding
         public void Argument_bool_will_default_to_true_when_no_argument_is_passed()
         {
             var option = new Option<bool>("-x");
-            var parser = new Parser(option);
 
-            var result = parser.Parse("-x");
+            var result = option.Parse("-x");
 
             result.Errors.Should().BeEmpty();
             result.GetValueForOption(option).Should().Be(true);

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -25,11 +25,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_accepts_only_specific_arguments_but_a_wrong_one_is_supplied_then_an_informative_error_is_returned()
         {
-            var parser = new Parser(
-                new Option("-x", arity: ArgumentArity.ExactlyOne)
-                    .FromAmong("this", "that", "the-other-thing"));
-
-            var result = parser.Parse("-x none-of-those");
+            var option = new Option("-x", arity: ArgumentArity.ExactlyOne)
+                .FromAmong("this", "that", "the-other-thing");
+            
+            var result = option.Parse("-x none-of-those");
 
             result.Errors
                   .Select(e => e.Message)
@@ -44,9 +43,7 @@ namespace System.CommandLine.Tests
             var option = new Option("-x", arity: ArgumentArity.ExactlyOne)
                 .FromAmong("this", "that");
 
-            var parser = new Parser(option);
-
-            var result = parser.Parse("-x something_else");
+            var result = option.Parse("-x something_else");
 
             result.Errors
                   .Where(e => e.SymbolResult != null)
@@ -57,9 +54,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_required_argument_is_not_supplied_then_an_error_is_returned()
         {
-            var parser = new Parser(new Option("-x", arity: ArgumentArity.ExactlyOne));
+            var option = new Option("-x", arity: ArgumentArity.ExactlyOne);
 
-            var result = parser.Parse("-x");
+            var result = option.Parse("-x");
 
             result.Errors
                   .Should()
@@ -894,10 +891,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_a_default_value_it_is_not_valid_to_specify_the_option_without_an_argument()
         {
-            var parser = new Parser(
-                new Option<int>("-x", () => 123));
+            var option = new Option<int>("-x", () => 123);
 
-            var result = parser.Parse("-x");
+            var result = option.Parse("-x");
 
             result.Errors
                   .Select(e => e.Message)

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -178,6 +178,8 @@ namespace System.CommandLine
         /// </summary>
         public bool HasDefaultValue => _defaultValueFactory is not null;
 
+        internal virtual bool HasCustomParser => false;
+
         internal static Argument None() => new()
         {
             Arity = ArgumentArity.Zero,

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -9,6 +9,8 @@ namespace System.CommandLine
     /// <inheritdoc cref="Argument" />
     public class Argument<T> : Argument, IValueDescriptor<T>
     {
+        private bool _hasCustomParser;
+
         /// <summary>
         /// Initializes a new instance of the Argument class.
         /// </summary>
@@ -110,6 +112,8 @@ namespace System.CommandLine
                 }
             };
 
+            _hasCustomParser = true;
+
             Description = description;
         }
 
@@ -121,6 +125,8 @@ namespace System.CommandLine
         public Argument(ParseArgument<T> parse, bool isDefault = false) : this(null, parse, isDefault)
         {
         }
+
+        internal override bool HasCustomParser => _hasCustomParser;
 
         /// <inheritdoc />
         public override Type ValueType

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -22,7 +22,7 @@ namespace System.CommandLine
         /// <summary>
         /// Initializes a new instance of the CommandLineConfiguration class.
         /// </summary>
-        /// <param name="symbol">The symbol to parse.</param>
+        /// <param name="command">The symbol to parse.</param>
         /// <param name="enablePosixBundling"><see langword="true"/> to enable POSIX bundling; otherwise, <see langword="false"/>.</param>
         /// <param name="enableDirectives"><see langword="true"/> to enable directive parsing; otherwise, <see langword="false"/>.</param>
         /// <param name="enableLegacyDoubleDashBehavior">Enables the legacy behavior of the <c>--</c> token, which is to ignore parsing of subsequent tokens and place them in the <see cref="ParseResult.UnparsedTokens"/> list.</param>
@@ -32,7 +32,7 @@ namespace System.CommandLine
         /// <param name="helpBuilderFactory">Provide a custom help builder.</param>
         /// <param name="configureHelp">Configures the help builder.</param>
         public CommandLineConfiguration(
-            Symbol symbol,
+            Command command,
             bool enablePosixBundling = true,
             bool enableDirectives = true,
             bool enableLegacyDoubleDashBehavior = false,
@@ -42,27 +42,11 @@ namespace System.CommandLine
             Func<BindingContext, IHelpBuilder>? helpBuilderFactory = null,
             Action<IHelpBuilder>? configureHelp = null)
         {
-            if (symbol is null)
-            {
-                throw new ArgumentNullException(nameof(symbol));
-            }
-
-            if (symbol is Command rootCommand)
-            {
-                RootCommand = rootCommand;
-            }
-            else
-            {
-                rootCommand = new RootCommand();
-
-                rootCommand.Add(symbol);
-
-                RootCommand = rootCommand;
-            }
+            RootCommand = command ?? throw new ArgumentNullException(nameof(command));
 
             _symbols.Add(RootCommand);
 
-            AddGlobalOptionsToChildren(rootCommand);
+            AddGlobalOptionsToChildren(command);
 
             EnableLegacyDoubleDashBehavior = enableLegacyDoubleDashBehavior;
             EnablePosixBundling = enablePosixBundling;

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -192,7 +192,7 @@ namespace System.CommandLine.Parsing
             var argument = optionNode.Option.Argument;
 
             var contiguousTokens = 0;
-            var  continueProcessing = true;
+            var continueProcessing = true;
 
             while (More() &&
                    CurrentToken.Type == TokenType.Argument &&

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -372,12 +372,27 @@ namespace System.CommandLine.Parsing
                 }
             }
 
-            for (var i = 0; i < optionResult.Children.Count; i++)
+            if (optionResult.Children.Count == 0)
             {
-                var result = optionResult.Children[i];
-                if (result is ArgumentResult argumentResult)
+                if (optionResult.Option.Argument is Argument { HasCustomParser: true })
                 {
-                    ValidateAndConvertArgumentResult(argumentResult);
+                    if (optionResult.Option is Option opt)
+                    {
+                        var argResult = optionResult.GetOrCreateDefaultArgumentResult(opt.Argument);
+                        optionResult.Children.Add(argResult);
+                        ValidateAndConvertArgumentResult(argResult);
+                    }
+                }
+            }
+            else
+            {
+                for (var i = 0; i < optionResult.Children.Count; i++)
+                {
+                    var result = optionResult.Children[i];
+                    if (result is ArgumentResult argumentResult)
+                    {
+                        ValidateAndConvertArgumentResult(argumentResult);
+                    }
                 }
             }
         }

--- a/src/System.CommandLine/Parsing/Parser.cs
+++ b/src/System.CommandLine/Parsing/Parser.cs
@@ -22,7 +22,8 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        public Parser(Symbol symbol) : this(new CommandLineConfiguration(symbol))
+        /// <param name="command">The root command for the parser.</param>
+        public Parser(Command command) : this(new CommandLineConfiguration(command))
         {
         }
         


### PR DESCRIPTION
This fixes #1294.

It also introduces a breaking change by replacing the `Parser` and  `CommandLineConfiguration` constructors that accepted `Symbol` to now accept only `Command`.

