### PR TITLE
Adding support for C#10 natural type lambdas in Generator

### DIFF
--- a/src/System.CommandLine.Generator.Tests/GeneratedCommandHandlerTests.cs
+++ b/src/System.CommandLine.Generator.Tests/GeneratedCommandHandlerTests.cs
@@ -259,6 +259,100 @@ namespace System.CommandLine.Generator.Tests
             secondValue.Should().Be("v2");
         }
 
+        [Fact]
+        public async Task Can_generate_handler_natural_type_delegates()
+        {
+            string? boundName = default;
+            int boundAge = default;
+            IConsole? boundConsole = null;
+
+            void Execute(string fullnameOrNickname, IConsole console, int age)
+            {
+                boundName = fullnameOrNickname;
+                boundConsole = console;
+                boundAge = age;
+            }
+
+            var nameArgument = new Argument<string>();
+            var ageOption = new Option<int>("--age");
+
+            var command = new Command("command")
+            {
+                nameArgument,
+                ageOption
+            };
+
+            command.SetHandler(Execute, nameArgument, ageOption);
+
+            await command.InvokeAsync("command Gandalf --age 425", _console);
+
+            boundName.Should().Be("Gandalf");
+            boundAge.Should().Be(425);
+            boundConsole.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task Can_generate_handler_for_lambda()
+        {
+            string? boundName = default;
+            int boundAge = default;
+            IConsole? boundConsole = null;
+
+            var nameArgument = new Argument<string>();
+            var ageOption = new Option<int>("--age");
+
+            var command = new Command("command")
+            {
+                nameArgument,
+                ageOption
+            };
+
+            command.SetHandler((string fullnameOrNickname, IConsole console, int age) =>
+            {
+                boundName = fullnameOrNickname;
+                boundConsole = console;
+                boundAge = age;
+            }, nameArgument, ageOption);
+
+            await command.InvokeAsync("command Gandalf --age 425", _console);
+
+            boundName.Should().Be("Gandalf");
+            boundAge.Should().Be(425);
+            boundConsole.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task Can_generate_handler_for_lambda_wth_return_type_specified()
+        {
+            string? boundName = default;
+            int boundAge = default;
+            IConsole? boundConsole = null;
+
+            var nameArgument = new Argument<string>();
+            var ageOption = new Option<int>("--age");
+
+            var command = new Command("command")
+            {
+                nameArgument,
+                ageOption
+            };
+
+            command.SetHandler(int (string fullnameOrNickname, IConsole console, int age) =>
+            {
+                boundName = fullnameOrNickname;
+                boundConsole = console;
+                boundAge = age;
+                return 42;
+            }, nameArgument, ageOption);
+
+            int rv = await command.InvokeAsync("command Gandalf --age 425", _console);
+
+            rv.Should().Be(42);
+            boundName.Should().Be("Gandalf");
+            boundAge.Should().Be(425);
+            boundConsole.Should().NotBeNull();
+        }
+
         public class Character
         {
             public Character(string? fullName, int age)

--- a/src/System.CommandLine.Generator.Tests/System.CommandLine.Generator.Tests.csproj
+++ b/src/System.CommandLine.Generator.Tests/System.CommandLine.Generator.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-    <LangVersion>9</LangVersion>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <Nullable>enable</Nullable>

--- a/src/System.CommandLine.Generator/CommandHandlerSourceGenerator.cs
+++ b/src/System.CommandLine.Generator/CommandHandlerSourceGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Generator.Invocations;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -45,95 +46,16 @@ namespace System.CommandLine
 
             foreach (var invocation in rx.Invocations)
             {
-                var methodParameters = invocation.Parameters
-                                                 .Select(x => x.GetMethodParameter())
-                                                 .Where(x => !string.IsNullOrWhiteSpace(x.Name))
-                                                 .ToArray();
+                var methodParameters = GetMethodParameters(invocation);
 
-                builder.Append(
-                    @$"
-        public static void SetHandler<{string.Join(", ", Enumerable.Range(1, invocation.NumberOfGenerericParameters).Select(x => $@"T{x}"))}>(
-            this Command command,");
-                builder.Append($@"
-            {invocation.DelegateType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} method");
+                GenerateSetHandler(builder, invocation, methodParameters, handlerCount, true);
+                //The non-geric overload is to support C# 10 natural type lambdas
+                GenerateSetHandler(builder, invocation, methodParameters, handlerCount, false);
 
-                if (methodParameters.Length > 0)
-                {
-                    builder.Append(",");
-                    builder.AppendLine(string.Join(", ", methodParameters.Select(x => $@"
-            {x.Type} {x.Name}")) + ")");
-                }
-                else
-                {
-                    builder.Append(")");
-                }
-
-                builder.Append(@"
-        {");
-                builder.Append($@"
-            command.Handler = new GeneratedHandler_{handlerCount}(method");
-
-                if (methodParameters.Length > 0)
-                {
-                    builder.Append(", ");
-                    builder.Append(string.Join(", ", methodParameters.Select(x => x.Name)));
-                }
-
-                builder.Append(");");
-
-                builder.AppendLine(@"
-        }");
+                GenerateHandlerClass(builder, invocation, methodParameters, handlerCount);
 
                 //TODO: fully qualify type names
-                builder.Append($@"
-        private class GeneratedHandler_{handlerCount} : {ICommandHandlerType}
-        {{
-            public GeneratedHandler_{handlerCount}(
-                {invocation.DelegateType} method");
-
-                if (methodParameters.Length > 0)
-                {
-                    builder.Append(",");
-                    builder.Append(string.Join($", ", methodParameters.Select(x => $@"
-                {x.Type} {x.Name}")) + ")");
-                }
-                else
-                {
-                    builder.Append(")");
-                }
-
-                builder.Append($@"
-            {{
-                Method = method;");
-                foreach (var propertyAssignment in invocation.Parameters
-                                                             .Select(x => x.GetPropertyAssignment())
-                                                             .Where(x => !string.IsNullOrWhiteSpace(x)))
-                {
-                    builder.Append($@"
-                {propertyAssignment}");
-                }
-
-                builder.AppendLine($@"
-            }}
                 
-            public {invocation.DelegateType} Method {{ get; }}");
-
-                foreach (var propertyDeclaration in invocation.Parameters
-                                                              .Select(x => x.GetPropertyDeclaration())
-                                                              .Where(x => !string.IsNullOrWhiteSpace(x)))
-                {
-                    builder.Append($@"
-            {propertyDeclaration}");
-                }
-
-                builder.Append($@"
-            public async Task<int> InvokeAsync(InvocationContext context)
-            {{");
-                builder.Append($@"
-                {invocation.InvokeContents()}");
-                builder.Append($@"
-            }}
-        }}");
                 handlerCount++;
             }
 
@@ -145,9 +67,123 @@ namespace System.CommandLine
             context.AddSource("CommandHandlerGeneratorExtensions_Generated.g.cs", builder.ToString());
         }
 
+        private static void GenerateHandlerClass(
+            StringBuilder builder,
+            DelegateInvocation invocation,
+            (string Type, string Name)[] methodParameters,
+            int handlerCount)
+        {
+            builder.Append($@"
+        private class GeneratedHandler_{handlerCount} : {ICommandHandlerType}
+        {{
+            public GeneratedHandler_{handlerCount}(
+                {invocation.DelegateType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} method");
+
+            if (methodParameters.Length > 0)
+            {
+                builder.Append(",");
+                builder.Append(string.Join($", ", methodParameters.Select(x => $@"
+                {x.Type} {x.Name}")) + ")");
+            }
+            else
+            {
+                builder.Append(")");
+            }
+
+            builder.Append($@"
+            {{
+                Method = method;");
+            foreach (var propertyAssignment in invocation.Parameters
+                                                         .Select(x => x.GetPropertyAssignment())
+                                                         .Where(x => !string.IsNullOrWhiteSpace(x)))
+            {
+                builder.Append($@"
+                {propertyAssignment}");
+            }
+
+            builder.AppendLine($@"
+            }}
+                
+            public {invocation.DelegateType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} Method {{ get; }}");
+
+            foreach (var propertyDeclaration in invocation.Parameters
+                                                          .Select(x => x.GetPropertyDeclaration())
+                                                          .Where(x => !string.IsNullOrWhiteSpace(x)))
+            {
+                builder.Append($@"
+            {propertyDeclaration}");
+            }
+
+            builder.Append($@"
+            public async global::System.Threading.Tasks.Task<int> InvokeAsync(global::System.CommandLine.Invocation.InvocationContext context)
+            {{");
+            builder.Append($@"
+                {invocation.InvokeContents()}");
+            builder.Append($@"
+            }}
+        }}");
+        }
+
+        private static (string Type, string Name)[] GetMethodParameters(DelegateInvocation invocation)
+        {
+            return invocation.Parameters
+                    .Select(x => x.GetMethodParameter())
+                    .Where(x => !string.IsNullOrWhiteSpace(x.Name))
+                    .ToArray();
+        }
+
+        private static void GenerateSetHandler(
+            StringBuilder builder, 
+            DelegateInvocation invocation,
+            (string Type, string Name)[] methodParameters,
+            int handlerCount,
+            bool isGeneric)
+        {
+            builder.Append(
+                @$"
+        public static void SetHandler");
+
+            if (isGeneric)
+            {
+                builder.Append($"<{string.Join(", ", Enumerable.Range(1, invocation.NumberOfGenerericParameters).Select(x => $@"T{x}"))}>");
+            }
+            builder.Append(@$"(
+            this global::System.CommandLine.Command command,");
+
+            builder.Append($@"
+            {invocation.DelegateType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} method");
+
+            if (methodParameters.Length > 0)
+            {
+                builder.Append(",");
+                builder.AppendLine(string.Join(", ", methodParameters.Select(x => $@"
+            {x.Type} {x.Name}")) + ")");
+            }
+            else
+            {
+                builder.Append(")");
+            }
+
+            builder.Append(@"
+        {");
+            builder.Append($@"
+            command.Handler = new GeneratedHandler_{handlerCount}(method");
+
+            if (methodParameters.Length > 0)
+            {
+                builder.Append(", ");
+                builder.Append(string.Join(", ", methodParameters.Select(x => x.Name)));
+            }
+
+            builder.Append(");");
+
+            builder.AppendLine(@"
+        }");
+        }
+
         public void Initialize(GeneratorInitializationContext context)
         {
-            // Debugger.Launch();
+            //System.Diagnostics.Debugger.Launch();
 
             context.RegisterForSyntaxNotifications(() => new SyntaxReceiver());
         }

--- a/src/System.CommandLine.Generator/Invocations/ConstructorModelBindingInvocation.cs
+++ b/src/System.CommandLine.Generator/Invocations/ConstructorModelBindingInvocation.cs
@@ -48,11 +48,11 @@ namespace System.CommandLine.Generator.Invocations
             {
                 case ReturnPattern.InvocationContextExitCode:
                     builder.Append(@"
-                return await Task.FromResult(context.ExitCode);");
+                return await global::System.Threading.Tasks.Task.FromResult(context.ExitCode);");
                     break;
                 case ReturnPattern.FunctionReturnValue:
                     builder.Append(@"
-                return await Task.FromResult(rv);");
+                return await global::System.Threading.Tasks.Task.FromResult(rv);");
                     break;
                 case ReturnPattern.AwaitFunction:
                     builder.Append(@"

--- a/src/System.CommandLine.Generator/System.CommandLine.Generator.csproj
+++ b/src/System.CommandLine.Generator/System.CommandLine.Generator.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)/../../../System.CommandLine.Generator.CommandHandler/**/System.CommandLine.Generator.CommandHandler.dll" 
-          Pack="true" 
+          Pack="true"
           PackagePath="lib/netstandard2.0/System.CommandLine.Generator.CommandHandler.dll" />
   </ItemGroup>
 


### PR DESCRIPTION
This takes advantage of a similar overload resolution trick when matching against SetHandler methods where the generic type is inferred by the compiler. This updates the generator to generate both a generic (existing behavior) and a non-generic (new behavior) SetHandler method. The latter is what will be resolved and use if the caller does not specify generic parameters (which is a compile error in C# 9 and earlier; but succeeds in C# 10). 