### PR TITLE
removed MaxWidth from HelpContext, fixed setting MaxWidth for HelpBuilder

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -301,9 +301,9 @@ System.CommandLine.Builder
     public static CommandLineBuilder UseDefaults(this CommandLineBuilder builder)
     public static CommandLineBuilder UseEnvironmentVariableDirective(this CommandLineBuilder builder)
     public static CommandLineBuilder UseExceptionHandler(this CommandLineBuilder builder, System.Action<System.Exception,System.CommandLine.Invocation.InvocationContext> onException = null, System.Nullable<System.Int32> errorExitCode = null)
-    public static CommandLineBuilder UseHelp(this CommandLineBuilder builder)
+    public static CommandLineBuilder UseHelp(this CommandLineBuilder builder, System.Nullable<System.Int32> maxWidth = null)
     public static CommandLineBuilder UseHelp(this CommandLineBuilder builder, System.String[] helpAliases)
-    public static CommandLineBuilder UseHelp(this CommandLineBuilder builder, System.Action<System.CommandLine.Help.HelpContext> customize)
+    public static CommandLineBuilder UseHelp(this CommandLineBuilder builder, System.Action<System.CommandLine.Help.HelpContext> customize, System.Nullable<System.Int32> maxWidth = null)
     public static TBuilder UseHelpBuilder<TBuilder>(this TBuilder builder, System.Func<System.CommandLine.Binding.BindingContext,System.CommandLine.Help.HelpBuilder> getHelpBuilder)
     public static CommandLineBuilder UseLocalizationResources(this CommandLineBuilder builder, System.CommandLine.LocalizationResources validationMessages)
     public static CommandLineBuilder UseMiddleware(this CommandLineBuilder builder, System.CommandLine.Invocation.InvocationMiddleware middleware, System.CommandLine.Invocation.MiddlewareOrder order = Default)
@@ -379,10 +379,9 @@ System.CommandLine.Help
     public static System.Void CustomizeSymbol(this HelpBuilder builder, System.CommandLine.ISymbol symbol, System.String firstColumnText = null, System.String secondColumnText = null, System.String defaultValue = null)
     public static System.Void Write(this HelpBuilder helpBuilder, System.CommandLine.ICommand command, System.IO.TextWriter writer)
   public class HelpContext
-    .ctor(HelpBuilder helpBuilder, System.CommandLine.ICommand command, System.IO.TextWriter output, System.CommandLine.Parsing.ParseResult parseResult = null, System.Nullable<System.Int32> maxWidth = 2147483647)
+    .ctor(HelpBuilder helpBuilder, System.CommandLine.ICommand command, System.IO.TextWriter output, System.CommandLine.Parsing.ParseResult parseResult = null)
     public System.CommandLine.ICommand Command { get; }
     public HelpBuilder HelpBuilder { get; }
-    public System.Int32 MaxWidth { get; }
     public System.IO.TextWriter Output { get; }
     public System.CommandLine.Parsing.ParseResult ParseResult { get; }
   public delegate HelpSectionDelegate : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -66,7 +66,7 @@ namespace System.CommandLine.Builder
             {
                 var helpBuilder = _helpBuilderFactory is { }
                                              ? _helpBuilderFactory(bindingContext)
-                                             : new HelpBuilder(LocalizationResources);
+                                             : CommandLineConfiguration.DefaultHelpBuilderFactory(bindingContext, MaxHelpWidth);
 
                 helpBuilder.OnCustomize = _customizeHelpBuilder;
 
@@ -77,6 +77,8 @@ namespace System.CommandLine.Builder
         internal HelpOption? HelpOption { get; set; }
 
         internal VersionOption? VersionOption { get; set; }
+
+        internal int? MaxHelpWidth { get; set; }
 
         internal LocalizationResources LocalizationResources
         {

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -411,10 +411,11 @@ ERR:
         /// </code>
         /// </summary>
         /// <param name="builder">A command line builder.</param>
+        /// <param name="maxWidth">Maximum output width for default help builder.</param>
         /// <returns>The same instance of <see cref="CommandLineBuilder"/>.</returns>
-        public static CommandLineBuilder UseHelp(this CommandLineBuilder builder)
+        public static CommandLineBuilder UseHelp(this CommandLineBuilder builder, int? maxWidth = null)
         {
-            return builder.UseHelp(new HelpOption(() => builder.LocalizationResources));
+            return builder.UseHelp(new HelpOption(() => builder.LocalizationResources), maxWidth);
         }
 
         /// <summary>
@@ -437,16 +438,18 @@ ERR:
         /// <remarks>The specified aliases will override the default values.</remarks>
         /// <param name="builder">A command line builder.</param>
         /// <param name="customize">A delegate that will be called to customize help if help is requested.</param>
+        /// <param name="maxWidth">Maximum output width for default help builder.</param>
         /// <returns>The same instance of <see cref="CommandLineBuilder"/>.</returns>
         public static CommandLineBuilder UseHelp(
             this CommandLineBuilder builder,
-            Action<HelpContext> customize)
+            Action<HelpContext> customize,
+            int? maxWidth = null)
         {
             builder.CustomizeHelpLayout(customize);
             
             if (builder.HelpOption is null)
             {
-                builder.UseHelp(new HelpOption(() => builder.LocalizationResources));
+                builder.UseHelp(new HelpOption(() => builder.LocalizationResources), maxWidth);
             }
 
             return builder;
@@ -454,12 +457,14 @@ ERR:
 
         internal static CommandLineBuilder UseHelp(
             this CommandLineBuilder builder,
-            HelpOption helpOption)
+            HelpOption helpOption,
+            int? maxWidth = null)
         {
             if (builder.HelpOption is null)
             {
                 builder.HelpOption = helpOption;
                 builder.Command.TryAddGlobalOption(helpOption);
+                builder.MaxHelpWidth = maxWidth;
 
                 builder.AddMiddleware(async (context, next) =>
                 {

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -56,9 +56,9 @@ namespace System.CommandLine
             _helpBuilderFactory = helpBuilderFactory;
         }
 
-        private static HelpBuilder DefaultHelpBuilderFactory(BindingContext context)
+        internal static HelpBuilder DefaultHelpBuilderFactory(BindingContext context, int? requestedMaxWidth = null)
         {
-            int maxWidth = int.MaxValue;
+            int maxWidth = requestedMaxWidth ?? int.MaxValue;           
             if (context.Console is SystemConsole systemConsole)
             {
                 maxWidth = systemConsole.GetWindowWidth();
@@ -115,7 +115,7 @@ namespace System.CommandLine
         /// </summary>
         public LocalizationResources LocalizationResources { get; }
 
-        internal Func<BindingContext, HelpBuilder> HelpBuilderFactory => _helpBuilderFactory ??= DefaultHelpBuilderFactory;
+        internal Func<BindingContext, HelpBuilder> HelpBuilderFactory => _helpBuilderFactory ??= (context) => DefaultHelpBuilderFactory(context);
 
         internal IReadOnlyList<InvocationMiddleware> Middleware { get; }
 

--- a/src/System.CommandLine/Help/HelpContext.cs
+++ b/src/System.CommandLine/Help/HelpContext.cs
@@ -15,27 +15,16 @@ namespace System.CommandLine.Help
         /// <param name="command">The command for which help is being formatted.</param>
         /// <param name="output">A text writer to write output to.</param>
         /// <param name="parseResult">The result of the current parse operation.</param>
-        /// <param name="maxWidth">The maximum width at which to format the text, used for wrapping text within multi-column output.</param>
         public HelpContext(
             HelpBuilder helpBuilder,
             ICommand command,
             TextWriter output,
-            ParseResult? parseResult = null,
-            int? maxWidth = int.MaxValue)
+            ParseResult? parseResult = null)
         {
             HelpBuilder = helpBuilder ?? throw new ArgumentNullException(nameof(helpBuilder));
             Command = command ?? throw new ArgumentNullException(nameof(command));
             Output = output ?? throw new ArgumentNullException(nameof(output));
             ParseResult = parseResult ?? ParseResult.Empty();
-
-            if (maxWidth is not null)
-            {
-                MaxWidth = maxWidth.Value;
-            }
-            else
-            {
-                MaxWidth = int.MaxValue;
-            }
         }
 
         /// <summary>
@@ -57,11 +46,6 @@ namespace System.CommandLine.Help
         /// A text writer to write output to.
         /// </summary>
         public TextWriter Output { get; }
-
-        /// <summary>
-        /// The maximum width at which to format the text, used for wrapping text within multi-column output.
-        /// </summary>
-        public int MaxWidth { get; }
 
         internal bool WasSectionSkipped { get; set; }
     }

--- a/src/System.CommandLine/Help/HelpResult.cs
+++ b/src/System.CommandLine/Help/HelpResult.cs
@@ -16,8 +16,7 @@ namespace System.CommandLine.Help
             var helpContext = new HelpContext(context.BindingContext.HelpBuilder,
                                               context.ParseResult.CommandResult.Command,
                                               output,
-                                              context.ParseResult,
-                                              (context.Console as SystemConsole)?.GetWindowWidth());
+                                              context.ParseResult);
 
             context.BindingContext
                    .HelpBuilder


### PR DESCRIPTION
Problem:
- help output was not wrapping the lines in tables due to `MaxWidth` in `HelpBuilder` was not set
- `HelpBuilder.MaxWidth` and `HelpContext.MaxWidth`: two properties for same

Solution:
- removed `HelpContext.MaxWidth`
- fixed setting  `MaxWidth` in `HelpBuilder` for all cases