### PR TITLE
Adding in cancellation support for InvokeAsync

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -66,8 +66,8 @@ System.CommandLine
   public static class CommandExtensions
     public static System.Int32 Invoke(this Command command, System.String[] args, IConsole console = null)
     public static System.Int32 Invoke(this Command command, System.String commandLine, IConsole console = null)
-    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Command command, System.String[] args, IConsole console = null)
-    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Command command, System.String commandLine, IConsole console = null)
+    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Command command, System.String[] args, IConsole console = null, System.Threading.CancellationToken cancellationToken = null)
+    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Command command, System.String commandLine, IConsole console = null, System.Threading.CancellationToken cancellationToken = null)
     public static ParseResult Parse(this Command command, System.String[] args)
     public static ParseResult Parse(this Command command, System.String commandLine)
   public class CommandLineBuilder
@@ -357,8 +357,8 @@ System.CommandLine.Help
 System.CommandLine.Invocation
   public interface IInvocationResult
     public System.Void Apply(InvocationContext context)
-  public class InvocationContext
-    .ctor(System.CommandLine.ParseResult parseResult, System.CommandLine.IConsole console = null)
+  public class InvocationContext, System.IDisposable
+    .ctor(System.CommandLine.ParseResult parseResult, System.CommandLine.IConsole console = null, System.Threading.CancellationToken cancellationToken = null)
     public System.CommandLine.Binding.BindingContext BindingContext { get; }
     public System.CommandLine.IConsole Console { get; set; }
     public System.Int32 ExitCode { get; set; }
@@ -451,12 +451,12 @@ System.CommandLine.Parsing
     public static System.String Diagram(this System.CommandLine.ParseResult parseResult)
     public static System.Boolean HasOption(this System.CommandLine.ParseResult parseResult, System.CommandLine.Option option)
     public static System.Int32 Invoke(this System.CommandLine.ParseResult parseResult, System.CommandLine.IConsole console = null)
-    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this System.CommandLine.ParseResult parseResult, System.CommandLine.IConsole console = null)
+    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this System.CommandLine.ParseResult parseResult, System.CommandLine.IConsole console = null, System.Threading.CancellationToken cancellationToken = null)
   public static class ParserExtensions
     public static System.Int32 Invoke(this Parser parser, System.String commandLine, System.CommandLine.IConsole console = null)
     public static System.Int32 Invoke(this Parser parser, System.String[] args, System.CommandLine.IConsole console = null)
-    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Parser parser, System.String commandLine, System.CommandLine.IConsole console = null)
-    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Parser parser, System.String[] args, System.CommandLine.IConsole console = null)
+    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Parser parser, System.String commandLine, System.CommandLine.IConsole console = null, System.Threading.CancellationToken cancellationToken = null)
+    public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Parser parser, System.String[] args, System.CommandLine.IConsole console = null, System.Threading.CancellationToken cancellationToken = null)
     public static System.CommandLine.ParseResult Parse(this Parser parser, System.String commandLine)
   public abstract class SymbolResult
     public System.Collections.Generic.IReadOnlyList<SymbolResult> Children { get; }

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -368,6 +368,7 @@ System.CommandLine.Invocation
     public System.CommandLine.Parsing.Parser Parser { get; }
     public System.CommandLine.ParseResult ParseResult { get; set; }
     public System.Threading.CancellationToken GetCancellationToken()
+    public System.Void LinkToken(System.Threading.CancellationToken token)
   public delegate InvocationMiddleware : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
     .ctor(System.Object object, System.IntPtr method)
     public System.IAsyncResult BeginInvoke(InvocationContext context, System.Func<InvocationContext,System.Threading.Tasks.Task> next, System.AsyncCallback callback, System.Object object)

--- a/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using FluentAssertions;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.CommandLine.Tests.Utility;
 using System.Diagnostics;

--- a/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
@@ -6,7 +6,6 @@ using System.CommandLine.Tests.Utility;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Xunit;
 using Process = System.Diagnostics.Process;
 

--- a/src/System.CommandLine.Tests/Invocation/InvocationContextTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationContextTests.cs
@@ -17,7 +17,7 @@ namespace System.CommandLine.Tests.Invocation
             var parseResult = new CommandLineBuilder(new RootCommand())
                 .Build()
                 .Parse("");
-            using InvocationContext context = new(parseResult, cancellationToken:cts.Token);
+            using InvocationContext context = new(parseResult, cancellationToken: cts.Token);
 
             var token = context.GetCancellationToken();
 
@@ -35,7 +35,7 @@ namespace System.CommandLine.Tests.Invocation
                 .Build()
                 .Parse("");
             using InvocationContext context = new(parseResult, cancellationToken: cts1.Token);
-            context.AddLinkedCancellationToken(() => cts2.Token);
+            context.LinkToken(cts2.Token);
 
             var token = context.GetCancellationToken();
 
@@ -53,28 +53,13 @@ namespace System.CommandLine.Tests.Invocation
                 .Build()
                 .Parse("");
             using InvocationContext context = new(parseResult, cancellationToken: cts1.Token);
-            context.AddLinkedCancellationToken(() => cts2.Token);
+            context.LinkToken(cts2.Token);
 
             var token = context.GetCancellationToken();
 
             token.IsCancellationRequested.Should().BeFalse();
             cts2.Cancel();
             token.IsCancellationRequested.Should().BeTrue();
-        }
-
-        [Fact]
-        public void InvocationContext_adding_additional_linked_token_after_token_has_been_built_throws()
-        {
-            using CancellationTokenSource cts = new();
-
-            var parseResult = new CommandLineBuilder(new RootCommand())
-                .Build()
-                .Parse("");
-            using InvocationContext context = new(parseResult, cancellationToken: cts.Token);
-            context.AddLinkedCancellationToken(() => cts.Token);
-            _ = context.GetCancellationToken();
-
-            Assert.Throws<InvalidOperationException>(() => context.AddLinkedCancellationToken(() => cts.Token));
         }
     }
 }

--- a/src/System.CommandLine.Tests/Invocation/InvocationContextTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationContextTests.cs
@@ -1,0 +1,80 @@
+﻿using FluentAssertions;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using System.Threading;
+using Xunit;
+
+namespace System.CommandLine.Tests.Invocation
+{
+    public class InvocationContextTests
+    {
+        [Fact]
+        public void InvocationContext_with_cancellation_token_returns_it()
+        {
+            using CancellationTokenSource cts = new();
+            var parseResult = new CommandLineBuilder(new RootCommand())
+                .Build()
+                .Parse("");
+            using InvocationContext context = new(parseResult, cancellationToken:cts.Token);
+
+            var token = context.GetCancellationToken();
+
+            token.IsCancellationRequested.Should().BeFalse();
+            cts.Cancel();
+            token.IsCancellationRequested.Should().BeTrue();
+        }
+
+        [Fact]
+        public void InvocationContext_with_linked_cancellation_token_can_cancel_by_passed_token()
+        {
+            using CancellationTokenSource cts1 = new();
+            using CancellationTokenSource cts2 = new();
+            var parseResult = new CommandLineBuilder(new RootCommand())
+                .Build()
+                .Parse("");
+            using InvocationContext context = new(parseResult, cancellationToken: cts1.Token);
+            context.AddLinkedCancellationToken(() => cts2.Token);
+
+            var token = context.GetCancellationToken();
+
+            token.IsCancellationRequested.Should().BeFalse();
+            cts1.Cancel();
+            token.IsCancellationRequested.Should().BeTrue();
+        }
+
+        [Fact]
+        public void InvocationContext_with_linked_cancellation_token_can_cancel_by_linked_token()
+        {
+            using CancellationTokenSource cts1 = new();
+            using CancellationTokenSource cts2 = new();
+            var parseResult = new CommandLineBuilder(new RootCommand())
+                .Build()
+                .Parse("");
+            using InvocationContext context = new(parseResult, cancellationToken: cts1.Token);
+            context.AddLinkedCancellationToken(() => cts2.Token);
+
+            var token = context.GetCancellationToken();
+
+            token.IsCancellationRequested.Should().BeFalse();
+            cts2.Cancel();
+            token.IsCancellationRequested.Should().BeTrue();
+        }
+
+        [Fact]
+        public void InvocationContext_adding_additional_linked_token_after_token_has_been_built_throws()
+        {
+            using CancellationTokenSource cts = new();
+
+            var parseResult = new CommandLineBuilder(new RootCommand())
+                .Build()
+                .Parse("");
+            using InvocationContext context = new(parseResult, cancellationToken: cts.Token);
+            context.AddLinkedCancellationToken(() => cts.Token);
+            _ = context.GetCancellationToken();
+
+            Assert.Throws<InvalidOperationException>(() => context.AddLinkedCancellationToken(() => cts.Token));
+        }
+    }
+}

--- a/src/System.CommandLine.Tests/Invocation/InvocationContextTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationContextTests.cs
@@ -1,6 +1,5 @@
 ﻿using FluentAssertions;
 using System.CommandLine;
-using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Threading;

--- a/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
@@ -5,6 +5,7 @@ using System.CommandLine.Help;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -44,7 +45,7 @@ namespace System.CommandLine.Tests.Invocation
 
             var parser = new CommandLineBuilder(new RootCommand
                          {
-                             first, 
+                             first,
                              second
                          })
                          .Build();
@@ -326,6 +327,40 @@ namespace System.CommandLine.Tests.Invocation
 
             handlerWasCalled.Should().BeTrue();
             factoryWasCalled.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Command_InvokeAsync_can_cancel_from_middleware()
+        {
+            var handlerWasCalled = false;
+            var isCancelRequested = false;
+
+            var command = new Command("the-command");
+            command.SetHandler((InvocationContext context) =>
+            {
+                handlerWasCalled = true;
+                isCancelRequested = context.GetCancellationToken().IsCancellationRequested;
+                return Task.FromResult(0);
+            });
+
+
+            using CancellationTokenSource cts = new();
+            var parser = new CommandLineBuilder(new RootCommand
+                         {
+                             command
+                         })
+                         .AddMiddleware(async (context, next) =>
+                         {
+                             context.AddLinkedCancellationToken(() => cts.Token);
+                             cts.Cancel();
+                             await next(context);
+                         })
+                         .Build();
+
+            await parser.InvokeAsync("the-command");
+
+            handlerWasCalled.Should().BeTrue();
+            isCancelRequested.Should().BeTrue();
         }
     }
 }

--- a/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
@@ -351,7 +351,7 @@ namespace System.CommandLine.Tests.Invocation
                          })
                          .AddMiddleware(async (context, next) =>
                          {
-                             context.AddLinkedCancellationToken(() => cts.Token);
+                             context.LinkToken(cts.Token);
                              cts.Cancel();
                              await next(context);
                          })

--- a/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Help;
+using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Linq;

--- a/src/System.CommandLine.Tests/ParserTests.RootCommandAndArg0.cs
+++ b/src/System.CommandLine.Tests/ParserTests.RootCommandAndArg0.cs
@@ -42,10 +42,11 @@ public partial class ParserTests
 
             command.Parse(Split("inner -x hello")).Errors.Should().BeEmpty();
 
-            command.Parse(Split($"{RootCommand.ExecutablePath} inner -x hello"))
-                   .Errors
-                   .Should()
-                   .ContainSingle(e => e.Message == $"{LocalizationResources.Instance.UnrecognizedCommandOrArgument(RootCommand.ExecutablePath)}");
+            var parserResult = command.Parse(Split($"\"{RootCommand.ExecutablePath}\" inner -x hello"));
+            parserResult
+               .Errors
+               .Should()
+               .ContainSingle(e => e.Message == LocalizationResources.Instance.UnrecognizedCommandOrArgument(RootCommand.ExecutablePath));
         }
 
         [Fact]
@@ -76,7 +77,7 @@ public partial class ParserTests
                 }
             };
 
-            var result2 = command.Parse($"{RootCommand.ExecutablePath} inner -x hello");
+            var result2 = command.Parse($"\"{RootCommand.ExecutablePath}\" inner -x hello");
 
             result2.RootCommandResult.Token.Value.Should().Be(RootCommand.ExecutablePath);
         }

--- a/src/System.CommandLine/Binding/BindingContext.cs
+++ b/src/System.CommandLine/Binding/BindingContext.cs
@@ -6,8 +6,6 @@ using System.CommandLine.Invocation;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-#nullable enable
-
 namespace System.CommandLine.Binding
 {
     /// <summary>

--- a/src/System.CommandLine/CommandExtensions.cs
+++ b/src/System.CommandLine/CommandExtensions.cs
@@ -4,6 +4,7 @@
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.CommandLine
@@ -48,13 +49,15 @@ namespace System.CommandLine
         /// <param name="command">The command to invoke.</param>
         /// <param name="args">The arguments to parse.</param>
         /// <param name="console">The console to which output is written during invocation.</param>
+        /// <param name="cancellationToken">A token that can be used to cancel the invocation.</param>
         /// <returns>The exit code for the invocation.</returns>
         public static async Task<int> InvokeAsync(
             this Command command,
             string[] args,
-            IConsole? console = null)
+            IConsole? console = null, 
+            CancellationToken cancellationToken = default)
         {
-            return await GetDefaultInvocationPipeline(command, args).InvokeAsync(console);
+            return await GetDefaultInvocationPipeline(command, args).InvokeAsync(console, cancellationToken);
         }
 
         /// <summary>
@@ -64,12 +67,14 @@ namespace System.CommandLine
         /// <param name="command">The command to invoke.</param>
         /// <param name="commandLine">The command line to parse.</param>
         /// <param name="console">The console to which output is written during invocation.</param>
+        /// <param name="cancellationToken">A token that can be used to cancel the invocation.</param>
         /// <returns>The exit code for the invocation.</returns>
         public static Task<int> InvokeAsync(
             this Command command,
             string commandLine,
-            IConsole? console = null) =>
-            command.InvokeAsync(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console);
+            IConsole? console = null,
+            CancellationToken cancellationToken = default) =>
+            command.InvokeAsync(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console, cancellationToken);
 
         private static InvocationPipeline GetDefaultInvocationPipeline(Command command, string[] args)
         {

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -3,22 +3,23 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation
 {
     internal class InvocationPipeline
     {
-        private readonly ParseResult parseResult;
+        private readonly ParseResult _parseResult;
 
         public InvocationPipeline(ParseResult parseResult)
         {
-            this.parseResult = parseResult ?? throw new ArgumentNullException(nameof(parseResult));
+            _parseResult = parseResult ?? throw new ArgumentNullException(nameof(parseResult));
         }
 
-        public Task<int> InvokeAsync(IConsole? console = null)
+        public Task<int> InvokeAsync(IConsole? console = null, CancellationToken cancellationToken = default)
         {
-            var context = new InvocationContext(parseResult, console);
+            var context = new InvocationContext(_parseResult, console, cancellationToken);
 
             if (context.Parser.Configuration.Middleware.Count == 0
                 && context.ParseResult.CommandResult.Command.Handler is ICommandHandler handler)
@@ -40,7 +41,7 @@ namespace System.CommandLine.Invocation
 
         public int Invoke(IConsole? console = null)
         {
-            var context = new InvocationContext(parseResult, console);
+            var context = new InvocationContext(_parseResult, console);
 
             if (context.Parser.Configuration.Middleware.Count == 0
                 && context.ParseResult.CommandResult.Command.Handler is ICommandHandler handler)

--- a/src/System.CommandLine/Invocation/ServiceProvider.cs
+++ b/src/System.CommandLine/Invocation/ServiceProvider.cs
@@ -6,8 +6,6 @@ using System.CommandLine.Binding;
 using System.CommandLine.Help;
 using System.Threading;
 
-#nullable enable
-
 namespace System.CommandLine.Invocation
 {
     internal class ServiceProvider : IServiceProvider

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -6,6 +6,7 @@ using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.CommandLine.Parsing
@@ -20,11 +21,13 @@ namespace System.CommandLine.Parsing
         /// </summary>
         /// <param name="parseResult">A parse result on which the invocation is based.</param>
         /// <param name="console">A console to which output can be written. By default, <see cref="System.Console"/> is used.</param>
+        /// <param name="cancellationToken">A token that can be used to cancel an invocation.</param>
         /// <returns>A task whose result can be used as a process exit code.</returns>
         public static async Task<int> InvokeAsync(
             this ParseResult parseResult,
-            IConsole? console = null) =>
-            await new InvocationPipeline(parseResult).InvokeAsync(console);
+            IConsole? console = null,
+            CancellationToken cancellationToken = default) =>
+            await new InvocationPipeline(parseResult).InvokeAsync(console, cancellationToken);
 
         /// <summary>
         /// Invokes the appropriate command handler for a parsed command line input.

--- a/src/System.CommandLine/Parsing/ParserExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParserExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.CommandLine.Parsing
@@ -40,8 +41,9 @@ namespace System.CommandLine.Parsing
         public static Task<int> InvokeAsync(
             this Parser parser,
             string commandLine,
-            IConsole? console = null) =>
-            parser.InvokeAsync(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console);
+            IConsole? console = null,
+            CancellationToken cancellationToken = default) =>
+            parser.InvokeAsync(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console, cancellationToken);
 
         /// <summary>
         /// Parses a command line string array and invokes the handler for the indicated command.
@@ -50,8 +52,9 @@ namespace System.CommandLine.Parsing
         public static async Task<int> InvokeAsync(
             this Parser parser,
             string[] args,
-            IConsole? console = null) =>
-            await parser.Parse(args).InvokeAsync(console);
+            IConsole? console = null,
+            CancellationToken cancellationToken = default) =>
+            await parser.Parse(args).InvokeAsync(console, cancellationToken);
 
         /// <summary>
         /// Parses a command line string.


### PR DESCRIPTION
Fixes #1469 

There is a slight behavior change in this. Previously, if you did not request a `CancellationToken` in a command handler, it would not register up on the `Console.CancelKeyPress` and `AppDomain.CurrentDomain.ProcessExit` events.
With these changes it now always registers for those events if you call `CommandLineBuilder.CancelOnProcessTermination` (which is part of the defaults; so likely often).

Key areas to review are `CommandLineBuilderExtensions` and `InvocationContext` changes.