### PR TITLE
Custom type binding

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_NamingConventionBinder_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_NamingConventionBinder_api_is_not_changed.approved.txt
@@ -81,7 +81,7 @@
     public System.CommandLine.Invocation.ICommandHandler GetCommandHandler()
      System.Collections.Generic.IEnumerable<ParameterDescriptor> InitializeParameterDescriptors()
     public System.String ToString()
-  public abstract class IMethodDescriptor
+  public interface IMethodDescriptor
     public System.Collections.Generic.IReadOnlyList<ParameterDescriptor> ParameterDescriptors { get; }
     public ModelDescriptor Parent { get; }
   public class ModelBinder

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -92,33 +92,33 @@
   public static class ConsoleExtensions
     public static System.Void Write(System.String value)
     public static System.Void WriteLine(System.String value)
-  public abstract class IArgument, System.CommandLine.Binding.IValueDescriptor, System.CommandLine.Completions.ICompletionSource, ISymbol
+  public interface IArgument : System.CommandLine.Binding.IValueDescriptor, System.CommandLine.Completions.ICompletionSource, ISymbol
     public IArgumentArity Arity { get; }
-  public abstract class IArgumentArity
+  public interface IArgumentArity
     public System.Int32 MaximumNumberOfValues { get; }
     public System.Int32 MinimumNumberOfValues { get; }
-  public abstract class ICommand, System.CommandLine.Completions.ICompletionSource, IIdentifierSymbol, ISymbol
+  public interface ICommand : System.CommandLine.Completions.ICompletionSource, IIdentifierSymbol, ISymbol
     public System.Collections.Generic.IReadOnlyList<IArgument> Arguments { get; }
     public System.Collections.Generic.IReadOnlyList<IOption> Options { get; }
     public System.Boolean TreatUnmatchedTokensAsErrors { get; }
-  public abstract class IConsole, System.CommandLine.IO.IStandardError, System.CommandLine.IO.IStandardIn, System.CommandLine.IO.IStandardOut
+  public interface IConsole : System.CommandLine.IO.IStandardError, System.CommandLine.IO.IStandardIn, System.CommandLine.IO.IStandardOut
   public abstract class IdentifierSymbol : Symbol, System.CommandLine.Completions.ICompletionSource, IIdentifierSymbol, ISymbol
     public System.Collections.Generic.IReadOnlyCollection<System.String> Aliases { get; }
     public System.String Name { get; set; }
      System.Void AddAliasInner(System.String alias)
     public System.Boolean HasAlias(System.String alias)
      System.Void RemoveAlias(System.String alias)
-  public abstract class IDirectiveCollection, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.String,System.Collections.Generic.IEnumerable<System.String>>>, System.Collections.IEnumerable
+  public interface IDirectiveCollection : System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.String,System.Collections.Generic.IEnumerable<System.String>>>, System.Collections.IEnumerable
     public System.Boolean Contains(System.String name)
     public System.Boolean TryGetValues(System.String name, ref System.Collections.Generic.IReadOnlyList<System.String> values)
-  public abstract class IIdentifierSymbol, System.CommandLine.Completions.ICompletionSource, ISymbol
+  public interface IIdentifierSymbol : System.CommandLine.Completions.ICompletionSource, ISymbol
     public System.Collections.Generic.IReadOnlyCollection<System.String> Aliases { get; }
     public System.Boolean HasAlias(System.String alias)
-  public abstract class IOption, System.CommandLine.Binding.IValueDescriptor, System.CommandLine.Completions.ICompletionSource, IIdentifierSymbol, ISymbol
+  public interface IOption : System.CommandLine.Binding.IValueDescriptor, System.CommandLine.Completions.ICompletionSource, IIdentifierSymbol, ISymbol
     public System.Boolean AllowMultipleArgumentsPerToken { get; }
     public IArgument Argument { get; }
     public System.Boolean IsRequired { get; }
-  public abstract class ISymbol, System.CommandLine.Completions.ICompletionSource
+  public interface ISymbol : System.CommandLine.Completions.ICompletionSource
     public System.CommandLine.Collections.ISymbolSet Children { get; }
     public System.String Description { get; }
     public System.Boolean IsHidden { get; }
@@ -220,6 +220,8 @@
      System.Void ThrowIfAliasIsInvalid(System.String alias)
     public System.String ToString()
 System.CommandLine.Binding
+  public abstract class BinderBase<T>, IValueDescriptor<T>, IValueDescriptor, IValueSource
+    protected T GetBoundValue(BindingContext bindingContext)
   public class BindingContext, System.IServiceProvider
     .ctor(System.CommandLine.Parsing.ParseResult parseResult, System.CommandLine.IConsole console = null)
     public System.CommandLine.IConsole Console { get; }
@@ -227,19 +229,19 @@ System.CommandLine.Binding
     public System.Void AddService(System.Type serviceType, System.Func<System.IServiceProvider,System.Object> factory)
     public System.Void AddService<T>(Func<System.IServiceProvider,T> factory)
     public System.Object GetService(System.Type serviceType)
-  public class BoundValue
+  public struct BoundValue : System.ValueType
     public static BoundValue DefaultForValueDescriptor(IValueDescriptor valueDescriptor)
     public System.Object Value { get; }
     public IValueDescriptor ValueDescriptor { get; }
     public IValueSource ValueSource { get; }
     public System.String ToString()
-  public abstract class IValueDescriptor
+  public interface IValueDescriptor
     public System.Boolean HasDefaultValue { get; }
     public System.String ValueName { get; }
     public System.Type ValueType { get; }
     public System.Object GetDefaultValue()
-  public abstract class IValueDescriptor<T>, IValueDescriptor
-  public abstract class IValueSource
+  public interface IValueDescriptor<out T> : IValueDescriptor
+  public interface IValueSource
     public System.Boolean TryGetValue(IValueDescriptor valueDescriptor, BindingContext bindingContext, ref System.Object& boundValue)
 System.CommandLine.Builder
   public class CommandLineBuilder
@@ -288,7 +290,7 @@ System.CommandLine.Collections
     public T GetByAlias(System.String alias)
     public IEnumerator<T> GetEnumerator()
      System.Void MarkAsDirty(T item)
-  public abstract class ISymbolSet, System.Collections.Generic.IEnumerable<System.CommandLine.ISymbol>, System.Collections.Generic.IReadOnlyCollection<System.CommandLine.ISymbol>, System.Collections.Generic.IReadOnlyList<System.CommandLine.ISymbol>, System.Collections.IEnumerable
+  public interface ISymbolSet : System.Collections.Generic.IEnumerable<System.CommandLine.ISymbol>, System.Collections.Generic.IReadOnlyCollection<System.CommandLine.ISymbol>, System.Collections.Generic.IReadOnlyList<System.CommandLine.ISymbol>, System.Collections.IEnumerable
     public System.CommandLine.ISymbol GetByAlias(System.String alias)
   public class SymbolSet : AliasedSet<System.CommandLine.ISymbol>, System.Collections.Generic.IEnumerable<System.CommandLine.ISymbol>, System.Collections.Generic.IReadOnlyCollection<System.CommandLine.ISymbol>, System.Collections.Generic.IReadOnlyList<System.CommandLine.ISymbol>, System.Collections.IEnumerable, ISymbolSet
     .ctor()
@@ -314,7 +316,7 @@ System.CommandLine.Completions
     public System.Boolean Equals(System.Object obj)
     public System.Int32 GetHashCode()
     public System.String ToString()
-  public abstract class ICompletionSource
+  public interface ICompletionSource
     public System.Collections.Generic.IEnumerable<CompletionItem> GetCompletions(CompletionContext context)
   public class TextCompletionContext : CompletionContext
     public System.String CommandLineText { get; }
@@ -396,9 +398,9 @@ System.CommandLine.Invocation
     public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Func<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,System.Threading.Tasks.Task> handle, System.CommandLine.Binding.IValueDescriptor[] symbols)
     public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Func<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,System.Threading.Tasks.Task> handle, System.CommandLine.Binding.IValueDescriptor[] symbols)
     public static ICommandHandler Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Func<T1,T2,T3,T4,T5,T6,T7,T8,T9,T10,T11,T12,T13,T14,T15,T16,System.Threading.Tasks.Task> handle, System.CommandLine.Binding.IValueDescriptor[] symbols)
-  public abstract class ICommandHandler
+  public interface ICommandHandler
     public System.Threading.Tasks.Task<System.Int32> InvokeAsync(InvocationContext context)
-  public abstract class IInvocationResult
+  public interface IInvocationResult
     public System.Void Apply(InvocationContext context)
   public class InvocationContext, System.IDisposable
     .ctor(System.CommandLine.Parsing.ParseResult parseResult, System.CommandLine.IConsole console = null)
@@ -423,15 +425,15 @@ System.CommandLine.Invocation
     ExceptionHandler=-2000
     Configuration=-1000
 System.CommandLine.IO
-  public abstract class IStandardError
+  public interface IStandardError
     public IStandardStreamWriter Error { get; }
     public System.Boolean IsErrorRedirected { get; }
-  public abstract class IStandardIn
+  public interface IStandardIn
     public System.Boolean IsInputRedirected { get; }
-  public abstract class IStandardOut
+  public interface IStandardOut
     public System.Boolean IsOutputRedirected { get; }
     public IStandardStreamWriter Out { get; }
-  public abstract class IStandardStreamWriter
+  public interface IStandardStreamWriter
     public System.Void Write(System.String value)
   public static class StandardStreamWriter
     public static IStandardStreamWriter Create(System.IO.TextWriter writer)
@@ -476,7 +478,7 @@ System.CommandLine.Parsing
      System.Int32 get_RemainingArgumentCapacity()
     public System.Object GetValueOrDefault()
     public T GetValueOrDefault<T>()
-  public delegate ParseArgument<T> : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
+  public delegate ParseArgument<out T> : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
     .ctor(System.Object object, System.IntPtr method)
     public System.IAsyncResult BeginInvoke(ArgumentResult result, System.AsyncCallback callback, System.Object object)
     public T EndInvoke(System.IAsyncResult result)
@@ -571,7 +573,7 @@ System.CommandLine.Parsing
     DoubleDash=3
     Unparsed=4
     Directive=5
-  public delegate ValidateSymbolResult<T> : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
+  public delegate ValidateSymbolResult<in T> : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
     .ctor(System.Object object, System.IntPtr method)
     public System.IAsyncResult BeginInvoke(T symbolResult, System.AsyncCallback callback, System.Object object)
     public System.String EndInvoke(System.IAsyncResult result)

--- a/src/System.CommandLine.NamingConventionBinder/ModelBinder.cs
+++ b/src/System.CommandLine.NamingConventionBinder/ModelBinder.cs
@@ -227,13 +227,15 @@ public class ModelBinder
             var valueSource = GetValueSource(bindingSources, bindingContext, valueDescriptor, enforceExplicitBinding);
             var (boundValue, usedNonDefault) = 
                 GetBoundValue(valueSource, bindingContext, valueDescriptor, includeMissingValues, parentType);
+            
             if (usedNonDefault && !anyNonDefaults)
             {
                 anyNonDefaults = true;
             }
-            if (boundValue is not null)
+
+            if (boundValue.HasValue)
             {
-                values.Add(boundValue);
+                values.Add(boundValue.Value);
             }
         }
 

--- a/src/System.CommandLine/Binding/BinderBase{T}.cs
+++ b/src/System.CommandLine/Binding/BinderBase{T}.cs
@@ -1,0 +1,37 @@
+﻿namespace System.CommandLine.Binding;
+
+/// <summary>
+/// Supports binding of custom types.
+/// </summary>
+/// <typeparam name="T">The type to be bound.</typeparam>
+public abstract class BinderBase<T> :
+    IValueDescriptor<T>,
+    IValueSource
+{
+    /// <summary>
+    /// Gets a value from the binding context.
+    /// </summary>
+    /// <param name="bindingContext"></param>
+    /// <returns></returns>
+    protected abstract T GetBoundValue(BindingContext bindingContext);
+
+    string IValueDescriptor.ValueName => GetType().Name;
+
+    Type IValueDescriptor.ValueType => typeof(T);
+
+    bool IValueDescriptor.HasDefaultValue => false;
+
+    object? IValueDescriptor.GetDefaultValue() => default(T);
+
+    bool IValueSource.TryGetValue(IValueDescriptor valueDescriptor, BindingContext? bindingContext, out object? boundValue)
+    {
+        if (bindingContext is null)
+        {
+            boundValue = default;
+            return false;
+        }
+
+        boundValue = GetBoundValue(bindingContext);
+        return true;
+    }
+}

--- a/src/System.CommandLine/Binding/BoundValue.cs
+++ b/src/System.CommandLine/Binding/BoundValue.cs
@@ -6,7 +6,7 @@ namespace System.CommandLine.Binding
     /// <summary>
     /// A value created by binding command line input.
     /// </summary>
-    public class BoundValue
+    public readonly struct BoundValue
     {
         internal BoundValue(
             object? value,
@@ -31,7 +31,7 @@ namespace System.CommandLine.Binding
         /// <summary>
         /// The value bound from the specified source.
         /// </summary>
-        public virtual object? Value { get; }
+        public object? Value { get; }
 
         /// <inheritdoc />
         public override string ToString() => $"{ValueDescriptor}: {Value}";

--- a/src/System.CommandLine/Binding/IValueDescriptor{T}.cs
+++ b/src/System.CommandLine/Binding/IValueDescriptor{T}.cs
@@ -4,7 +4,7 @@
 namespace System.CommandLine.Binding
 {
     /// <inheritdoc />
-    public interface IValueDescriptor<T> : IValueDescriptor
+    public interface IValueDescriptor<out T> : IValueDescriptor
     {
     }
 }

--- a/src/System.CommandLine/Invocation/CommandHandler.cs
+++ b/src/System.CommandLine/Invocation/CommandHandler.cs
@@ -13,21 +13,29 @@ public static partial class CommandHandler
         InvocationContext context)
     {
         if (symbols.Length > index &&
-            symbols[index] is IValueDescriptor<T> symbol1)
+            symbols[index] is IValueDescriptor<T> symbol)
         {
             index++;
-            return context.ParseResult.GetValueFor(symbol1);
-        }
-        else
-        {
-            var service = context.BindingContext.GetService(typeof(T));
 
-            if (service is null)
+            if (symbol is IValueSource valueSource && 
+                valueSource.TryGetValue(symbol, context.BindingContext, out var boundValue) &&
+                boundValue is T value)
             {
-                throw new ArgumentException($"Service not found for type {typeof(T)}.");
+                return value;
             }
-
-            return (T)service;
+            else
+            {
+                return context.ParseResult.GetValueFor(symbol);
+            }
         }
+
+        var service = context.BindingContext.GetService(typeof(T));
+
+        if (service is null)
+        {
+            throw new ArgumentException($"Service not found for type {typeof(T)}.");
+        }
+
+        return (T)service;
     }
 }


### PR DESCRIPTION
This adds support for binding custom types using the new `CommandHandler.Create` signatures.