### PR TITLE
fix implicit parser side effect when using CommandLineBuilder

### DIFF
--- a/src/System.CommandLine.Tests/CommandExtensionsTests.cs
+++ b/src/System.CommandLine.Tests/CommandExtensionsTests.cs
@@ -32,7 +32,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void When_CommandLineBuilder_is_used_then_Command_Invoke_uses_its_configuration()
+        public void When_CommandLineBuilder_is_used_then_Command_Invoke_does_not_use_its_configuration()
         {
             var command = new RootCommand();
 
@@ -50,7 +50,7 @@ namespace System.CommandLine.Tests
             console.Out
                    .ToString()
                    .Should()
-                   .Contain("hello!");
+                   .NotContain("hello!");
         }
     }
 }

--- a/src/System.CommandLine/CommandExtensions.cs
+++ b/src/System.CommandLine/CommandExtensions.cs
@@ -26,7 +26,7 @@ namespace System.CommandLine
             string[] args,
             IConsole? console = null)
         {
-            return GetInvocationPipeline(command, args).Invoke(console);
+            return GetDefaultInvocationPipeline(command, args).Invoke(console);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace System.CommandLine
             string[] args,
             IConsole? console = null)
         {
-            return await GetInvocationPipeline(command, args).InvokeAsync(console);
+            return await GetDefaultInvocationPipeline(command, args).InvokeAsync(console);
         }
 
         /// <summary>
@@ -72,14 +72,16 @@ namespace System.CommandLine
             IConsole? console = null) =>
             command.InvokeAsync(CommandLineStringSplitter.Instance.Split(commandLine).ToArray(), console);
 
-        private static InvocationPipeline GetInvocationPipeline(Command command, string[] args)
+        private static InvocationPipeline GetDefaultInvocationPipeline(Command command, string[] args)
         {
-            var parser = command.ImplicitParser ??
-                         new CommandLineBuilder(command)
-                             .UseDefaults()
-                             .Build();
+            if (command.ImplicitParser is null)
+            {
+                command.ImplicitParser = new CommandLineBuilder(command)
+                                         .UseDefaults()
+                                         .Build();
+            }
 
-            var parseResult = parser.Parse(args);
+            var parseResult = command.ImplicitParser.Parse(args);
 
             return new InvocationPipeline(parseResult);
         }

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;
-using System.Collections.Generic;
 using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
-using System.CommandLine.Completions;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/System.CommandLine/Parsing/Parser.cs
+++ b/src/System.CommandLine/Parsing/Parser.cs
@@ -15,11 +15,6 @@ namespace System.CommandLine.Parsing
         public Parser(CommandLineConfiguration configuration)
         {
             Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-
-            if (configuration.RootCommand is Command { ImplicitParser: null} cmd)
-            {
-                cmd.ImplicitParser = this;
-            }
         }
 
         /// <param name="command">The root command for the parser.</param>

--- a/src/System.CommandLine/SymbolExtensions.cs
+++ b/src/System.CommandLine/SymbolExtensions.cs
@@ -37,19 +37,13 @@ namespace System.CommandLine
         {
             var root = GetOrCreateRootCommand(symbol);
 
-            if (root.ImplicitParser is { } parser)
+            if (root.ImplicitParser is not { } parser)
             {
-                return parser;
-            }
-            else
-            {
-                return BuildParser(root);
+                parser = new Parser(new CommandLineConfiguration(root));
+                root.ImplicitParser = parser;
             }
 
-            static Parser BuildParser(Command cmd)
-            {
-                return new Parser(new CommandLineConfiguration(cmd));
-            }
+            return parser;
         }
 
         internal static Command GetOrCreateRootCommand(Symbol symbol)


### PR DESCRIPTION
This addresses an issue that came up here: https://github.com/dotnet/command-line-api/issues/796#issuecomment-999734612