### PR TITLE
Perf improvements part 2

### DIFF
--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Simple.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Simple.cs
@@ -1,5 +1,7 @@
 ﻿using BenchmarkDotNet.Attributes;
+using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Threading.Tasks;
 
 namespace System.CommandLine.Benchmarks.CommandLine
@@ -11,10 +13,16 @@ namespace System.CommandLine.Benchmarks.CommandLine
         public string[] Args { get; set; }
 
         [Benchmark]
-        public int Sync() => BuildCommand().Invoke(Args);
+        public int DefaultsSync() => BuildCommand().Invoke(Args);
 
         [Benchmark]
-        public Task<int> Async() => BuildCommand().InvokeAsync(Args);
+        public Task<int> DefaultsAsync() => BuildCommand().InvokeAsync(Args);
+
+        [Benchmark]
+        public int MinimalSync() => new CommandLineBuilder(BuildCommand()).Build().Invoke(Args);
+
+        [Benchmark]
+        public Task<int> MinimalAsync() => new CommandLineBuilder(BuildCommand()).Build().InvokeAsync(Args);
 
         private static RootCommand BuildCommand()
         {

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -52,7 +52,7 @@ namespace System.CommandLine
             {
                 if (_arity is null)
                 {
-                    return ArgumentArity.Default(
+                    _arity = ArgumentArity.Default(
                         ValueType, 
                         this, 
                         Parents);

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -94,27 +94,27 @@ namespace System.CommandLine
         /// <summary>
         /// An arity that does not allow any values.
         /// </summary>
-        public static readonly IArgumentArity Zero = new ArgumentArity(0, 0);
+        public static IArgumentArity Zero { get; } = new ArgumentArity(0, 0);
 
         /// <summary>
         /// An arity that may have one value, but no more than one.
         /// </summary>
-        public static readonly IArgumentArity ZeroOrOne = new ArgumentArity(0, 1);
+        public static IArgumentArity ZeroOrOne { get; } = new ArgumentArity(0, 1);
 
         /// <summary>
         /// An arity that must have exactly one value.
         /// </summary>
-        public static readonly IArgumentArity ExactlyOne = new ArgumentArity(1, 1);
+        public static IArgumentArity ExactlyOne { get; } = new ArgumentArity(1, 1);
 
         /// <summary>
         /// An arity that may have multiple values.
         /// </summary>
-        public static readonly IArgumentArity ZeroOrMore = new ArgumentArity(0, MaximumArity);
+        public static IArgumentArity ZeroOrMore { get; } = new ArgumentArity(0, MaximumArity);
 
         /// <summary>
         /// An arity that must have at least one value.
         /// </summary>
-        public static readonly IArgumentArity OneOrMore = new ArgumentArity(1, MaximumArity);
+        public static IArgumentArity OneOrMore { get; } = new ArgumentArity(1, MaximumArity);
 
         internal static IArgumentArity Default(Type type, Argument argument, ISymbolSet parents)
         {

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -94,27 +94,27 @@ namespace System.CommandLine
         /// <summary>
         /// An arity that does not allow any values.
         /// </summary>
-        public static IArgumentArity Zero => new ArgumentArity(0, 0);
+        public static readonly IArgumentArity Zero = new ArgumentArity(0, 0);
 
         /// <summary>
         /// An arity that may have one value, but no more than one.
         /// </summary>
-        public static IArgumentArity ZeroOrOne => new ArgumentArity(0, 1);
+        public static readonly IArgumentArity ZeroOrOne = new ArgumentArity(0, 1);
 
         /// <summary>
         /// An arity that must have exactly one value.
         /// </summary>
-        public static IArgumentArity ExactlyOne => new ArgumentArity(1, 1);
+        public static readonly IArgumentArity ExactlyOne = new ArgumentArity(1, 1);
 
         /// <summary>
         /// An arity that may have multiple values.
         /// </summary>
-        public static IArgumentArity ZeroOrMore => new ArgumentArity(0, MaximumArity);
+        public static readonly IArgumentArity ZeroOrMore = new ArgumentArity(0, MaximumArity);
 
         /// <summary>
         /// An arity that must have at least one value.
         /// </summary>
-        public static IArgumentArity OneOrMore => new ArgumentArity(1, MaximumArity);
+        public static readonly IArgumentArity OneOrMore = new ArgumentArity(1, MaximumArity);
 
         internal static IArgumentArity Default(Type type, Argument argument, ISymbolSet parents)
         {

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -125,8 +125,7 @@ namespace System.CommandLine
 
             var parent = parents.Count > 0 ? parents[0] : default;
 
-            if (typeof(IEnumerable).IsAssignableFrom(type) &&
-                type != typeof(string))
+            if (type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type))
             {
                 return parent is ICommand
                            ? ZeroOrMore

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -76,12 +76,21 @@ namespace System.CommandLine.Builder
                     enableLegacyDoubleDashBehavior: EnableLegacyDoubleDashBehavior,
                     resources: LocalizationResources,
                     responseFileHandling: ResponseFileHandling,
-                    middlewarePipeline: _middlewareList.OrderBy(m => m.order)
-                                                       .Select(m => m.middleware)
-                                                       .ToArray(),
+                    middlewarePipeline: GetMiddleware(),
                     helpBuilderFactory: HelpBuilderFactory));
             
             return parser;
+        }
+
+        private IReadOnlyList<InvocationMiddleware> GetMiddleware()
+        {
+            _middlewareList.Sort(static (m1, m2) => m1.order.CompareTo(m2.order));
+            InvocationMiddleware[] result = new InvocationMiddleware[_middlewareList.Count];
+            for (int i = 0; i < result.Length; i++)
+            {
+                result[i] = _middlewareList[i].middleware;
+            }
+            return result;
         }
 
         internal void AddMiddleware(

--- a/src/System.CommandLine/Collections/SymbolSet.cs
+++ b/src/System.CommandLine/Collections/SymbolSet.cs
@@ -54,12 +54,8 @@ namespace System.CommandLine.Collections
 
             if (item is IIdentifierSymbol identifier)
             {
-                var aliases = identifier.Aliases.ToArray();
-
-                for (var i = 0; i < aliases.Length; i++)
+                foreach (string alias in identifier.Aliases)
                 {
-                    var alias = aliases[i];
-
                     if (ItemsByAlias.ContainsKey(alias))
                     {
                         aliasAlreadyInUse = alias;

--- a/src/System.CommandLine/IdentifierSymbol.cs
+++ b/src/System.CommandLine/IdentifierSymbol.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine
     /// </summary>
     public abstract class IdentifierSymbol : Symbol, IIdentifierSymbol
     {
-        protected readonly HashSet<string> _aliases = new();
+        private protected readonly HashSet<string> _aliases = new();
         private string? _specifiedName;
 
         /// <summary>

--- a/src/System.CommandLine/IdentifierSymbol.cs
+++ b/src/System.CommandLine/IdentifierSymbol.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine
     /// </summary>
     public abstract class IdentifierSymbol : Symbol, IIdentifierSymbol
     {
-        private readonly HashSet<string> _aliases = new();
+        protected readonly HashSet<string> _aliases = new();
         private string? _specifiedName;
 
         /// <summary>

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -233,6 +233,8 @@ namespace System.CommandLine
             return false;
         }
 
+        private protected override void RemoveAlias(string alias) => base.RemoveAlias(alias);
+
         /// <summary>
         /// Sets the default value for the option.
         /// </summary>

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -253,8 +253,7 @@ namespace System.CommandLine
         /// <inheritdoc/>
         public bool AllowMultipleArgumentsPerToken { get; set; }
 
-        internal bool IsGreedy => Arity.MinimumNumberOfValues > 0 &&
-                                  ValueType != typeof(bool);
+        internal bool IsGreedy => ValueType != typeof(bool) && Arity.MinimumNumberOfValues > 0;
 
         /// <summary>
         /// Indicates whether the option is required when its parent command is invoked.

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -574,10 +574,8 @@ namespace System.CommandLine.Parsing
         {
             var tokens = new Dictionary<string, (Token, bool isGreedy)>();
 
-            for (var commandAliasIndex = 0; commandAliasIndex < command.Aliases.Count; commandAliasIndex++)
+            foreach (var commandAlias in command.Aliases)
             {
-                var commandAlias = command.Aliases.ElementAt(commandAliasIndex);
-
                 tokens.Add(
                     commandAlias,
                     (new Token(

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -167,8 +167,11 @@ namespace System.CommandLine.Parsing
                                 if (symbolSet.GetByAlias(arg) is Command cmd && 
                                     cmd != currentCommand)
                                 {
+                                    if (!(currentCommand is null && cmd == configuration.RootCommand))
+                                    {
+                                        knownTokens = cmd.ValidTokens();
+                                    }
                                     currentCommand = cmd;
-                                    knownTokens = currentCommand.ValidTokens();
                                     tokenList.Add(Command(arg));
                                 }
                                 else

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -28,18 +28,21 @@ namespace System.CommandLine.Parsing
                                 value,
                                 CompareOptions.OrdinalIgnoreCase);
 
-        internal static string RemovePrefix(this string rawAlias)
+        internal static string RemovePrefix(this string alias)
         {
-            for (var i = 0; i < _optionPrefixStrings.Length; i++)
-            {
-                var prefix = _optionPrefixStrings[i];
-                if (rawAlias.StartsWith(prefix, StringComparison.Ordinal))
-                {
-                    return rawAlias.Substring(prefix.Length);
-                }
-            }
+            int prefixLength = GetPrefixLength(alias);
+            return prefixLength > 0 ? alias.Substring(prefixLength) : alias;
+        }
 
-            return rawAlias;
+        internal static int GetPrefixLength(this string alias)
+        {
+            // empty aliases are illegal, so there is no need to check for length
+            if (alias[0] == '-')
+                return alias.Length > 1 && alias[1] == '-' ? 2 : 1;
+            if (alias[0] == '/')
+                return 1;
+
+            return 0;
         }
 
         internal static (string? Prefix, string Alias) SplitPrefix(this string rawAlias)


### PR DESCRIPTION
|        Method |      Args | Mean before | Mean after | Allocated before | Allocated after |
|-------------- |---------- |------------:|-----------:|-----------------:|----------------:|
|  DefaultsSync | String[0] |   45.093 us |  38.805 us |            32 KB |           25 KB |
| DefaultsAsync | String[0] |   45.541 us |  38.980 us |            32 KB |           25 KB |
|   MinimalSync | String[0] |    8.666 us |   6.903 us |            14 KB |           12 KB |
|  MinimalAsync | String[0] |    8.946 us |   7.146 us |            14 KB |           12 KB |
|  DefaultsSync | String[4] |   50.876 us |  43.782 us |            37 KB |           29 KB |
| DefaultsAsync | String[4] |   51.021 us |  44.395 us |            37 KB |           29 KB |
|   MinimalSync | String[4] |   12.436 us |  10.294 us |            18 KB |           16 KB |
|  MinimalAsync | String[4] |   12.603 us |  10.698 us |            18 KB |           16 KB |

cc @jonsequitur 

I'll most probably send a few more PRs, I am currently focusing on things that don't introduce breaking changes