### PR TITLE
Perf improvements part 1

### DIFF
--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Simple.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Simple.cs
@@ -1,0 +1,35 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+
+namespace System.CommandLine.Benchmarks.CommandLine
+{
+    [BenchmarkCategory(Categories.CommandLine)]
+    public class Perf_Parser_Simple
+    {
+        [Params(new string[0], new string[4] { "--bool", "true", "-s", "test" })]
+        public string[] Args { get; set; }
+
+        [Benchmark]
+        public int Sync() => BuildCommand().Invoke(Args);
+
+        [Benchmark]
+        public Task<int> Async() => BuildCommand().InvokeAsync(Args);
+
+        private static RootCommand BuildCommand()
+        {
+            Option<bool> boolOption = new Option<bool>(new[] { "--bool", "-b" }, "Bool option");
+            Option<string> stringOption = new Option<string>(new[] { "--string", "-s" }, "String option");
+
+            RootCommand command = new RootCommand()
+            {
+                boolOption,
+                stringOption
+            };
+
+            command.Handler = CommandHandler.Create<bool, string>(boolOption, stringOption, static (bool _, string __) => { });
+
+            return command;
+        }
+    }
+}

--- a/src/System.CommandLine.Benchmarks/RecommendedConfig.cs
+++ b/src/System.CommandLine.Benchmarks/RecommendedConfig.cs
@@ -7,8 +7,8 @@ using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters.Json;
-using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Jobs;
+using Perfolizer.Horology;
 
 namespace System.CommandLine.Benchmarks
 {

--- a/src/System.CommandLine.Benchmarks/System.CommandLine.Benchmarks.csproj
+++ b/src/System.CommandLine.Benchmarks/System.CommandLine.Benchmarks.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.5.0" />
   </ItemGroup>
 

--- a/src/System.CommandLine/Invocation/FeatureRegistration.cs
+++ b/src/System.CommandLine/Invocation/FeatureRegistration.cs
@@ -23,13 +23,13 @@ namespace System.CommandLine.Invocation
 
         public async Task EnsureRegistered(Func<Task<string>> onInitialize)
         {
-            if (!_sentinelFile.Directory.Exists)
-            {
-                _sentinelFile.Directory.Create();
-            }
-
             if (!_sentinelFile.Exists)
             {
+                if (!_sentinelFile.Directory.Exists)
+                {
+                    _sentinelFile.Directory.Create();
+                }
+
                 try
                 {
                     var message = await onInitialize();

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -34,7 +34,7 @@ namespace System.CommandLine.Invocation
 
             InvocationMiddleware invocationChain = BuildInvocationChain(context);
 
-            Task.Run(() => invocationChain(context, _ => Task.CompletedTask)).GetAwaiter().GetResult();
+            invocationChain(context, static _ => Task.CompletedTask).ConfigureAwait(false).GetAwaiter().GetResult();
 
             return GetExitCode(context);
         }


### PR DESCRIPTION
I've added a simple benchmark based on @jkotas sample (https://github.com/jkotas/commandline-perf/blob/master/command-line-api/Program.cs)

`String[0]` is test case when user has not passed any args
`String[4]` is for `--bool true -s test`

| Method |      Args | Mean before | Mean after |
|------- |---------- |------------:|-----------:|
|   Sync | String[0] |    88.04 us |   45.60 us |
|  Async | String[0] |    61.21 us |   46.05 us |
|   Sync | String[4] |    85.71 us |   50.65 us |
|  Async | String[4] |    66.33 us |   51.73 us |

Explanation:
* there is no need to start a new task, we can call `invocationChain` (it returns a task) and wait for it directly
* there is no need to check if directory exists if we know that the file that belongs to this directory exists

@jonsequitur PTAL