### PR TITLE
made certain members of `HelpBuilder` public, strings fixes

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -372,6 +372,9 @@ System.CommandLine.Help
     public System.Int32 MaxWidth { get; }
     public System.Void CustomizeLayout(System.Func<HelpContext,System.Collections.Generic.IEnumerable<HelpSectionDelegate>> getLayout)
     public System.Void CustomizeSymbol(System.CommandLine.ISymbol symbol, System.Func<HelpContext,System.String> firstColumnText = null, System.Func<HelpContext,System.String> secondColumnText = null, System.Func<HelpContext,System.String> defaultValue = null)
+    public System.String GetArgumentDefaultValue(System.CommandLine.IArgument argument, System.String argumentDisplayName)
+    public System.String GetFirstColumnText(System.CommandLine.IIdentifierSymbol symbol)
+    public System.String GetSecondColumnText(System.CommandLine.IIdentifierSymbol symbol, HelpContext context)
     public TwoColumnHelpRow GetTwoColumnRow(System.CommandLine.ISymbol symbol, HelpContext context)
     public System.Void Write(HelpContext context)
     public System.Void WriteColumns(System.Collections.Generic.IReadOnlyList<TwoColumnHelpRow> items, HelpContext context)

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -231,7 +231,7 @@ namespace System.CommandLine.Tests.Binding
                     .Which
                     .Message
                     .Should()
-                    .Be("Required argument missing for option: -x");
+                    .Be("Required argument missing for option: '-x'.");
         }
 
         [Fact]
@@ -294,7 +294,7 @@ namespace System.CommandLine.Tests.Binding
                     .Which
                     .Message
                     .Should()
-                    .Be("Required argument missing for option: -x");
+                    .Be("Required argument missing for option: '-x'.");
         }
 
         [Fact]
@@ -622,7 +622,7 @@ namespace System.CommandLine.Tests.Binding
             value.Errors
                  .Select(e => e.Message)
                  .Should()
-                 .Contain("Cannot parse argument 'Notaday' for option '-x' as expected type System.DayOfWeek.");
+                 .Contain("Cannot parse argument 'Notaday' for option '-x' as expected type 'System.DayOfWeek'.");
         }
 
         [Fact]
@@ -639,7 +639,7 @@ namespace System.CommandLine.Tests.Binding
                     .Which
                     .Message
                     .Should()
-                    .Be("Cannot parse argument 'not-an-int' for option '-x' as expected type System.Int32.");
+                    .Be("Cannot parse argument 'not-an-int' for option '-x' as expected type 'System.Int32'.");
         }
 
         [Fact]
@@ -656,7 +656,7 @@ namespace System.CommandLine.Tests.Binding
                     .Which
                     .Message
                     .Should()
-                    .Be("Cannot parse argument 'not-an-int' for option '-x' as expected type System.Int32.");
+                    .Be("Cannot parse argument 'not-an-int' for option '-x' as expected type 'System.Int32'.");
         }
     }
 }

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -94,7 +94,7 @@ namespace System.CommandLine.Tests
 
             result.Errors
                   .Should()
-                  .Contain(e => e.Message == "Required argument missing for option: -x");
+                  .Contain(e => e.Message == "Required argument missing for option: '-x'.");
         }
 
         [Fact]
@@ -176,7 +176,7 @@ namespace System.CommandLine.Tests
             result.Errors
                   .Select(e => e.Message)
                   .Should()
-                  .ContainSingle(e => e == "Unrecognized command or argument 'some-arg'");
+                  .ContainSingle(e => e == "Unrecognized command or argument 'some-arg'.");
         }
 
         [Fact]
@@ -401,7 +401,7 @@ namespace System.CommandLine.Tests
                 result.Errors
                       .Should()
                       .Contain(e => e.SymbolResult.Symbol == command.Arguments.First() &&
-                                    e.Message == $"Character not allowed in a path: {invalidCharacter}");
+                                    e.Message == $"Character not allowed in a path: '{invalidCharacter}'.");
             }   
             
             [Fact]
@@ -419,7 +419,7 @@ namespace System.CommandLine.Tests
                 result.Errors
                       .Should()
                       .Contain(e => e.SymbolResult.Symbol.Name == "x" &&
-                                    e.Message == $"Character not allowed in a path: {invalidCharacter}");
+                                    e.Message == $"Character not allowed in a path: '{invalidCharacter}'.");
             }
 
             [Fact]
@@ -472,7 +472,7 @@ namespace System.CommandLine.Tests
                 result.Errors
                       .Should()
                       .Contain(e => e.SymbolResult.Symbol == command.Arguments.First() &&
-                                    e.Message == $"Character not allowed in a file name: {invalidCharacter}");
+                                    e.Message == $"Character not allowed in a file name: '{invalidCharacter}'.");
             }
 
             [Fact]
@@ -490,7 +490,7 @@ namespace System.CommandLine.Tests
                 result.Errors
                       .Should()
                       .Contain(e => e.SymbolResult.Symbol.Name == "x" &&
-                                    e.Message == $"Character not allowed in a file name: {invalidCharacter}");
+                                    e.Message == $"Character not allowed in a file name: '{invalidCharacter}'.");
             }
 
             [Fact]
@@ -544,7 +544,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"File does not exist: {path}");
+                                    e.Message == $"File does not exist: '{path}'.");
             }
 
             [Fact]
@@ -563,7 +563,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"File does not exist: {path}");
+                                    e.Message == $"File does not exist: '{path}'.");
             }
 
             [Fact]
@@ -582,7 +582,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"Directory does not exist: {path}");
+                                    e.Message == $"Directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -601,7 +601,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"Directory does not exist: {path}");
+                                    e.Message == $"Directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -620,7 +620,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol == command.Arguments.First() &&
-                                    e.Message == $"File or directory does not exist: {path}");
+                                    e.Message == $"File or directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -639,7 +639,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"File or directory does not exist: {path}");
+                                    e.Message == $"File or directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -658,7 +658,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" && 
-                                    e.Message == $"File does not exist: {path}");
+                                    e.Message == $"File does not exist: '{path}'.");
             }
             
             [Fact]
@@ -677,7 +677,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" && 
-                                    e.Message == $"File does not exist: {path}");
+                                    e.Message == $"File does not exist: '{path}'.");
             }
 
             [Fact]
@@ -696,7 +696,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"Directory does not exist: {path}");
+                                    e.Message == $"Directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -715,7 +715,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"Directory does not exist: {path}");
+                                    e.Message == $"Directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -736,7 +736,7 @@ namespace System.CommandLine.Tests
                 result.Errors
                       .Should()
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" && 
-                                    e.Message == $"File or directory does not exist: {path}");
+                                    e.Message == $"File or directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -755,7 +755,7 @@ namespace System.CommandLine.Tests
                 result.Errors
                       .Should()
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"File or directory does not exist: {path}");
+                                    e.Message == $"File or directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -774,7 +774,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"File or directory does not exist: {path}");
+                                    e.Message == $"File or directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -793,7 +793,7 @@ namespace System.CommandLine.Tests
                       .HaveCount(1)
                       .And
                       .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
-                                    e.Message == $"File or directory does not exist: {path}");
+                                    e.Message == $"File or directory does not exist: '{path}'.");
             }
 
             [Fact]
@@ -928,7 +928,7 @@ namespace System.CommandLine.Tests
             result.Errors
                   .Select(e => e.Message)
                   .Should()
-                  .Contain("Required argument missing for option: -x");
+                  .Contain("Required argument missing for option: '-x'.");
         }
 
         [Fact]
@@ -967,7 +967,7 @@ namespace System.CommandLine.Tests
                        .Message
                        .Should()
                        .Be(
-"Required argument missing for option: --opt");
+"Required argument missing for option: '--opt'.");
         }
 
         private static string ParseMe(ArgumentResult argumentResult)

--- a/src/System.CommandLine.Tests/ResponseFileTests.cs
+++ b/src/System.CommandLine.Tests/ResponseFileTests.cs
@@ -224,7 +224,7 @@ namespace System.CommandLine.Tests
             result.HasOption(optionOne).Should().BeFalse();
             result.HasOption(optionTwo).Should().BeFalse();
             result.Errors.Should().HaveCount(1);
-            result.Errors.Single().Message.Should().Be("Response file not found 'nonexistent.rsp'");
+            result.Errors.Single().Message.Should().Be("Response file not found 'nonexistent.rsp'.");
         }
 
         [Fact]
@@ -247,7 +247,7 @@ namespace System.CommandLine.Tests
                   .Single()
                   .Message
                   .Should()
-                  .Be("Unrecognized command or argument '@'");
+                  .Be("Unrecognized command or argument '@'.");
         }
 
         [Fact]

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -540,7 +540,12 @@ namespace System.CommandLine.Help
             }
         }
 
-        private string GetFirstColumnText(IIdentifierSymbol symbol)
+        /// <summary>
+        /// Gets the first column content for the specified symbol (typically the usage).
+        /// </summary>
+        /// <param name="symbol">The symbol to get a help item for.</param>
+        /// <returns>Text to dispay.</returns>
+        public string GetFirstColumnText(IIdentifierSymbol symbol)
         {
             var aliases = symbol.Aliases
                                 .Select(r => r.SplitPrefix())
@@ -578,7 +583,7 @@ namespace System.CommandLine.Help
         /// </summary>
         /// <param name="symbol">The symbol to get the description for.</param>
         /// <param name="context">A parse result providing context for help formatting.</param>
-        private string GetSecondColumnText(IIdentifierSymbol symbol, HelpContext context)
+        public string GetSecondColumnText(IIdentifierSymbol symbol, HelpContext context)
         {
             return string.Join(" ", GetSecondColumnTextParts());
 
@@ -588,13 +593,6 @@ namespace System.CommandLine.Help
                 if (!string.IsNullOrWhiteSpace(description))
                 {
                     yield return description!;
-                }
-                else if (
-                    _customizationsBySymbol is { } &&
-                    _customizationsBySymbol.TryGetValue(symbol, out var customization) &&
-                    customization.GetSecondColumn?.Invoke(context) is { } descriptionValue)
-                {
-                    yield return descriptionValue;
                 }
                 string argumentDescription = GetArgumentDescription();
                 if (!string.IsNullOrWhiteSpace(argumentDescription))
@@ -624,7 +622,6 @@ namespace System.CommandLine.Help
             HelpContext context)
         {
             string name = displayArgumentName ? LocalizationResources.HelpArgumentDefaultValueTitle() : argument.Name;
-
             if (_customizationsBySymbol is not null)
             {
                 if (_customizationsBySymbol.TryGetValue(parent, out Customization customization) &&
@@ -639,9 +636,20 @@ namespace System.CommandLine.Help
                     return $"{name}: {ownDefaultValue}";
                 }
             }
+            return GetArgumentDefaultValue(argument, name);
+        }
 
+        /// <summary>
+        /// Gets the argument default value to be displayed for help purposes.
+        /// </summary>
+        /// <param name="argument">The argument to get the description for.</param>
+        /// <param name="argumentDisplayName">The display name to be used for argument (if differs from argument name)</param>
+        public string GetArgumentDefaultValue(
+            IArgument argument,
+            string? argumentDisplayName)
+        {
             object? argumentDefaultValue = argument.GetDefaultValue();
-            string? defaultValue = null;
+            string? defaultValue;
             if (argumentDefaultValue is IEnumerable enumerable and not string)
             {
                 defaultValue = string.Join("|", enumerable.OfType<object>().ToArray());
@@ -651,7 +659,7 @@ namespace System.CommandLine.Help
                 defaultValue = argumentDefaultValue?.ToString();
             }
 
-            return $"{name}: {defaultValue}";
+            return $"{argumentDisplayName ?? argument.Name}: {defaultValue}";
         }
 
         /// <summary>

--- a/src/System.CommandLine/Properties/Resources.Designer.cs
+++ b/src/System.CommandLine/Properties/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; as expected type {1}..
+        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; as expected type &apos;{1}&apos;..
         /// </summary>
         internal static string ArgumentConversionCannotParse {
             get {
@@ -70,7 +70,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; for command &apos;{1}&apos; as expected type {2}..
+        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; for command &apos;{1}&apos; as expected type &apos;{2}&apos;..
         /// </summary>
         internal static string ArgumentConversionCannotParseForCommand {
             get {
@@ -79,7 +79,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; for option &apos;{1}&apos; as expected type {2}..
+        ///   Looks up a localized string similar to Cannot parse argument &apos;{0}&apos; for option &apos;{1}&apos; as expected type &apos;{2}&apos;..
         /// </summary>
         internal static string ArgumentConversionCannotParseForOption {
             get {
@@ -115,7 +115,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Required argument missing for command: {0}.
+        ///   Looks up a localized string similar to Required argument missing for command: &apos;{0}&apos;..
         /// </summary>
         internal static string CommandRequiredArgumentMissing {
             get {
@@ -153,7 +153,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Directory does not exist: {0}.
+        ///   Looks up a localized string similar to Directory does not exist: &apos;{0}&apos;..
         /// </summary>
         internal static string DirectoryDoesNotExist {
             get {
@@ -180,7 +180,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File does not exist: {0}.
+        ///   Looks up a localized string similar to File does not exist: &apos;{0}&apos;..
         /// </summary>
         internal static string FileDoesNotExist {
             get {
@@ -189,7 +189,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File or directory does not exist: {0}.
+        ///   Looks up a localized string similar to File or directory does not exist: &apos;{0}&apos;..
         /// </summary>
         internal static string FileOrDirectoryDoesNotExist {
             get {
@@ -239,6 +239,15 @@ namespace System.CommandLine.Properties {
         internal static string HelpCommandsTitle {
             get {
                 return ResourceManager.GetString("HelpCommandsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Description:.
+        /// </summary>
+        internal static string HelpDescriptionTitle {
+            get {
+                return ResourceManager.GetString("HelpDescriptionTitle", resourceCulture);
             }
         }
         
@@ -304,18 +313,9 @@ namespace System.CommandLine.Properties {
                 return ResourceManager.GetString("HelpUsageTitle", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Description:.
-        /// </summary>
-        internal static string HelpDescriptionTitle {
-            get {
-                return ResourceManager.GetString("HelpDescriptionTitle", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Character not allowed in a file name: {0}.
+        ///   Looks up a localized string similar to Character not allowed in a file name: &apos;{0}&apos;..
         /// </summary>
         internal static string InvalidCharactersInFileName {
             get {
@@ -324,7 +324,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Character not allowed in a path: {0}.
+        ///   Looks up a localized string similar to Character not allowed in a path: &apos;{0}&apos;..
         /// </summary>
         internal static string InvalidCharactersInPath {
             get {
@@ -360,7 +360,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Required argument missing for option: {0}.
+        ///   Looks up a localized string similar to Required argument missing for option: &apos;{0}&apos;..
         /// </summary>
         internal static string OptionRequiredArgumentMissing {
             get {
@@ -378,7 +378,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Response file not found &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Response file not found &apos;{0}&apos;..
         /// </summary>
         internal static string ResponseFileNotFound {
             get {
@@ -405,7 +405,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unrecognized command or argument &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Unrecognized command or argument &apos;{0}&apos;..
         /// </summary>
         internal static string UnrecognizedCommandOrArgument {
             get {

--- a/src/System.CommandLine/Properties/Resources.resx
+++ b/src/System.CommandLine/Properties/Resources.resx
@@ -127,7 +127,7 @@
     <value>No argument was provided for Command '{0}'.</value>
   </data>
   <data name="DirectoryDoesNotExist" xml:space="preserve">
-    <value>Directory does not exist: {0}</value>
+    <value>Directory does not exist: '{0}'.</value>
   </data>
   <data name="OptionExpectsFewerArguments" xml:space="preserve">
     <value>Option '{0}' expects no more than {1} arguments, but {2} were provided.</value>
@@ -139,19 +139,19 @@
     <value>No argument was provided for Option '{0}'.</value>
   </data>
   <data name="FileDoesNotExist" xml:space="preserve">
-    <value>File does not exist: {0}</value>
+    <value>File does not exist: '{0}'.</value>
   </data>
   <data name="FileOrDirectoryDoesNotExist" xml:space="preserve">
-    <value>File or directory does not exist: {0}</value>
+    <value>File or directory does not exist: '{0}'.</value>
   </data>
   <data name="InvalidCharactersInPath" xml:space="preserve">
-    <value>Character not allowed in a path: {0}</value>
+    <value>Character not allowed in a path: '{0}'.</value>
   </data>
   <data name="CommandRequiredArgumentMissing" xml:space="preserve">
-    <value>Required argument missing for command: {0}</value>
+    <value>Required argument missing for command: '{0}'.</value>
   </data>
   <data name="OptionRequiredArgumentMissing" xml:space="preserve">
-    <value>Required argument missing for option: {0}</value>
+    <value>Required argument missing for option: '{0}'.</value>
   </data>
   <data name="RequiredCommandWasNotProvided" xml:space="preserve">
     <value>Required command was not provided.</value>
@@ -160,10 +160,10 @@
     <value>Argument '{0}' not recognized. Must be one of:{1}</value>
   </data>
   <data name="UnrecognizedCommandOrArgument" xml:space="preserve">
-    <value>Unrecognized command or argument '{0}'</value>
+    <value>Unrecognized command or argument '{0}'.</value>
   </data>
   <data name="ResponseFileNotFound" xml:space="preserve">
-    <value>Response file not found '{0}'</value>
+    <value>Response file not found '{0}'.</value>
   </data>
   <data name="ErrorReadingResponseFile" xml:space="preserve">
     <value>Error reading response file '{0}': {1}</value>
@@ -172,7 +172,7 @@
     <value>Show help and usage information</value>
   </data>
   <data name="InvalidCharactersInFileName" xml:space="preserve">
-    <value>Character not allowed in a file name: {0}</value>
+    <value>Character not allowed in a file name: '{0}'.</value>
   </data>
   <data name="HelpUsageAdditionalArguments" xml:space="preserve">
     <value>[[--] &lt;additional arguments&gt;...]]</value>
@@ -186,7 +186,7 @@
   <data name="HelpUsageTitle" xml:space="preserve">
     <value>Usage:</value>
   </data>
-    <data name="HelpDescriptionTitle" xml:space="preserve">
+  <data name="HelpDescriptionTitle" xml:space="preserve">
     <value>Description:</value>
   </data>
   <data name="HelpArgumentDefaultValueTitle" xml:space="preserve">
@@ -234,12 +234,12 @@ The value of the variable should be the name of the processes, separated by a se
     <value>Show version information</value>
   </data>
   <data name="ArgumentConversionCannotParse" xml:space="preserve">
-    <value>Cannot parse argument '{0}' as expected type {1}.</value>
+    <value>Cannot parse argument '{0}' as expected type '{1}'.</value>
   </data>
   <data name="ArgumentConversionCannotParseForCommand" xml:space="preserve">
-    <value>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</value>
+    <value>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</value>
   </data>
   <data name="ArgumentConversionCannotParseForOption" xml:space="preserve">
-    <value>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</value>
+    <value>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</value>
   </data>
 </root>

--- a/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.de.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.de.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.es.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.es.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.it.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.it.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
@@ -3,18 +3,18 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
-        <source>Cannot parse argument '{0}' as expected type {1}.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type {1}.</target>
+        <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
+        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
-        <source>Cannot parse argument '{0}' for command '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
-        <source>Cannot parse argument '{0}' for option '{1}' as expected type {2}.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type {2}.</target>
+        <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
+        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandExpectsFewerArguments">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: {0}</source>
-        <target state="new">Required argument missing for command: {0}</target>
+        <source>Required argument missing for command: '{0}'.</source>
+        <target state="new">Required argument missing for command: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugDirectiveAttachToProcess">
@@ -57,8 +57,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
-        <source>Directory does not exist: {0}</source>
-        <target state="new">Directory does not exist: {0}</target>
+        <source>Directory does not exist: '{0}'.</source>
+        <target state="new">Directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
@@ -72,13 +72,13 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
-        <source>File does not exist: {0}</source>
-        <target state="new">File does not exist: {0}</target>
+        <source>File does not exist: '{0}'.</source>
+        <target state="new">File does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
-        <source>File or directory does not exist: {0}</source>
-        <target state="new">File or directory does not exist: {0}</target>
+        <source>File or directory does not exist: '{0}'.</source>
+        <target state="new">File or directory does not exist: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
@@ -117,8 +117,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
-        <source>Character not allowed in a file name: {0}</source>
-        <target state="new">Character not allowed in a file name: {0}</target>
+        <source>Character not allowed in a file name: '{0}'.</source>
+        <target state="new">Character not allowed in a file name: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequired">
@@ -152,8 +152,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
-        <source>Character not allowed in a path: {0}</source>
-        <target state="new">Character not allowed in a path: {0}</target>
+        <source>Character not allowed in a path: '{0}'.</source>
+        <target state="new">Character not allowed in a path: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsFewerArguments">
@@ -172,8 +172,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
-        <source>Required argument missing for option: {0}</source>
-        <target state="new">Required argument missing for option: {0}</target>
+        <source>Required argument missing for option: '{0}'.</source>
+        <target state="new">Required argument missing for option: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
@@ -182,8 +182,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
-        <source>Response file not found '{0}'</source>
-        <target state="new">Response file not found '{0}'</target>
+        <source>Response file not found '{0}'.</source>
+        <target state="new">Response file not found '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
@@ -197,8 +197,8 @@ The value of the variable should be the name of the processes, separated by a se
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
-        <source>Unrecognized command or argument '{0}'</source>
-        <target state="new">Unrecognized command or argument '{0}'</target>
+        <source>Unrecognized command or argument '{0}'.</source>
+        <target state="new">Unrecognized command or argument '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">


### PR DESCRIPTION
Couple of improvements:
- made certain members of `HelpBuilder` public to benefit from them when customizing symbols: https://github.com/dotnet/command-line-api/issues/1523#issuecomment-994776662

- fixed usage of period and quotes in strings (made them consistently using 'quotes' and period at the end of the error