### PR TITLE
HelpBuilder: made Indent const protected

### DIFF
--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -431,7 +431,7 @@ namespace System.CommandLine.Help
             }
         }
 
-        private static IEnumerable<string> WrapText(string text, int maxWidth)
+        protected static IEnumerable<string> WrapText(string text, int maxWidth)
         {
             if (string.IsNullOrWhiteSpace(text))
             {

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Help
     /// <inheritdoc />
     public class HelpBuilder : IHelpBuilder
     {
-        private const string Indent = "  ";
+        protected const string Indent = "  ";
 
         private Dictionary<ISymbol, Customization>? _customizationsBySymbol;
 


### PR DESCRIPTION
I'm building custom sections for templating, however I would like indentation to be aligned.
Thus, made constant protected so I can use it.

Update: also made WrapText protected for same reason