### PR TITLE
allow help layout to be prepared dynamically based on HelpContext

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -262,7 +262,7 @@ System.CommandLine.Builder
     public static CommandLineBuilder UseExceptionHandler(System.Action<System.Exception,System.CommandLine.Invocation.InvocationContext> onException = null, System.Nullable<System.Int32> errorExitCode = null)
     public static CommandLineBuilder UseHelp()
     public static CommandLineBuilder UseHelp(System.String[] helpAliases)
-    public static CommandLineBuilder UseHelp(System.Collections.Generic.IEnumerable<System.CommandLine.Help.HelpDelegate> layout)
+    public static CommandLineBuilder UseHelp(System.Func<System.CommandLine.Help.HelpContext,System.Collections.Generic.IEnumerable<System.CommandLine.Help.HelpDelegate>> layout)
     public static TBuilder UseHelpBuilder<TBuilder>(System.Func<System.CommandLine.Binding.BindingContext,System.CommandLine.Help.HelpBuilder> getHelpBuilder)
     public static CommandLineBuilder UseLocalizationResources(System.CommandLine.LocalizationResources validationMessages)
     public static CommandLineBuilder UseMiddleware(System.CommandLine.Invocation.InvocationMiddleware middleware, System.CommandLine.Invocation.MiddlewareOrder order = Default)
@@ -298,11 +298,11 @@ System.CommandLine.Help
     public static HelpDelegate OptionsSection()
     public static HelpDelegate SubcommandsSection()
     public static HelpDelegate SynopsisSection()
-    .ctor(System.CommandLine.LocalizationResources localizationResources, System.Int32 maxWidth = 2147483647, System.Collections.Generic.IEnumerable<HelpDelegate> layout = null)
-    public System.Collections.Generic.IEnumerable<HelpDelegate> Layout { get; }
+    .ctor(System.CommandLine.LocalizationResources localizationResources, System.Int32 maxWidth = 2147483647, System.Func<HelpContext,System.Collections.Generic.IEnumerable<HelpDelegate>> getLayout = null)
     public System.CommandLine.LocalizationResources LocalizationResources { get; }
     public System.Int32 MaxWidth { get; }
     public System.Void Customize(System.CommandLine.ISymbol symbol, System.Func<HelpContext,System.String> firstColumnText = null, System.Func<HelpContext,System.String> secondColumnText = null, System.Func<HelpContext,System.String> defaultValue = null)
+    public System.Collections.Generic.IEnumerable<HelpDelegate> GetLayout(HelpContext context)
     public TwoColumnHelpRow GetTwoColumnRow(System.CommandLine.IIdentifierSymbol symbol, HelpContext context)
     public System.Void Write(HelpContext context)
     public System.Void WriteColumns(System.Collections.Generic.IReadOnlyList<TwoColumnHelpRow> items, HelpContext context)

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
@@ -72,45 +72,6 @@ namespace System.CommandLine.Tests.Help
             }
 
             [Fact]
-            public void Option_can_customize_left_column_text_based_on_parse_result()
-            {
-                var option = new Option<bool>("option");
-                var commandA = new Command("a", "a command help")
-                {
-                    option
-                };
-                var commandB = new Command("b", "b command help")
-                {
-                    option
-                };
-                var command = new Command("root", "root command help")
-                {
-                    commandA, commandB
-                };
-                var optionADescription = "option a help";
-                var optionBDescription = "option b help";
-
-                var helpBuilder = new HelpBuilder(LocalizationResources.Instance, LargeMaxWidth);
-                helpBuilder.Customize(option, secondColumnText: ctx =>
-                                          ctx.Command.Equals(commandA)
-                                              ? optionADescription
-                                              : optionBDescription);
-
-                var parser = new CommandLineBuilder(command)
-                             .UseDefaults()
-                             .UseHelpBuilder(_ => helpBuilder)
-                             .Build();
-
-                var console = new TestConsole();
-                parser.Invoke("root a -h", console);
-                console.Out.ToString().Should().Contain($"option          {optionADescription}");
-
-                console = new TestConsole();
-                parser.Invoke("root b -h", console);
-                console.Out.ToString().Should().Contain($"option          {optionBDescription}");
-            }
-
-            [Fact]
             public void Option_can_customize_first_column_text_based_on_parse_result()
             {
                 var option = new Option<bool>("option");
@@ -149,6 +110,45 @@ namespace System.CommandLine.Tests.Help
             }
 
             [Fact]
+            public void Option_can_customize_second_column_text_based_on_parse_result()
+            {
+                var option = new Option<bool>("option");
+                var commandA = new Command("a", "a command help")
+                {
+                    option
+                };
+                var commandB = new Command("b", "b command help")
+                {
+                    option
+                };
+                var command = new Command("root", "root command help")
+                {
+                    commandA, commandB
+                };
+                var optionADescription = "option a help";
+                var optionBDescription = "option b help";
+
+                var helpBuilder = new HelpBuilder(LocalizationResources.Instance, LargeMaxWidth);
+                helpBuilder.Customize(option, secondColumnText: ctx =>
+                                          ctx.Command.Equals(commandA)
+                                              ? optionADescription
+                                              : optionBDescription);
+
+                var parser = new CommandLineBuilder(command)
+                             .UseDefaults()
+                             .UseHelpBuilder(_ => helpBuilder)
+                             .Build();
+
+                var console = new TestConsole();
+                parser.Invoke("root a -h", console);
+                console.Out.ToString().Should().Contain($"option          {optionADescription}");
+
+                console = new TestConsole();
+                parser.Invoke("root b -h", console);
+                console.Out.ToString().Should().Contain($"option          {optionBDescription}");
+            }
+
+            [Fact]
             public void Subcommand_can_customize_first_column_text()
             {
                 var subcommand = new Command("subcommand", "subcommand description");
@@ -168,6 +168,44 @@ namespace System.CommandLine.Tests.Help
             }
 
             [Fact]
+            public void Command_arguments_can_customize_first_column_text()
+            {
+                var argument = new Argument<string>("arg-name", "arg description");
+                var command = new Command("the-command", "command help")
+                {
+                    argument
+                };
+
+                _helpBuilder.Customize(argument, firstColumnText: "<CUSTOM-ARG-NAME>");
+
+                _helpBuilder.Write(command, _console);
+                var expected =
+                    $"Arguments:{NewLine}" +
+                    $"{_indentation}<CUSTOM-ARG-NAME>{_columnPadding}arg description{NewLine}{NewLine}";
+
+                _console.ToString().Should().Contain(expected);
+            }
+
+            [Fact]
+            public void Command_arguments_can_customize_second_column_text()
+            {
+                var argument = new Argument<string>("some-arg", description: "Default description", getDefaultValue: () => "not 42");
+                var command = new Command("the-command", "command help")
+                {
+                    argument
+                };
+
+                _helpBuilder.Customize(argument, secondColumnText: "Custom description");
+
+                _helpBuilder.Write(command, _console);
+                var expected =
+                    $"Arguments:{NewLine}" +
+                    $"{_indentation}<some-arg>{_columnPadding}Custom description [default: not 42]{NewLine}{NewLine}";
+
+                _console.ToString().Should().Contain(expected);
+            }
+
+            [Fact]
             public void Command_arguments_can_customize_default_value()
             {
                 var argument = new Argument<string>("some-arg", getDefaultValue: () => "not 42");
@@ -182,25 +220,6 @@ namespace System.CommandLine.Tests.Help
                 var expected =
                     $"Arguments:{NewLine}" +
                     $"{_indentation}<some-arg>{_columnPadding}[default: 42]{NewLine}{NewLine}";
-
-                _console.ToString().Should().Contain(expected);
-            }
-
-            [Fact]
-            public void Command_arguments_can_customize_second_column_text()
-            {
-                var argument = new Argument<string>("some-arg", getDefaultValue: () => "not 42");
-                var command = new Command("the-command", "command help")
-                {
-                    argument
-                };
-
-                _helpBuilder.Customize(argument, firstColumnText: "some-other-arg");
-
-                _helpBuilder.Write(command, _console);
-                var expected =
-                    $"Arguments:{NewLine}" +
-                    $"{_indentation}some-other-arg{_columnPadding}[default: not 42]{NewLine}{NewLine}";
 
                 _console.ToString().Should().Contain(expected);
             }

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -816,7 +816,7 @@ namespace System.CommandLine.Tests.Help
         }
 
         [Fact]
-        public void Help_describes_default_value_for_defaultable_argument()
+        public void Help_describes_default_value_for_argument()
         {
             var argument = new Argument
             {
@@ -834,7 +834,7 @@ namespace System.CommandLine.Tests.Help
 
             var help = _console.ToString();
 
-            help.Should().Contain($"[default: the-arg-value]");
+            help.Should().Contain("[default: the-arg-value]");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -8,6 +8,8 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.CommandLine.Tests.Utility;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -261,7 +263,7 @@ namespace System.CommandLine.Tests
         public void Help_sections_can_be_replaced()
         {
             var parser = new CommandLineBuilder()
-                         .UseHelp(CustomLayout())
+                         .UseHelp(_ => CustomLayout())
                          .Build();
 
             var console = new TestConsole();
@@ -282,7 +284,7 @@ namespace System.CommandLine.Tests
         {
             var command = new RootCommand("hello");
             var parser = new CommandLineBuilder(command)
-                         .UseHelp(CustomLayout())
+                         .UseHelp(_ => CustomLayout())
                          .Build();
 
             var console = new TestConsole();
@@ -307,8 +309,39 @@ namespace System.CommandLine.Tests
                 yield return ctx => ctx.Output.WriteLine("last");
             }
         }
-        
-        private string GetDefaultHelp(Command command)
+
+        [Fact]
+        public void Layout_can_be_composed_dynamically_based_on_context()
+        {
+            var commandWithTypicalHelp = new Command("typical");
+            var commandWithCustomHelp = new Command("custom");
+            var command = new RootCommand
+            {
+                commandWithTypicalHelp,
+                commandWithCustomHelp
+            };
+
+            var parser = new CommandLineBuilder(command)
+                         .UseHelp(context => context.Command == commandWithTypicalHelp
+                                                 ? HelpBuilder.DefaultLayout()
+                                                 : new HelpDelegate[]
+                                                     {
+                                                         c => c.Output.WriteLine("Custom layout!")
+                                                     }
+                                                     .Concat(HelpBuilder.DefaultLayout()))
+                         .Build();
+
+            var typicalOutput = new TestConsole();
+            parser.Invoke("typical -h", typicalOutput);
+
+            var customOutput = new TestConsole();
+            parser.Invoke("custom -h", customOutput);
+
+            typicalOutput.Out.ToString().Should().Be(GetDefaultHelp(commandWithTypicalHelp, false));
+            customOutput.Out.ToString().Should().Be($"Custom layout!{NewLine}{NewLine}{GetDefaultHelp(commandWithCustomHelp, false)}");
+        }
+
+        private string GetDefaultHelp(Command command, bool trimOneNewline = true)
         {
             var console = new TestConsole();
 
@@ -319,7 +352,11 @@ namespace System.CommandLine.Tests
             parser.Invoke("-h", console);
 
             var output = console.Out.ToString();
-            output = output.Substring(0, output.Length - NewLine.Length);
+
+            if (trimOneNewline)
+            {
+                output = output.Substring(0, output.Length - NewLine.Length);
+            }
             return output;
         }
     }

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -8,7 +8,6 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.CommandLine.Tests.Utility;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -440,9 +440,9 @@ ERR:
         /// <returns>The same instance of <see cref="CommandLineBuilder"/>.</returns>
         public static CommandLineBuilder UseHelp(
             this CommandLineBuilder builder,
-            IEnumerable<HelpDelegate> layout)
+            Func<HelpContext, IEnumerable<HelpDelegate>> layout)
         {
-            return builder.UseHelpBuilder(_ => new HelpBuilder(builder.LocalizationResources, layout: layout))
+            return builder.UseHelpBuilder(_ => new HelpBuilder(builder.LocalizationResources, getLayout: layout))
                           .UseHelp(new HelpOption(() => builder.LocalizationResources));
         }
 


### PR DESCRIPTION
This enables lazily calculating custom help layouts when help is invoked. 

@vlada-shubina, hopefully this helps with https://github.com/dotnet/templating/pull/4143#discussion_r766681916? 