### PR TITLE
Move command handler generator anchor into its own assembly

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -29,7 +29,7 @@ stages:
       enablePublishTestResults: true
       enablePublishBuildAssets: true
       enableTelemetry: true
-      enableSourceBuild: true
+      enableSourceBuild: false
       helixRepo: dotnet/command-line-api
       timeoutInMinutes: 180 # increase timeout since BAR publishing might wait a long time
       jobs:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <NoWarn>$(NoWarn);NU5125;CS0618</NoWarn>
     <NoWarn Condition=" '$(DotnetBuildFromSource)' == 'true' ">$(NoWarn);CS8714;CS8765;CS8600;CS8601;CS8602;CS8603;CS8604</NoWarn>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/System.CommandLine.sln
+++ b/System.CommandLine.sln
@@ -62,6 +62,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.CommandLine.Generato
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.CommandLine.Generator.Tests", "src\System.CommandLine.Generator.Tests\System.CommandLine.Generator.Tests.csproj", "{70B98293-2F69-4262-AADD-D3EEE12046A8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.CommandLine.Generator.CommandHandler", "src\System.CommandLine.Generator.CommandHandler\System.CommandLine.Generator.CommandHandler.csproj", "{591EF370-7AD7-4624-8B9D-FD15010CA657}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -264,6 +266,18 @@ Global
 		{70B98293-2F69-4262-AADD-D3EEE12046A8}.Release|x64.Build.0 = Release|Any CPU
 		{70B98293-2F69-4262-AADD-D3EEE12046A8}.Release|x86.ActiveCfg = Release|Any CPU
 		{70B98293-2F69-4262-AADD-D3EEE12046A8}.Release|x86.Build.0 = Release|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Debug|x64.Build.0 = Debug|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Debug|x86.Build.0 = Debug|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Release|Any CPU.Build.0 = Release|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Release|x64.ActiveCfg = Release|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Release|x64.Build.0 = Release|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Release|x86.ActiveCfg = Release|Any CPU
+		{591EF370-7AD7-4624-8B9D-FD15010CA657}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -285,6 +299,7 @@ Global
 		{0BF6958D-9EE3-4623-B3D6-4DA77EAC1906} = {6749FB3E-39DE-4321-A39E-525278E9408D}
 		{B0D00128-E41B-4648-9D22-9B91F8F6BF0C} = {E5B1EC71-0FC4-4FAA-9C65-32D5016FBC45}
 		{70B98293-2F69-4262-AADD-D3EEE12046A8} = {E5B1EC71-0FC4-4FAA-9C65-32D5016FBC45}
+		{591EF370-7AD7-4624-8B9D-FD15010CA657} = {E5B1EC71-0FC4-4FAA-9C65-32D5016FBC45}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5C159F93-800B-49E7-9905-EE09F8B8434A}

--- a/src/System.CommandLine.Generator.CommandHandler/CommandExtensions.cs
+++ b/src/System.CommandLine.Generator.CommandHandler/CommandExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace System.CommandLine;
+
+/// <summary>
+/// Provides extension methods for <see cref="Command" />.
+/// </summary>
+public static class CommandExtensions
+{
+    private const string _messageForWhenGeneratorIsNotInUse =
+            "This overload should not be called. You should reference the System.CommandLine.Generator package which will generate a more specific overload for your delegate.";
+
+    /// <summary>
+    /// Sets a command handler.
+    /// </summary>
+    /// <remarks>Currently, this method only works with C# source generators.</remarks>
+    /// <param name="command">The command on which to set the handler.</param>
+    /// <param name="delegate">A delegate implementing the handler for the command.</param>
+    /// <param name="symbols">The symbols used to bind the handler's parameters.</param>
+    public static void SetHandler<TDelegate>(
+        this Command command,
+        TDelegate @delegate,
+        params ISymbol[] symbols)
+    {
+        throw new InvalidOperationException(_messageForWhenGeneratorIsNotInUse);
+    }
+}
+

--- a/src/System.CommandLine.Generator.CommandHandler/System.CommandLine.Generator.CommandHandler.csproj
+++ b/src/System.CommandLine.Generator.CommandHandler/System.CommandLine.Generator.CommandHandler.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\System.CommandLine\System.CommandLine.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/System.CommandLine.Generator.Tests/System.CommandLine.Generator.Tests.csproj
+++ b/src/System.CommandLine.Generator.Tests/System.CommandLine.Generator.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <ProjectReference Include="..\System.CommandLine.Generator.CommandHandler\System.CommandLine.Generator.CommandHandler.csproj" />
     <ProjectReference Include="..\System.CommandLine\System.CommandLine.csproj" />
     <ProjectReference Include="..\System.CommandLine.Generator\System.CommandLine.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
   </ItemGroup>

--- a/src/System.CommandLine.Generator/System.CommandLine.Generator.csproj
+++ b/src/System.CommandLine.Generator/System.CommandLine.Generator.csproj
@@ -10,13 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)/../../../System.CommandLine.Generator.CommandHandler/**/System.CommandLine.Generator.CommandHandler.dll" 
+          Pack="true" 
+          PackagePath="lib/netstandard2.0/System.CommandLine.Generator.CommandHandler.dll" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\System.Diagnostics.CodeAnalysis.cs" Link="System.Diagnostics.CodeAnalysis.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" PrivateAssets="all" />

--- a/src/System.CommandLine/CommandExtensions.cs
+++ b/src/System.CommandLine/CommandExtensions.cs
@@ -107,23 +107,5 @@ namespace System.CommandLine
             this Command command,
             string commandLine) =>
             command.GetOrCreateDefaultParser().Parse(commandLine);
-
-        private const string _messageForWhenGeneratorIsNotInUse =
-            "This overload should not be called. You should reference the System.CommandLine.Generator package which will generate a more specific overload for your delegate.";
-
-        /// <summary>
-        /// Sets a command handler.
-        /// </summary>
-        /// <remarks>Currently, this method only works with C# source generators.</remarks>
-        /// <param name="command">The command on which to set the handler.</param>
-        /// <param name="delegate">A delegate implementing the handler for the command.</param>
-        /// <param name="symbols">The symbols used to bind the handler's parameters.</param>
-        public static void SetHandler<TDelegate>(
-            this Command command,
-            TDelegate @delegate,
-            params ISymbol[] symbols)
-        {
-            throw new InvalidOperationException(_messageForWhenGeneratorIsNotInUse);
-        }
     }
 }


### PR DESCRIPTION
This separates out the generator's anchor into its own assembly so that we don't clutter up the main project with generator specific code.