### PR TITLE
make error on missing symbol in SetHandler more helpful

### DIFF
--- a/src/System.CommandLine.Tests/Binding/SetHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Binding/SetHandlerTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
+using static System.Environment;
 
 namespace System.CommandLine.Tests.Binding
 {
@@ -158,6 +159,62 @@ namespace System.CommandLine.Tests.Binding
 
             wasCalled.Should().BeFalse();
             exitCode.Should().Be(1);
+        }
+
+        [Fact]
+        public void If_no_symbol_was_passed_for_binding_then_the_error_message_suggests_a_fix_for_the_first_missing_symbol()
+        {
+            var boolOption = new Option<bool>("-o");
+            var stringArg = new Argument<string>("value");
+
+            var subcommand = new Command("TheCommand")
+            {
+                boolOption,
+                stringArg
+            };
+
+            var command = new RootCommand
+            {
+                subcommand
+            };
+
+            subcommand.SetHandler((bool boolValue, string stringValue) => { });
+
+            var console = new TestConsole();
+
+            command.Invoke("TheCommand -o hi", console);
+
+            console.Error.ToString().Should()
+                   .Contain(
+                       $"No binding target was provided to the handler for command 'TheCommand' for the parameter at position 0. Did you mean to pass one of these?{NewLine}Option<Boolean> -o");
+        }
+
+        [Fact]
+        public void If_no_symbol_was_passed_for_binding_subsequent_parameter_then_the_error_message_suggests_a_fix_for_the_first_missing_symbol()
+        {
+            var boolOption = new Option<bool>("-o");
+            var stringArg = new Argument<string>("value");
+
+            var subcommand = new Command("TheCommand")
+            {
+                boolOption,
+                stringArg
+            };
+
+            var command = new RootCommand
+            {
+                subcommand
+            };
+
+            subcommand.SetHandler((bool boolValue, string stringValue) => { }, boolOption);
+
+            var console = new TestConsole();
+
+            command.Invoke("TheCommand -o hi", console);
+
+            console.Error.ToString().Should()
+                   .Contain(
+                       $"No binding target was provided to the handler for command 'TheCommand' for the parameter at position 1. Did you mean to pass one of these?{NewLine}Argument<String> value");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/Binding/SetHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Binding/SetHandlerTests.cs
@@ -186,7 +186,7 @@ namespace System.CommandLine.Tests.Binding
 
             console.Error.ToString().Should()
                    .Contain(
-                       $"No binding target was provided to the handler for command 'TheCommand' for the parameter at position 0. Did you mean to pass one of these?{NewLine}Option<Boolean> -o");
+                       $"The SetHandler call for command 'TheCommand' is missing an Argument or Option for the parameter at position 0. Did you mean to pass one of these?{NewLine}Option<Boolean> -o");
         }
 
         [Fact]
@@ -214,7 +214,7 @@ namespace System.CommandLine.Tests.Binding
 
             console.Error.ToString().Should()
                    .Contain(
-                       $"No binding target was provided to the handler for command 'TheCommand' for the parameter at position 1. Did you mean to pass one of these?{NewLine}Argument<String> value");
+                       $"The SetHandler call for command 'TheCommand' is missing an Argument or Option for the parameter at position 1. Did you mean to pass one of these?{NewLine}Argument<String> value");
         }
 
         [Fact]

--- a/src/System.CommandLine/Handler.cs
+++ b/src/System.CommandLine/Handler.cs
@@ -61,7 +61,7 @@ public static partial class Handler
                         }));
 
                 throw new ArgumentException(
-                    $"No binding target was provided to the handler for command '{context.ParseResult.CommandResult.Command.Name}' for the parameter at position {index}. Did you mean to pass one of these?{NewLine}{candidatesDescription}");
+                    $"The {nameof(SetHandler)} call for command '{context.ParseResult.CommandResult.Command.Name}' is missing an {nameof(Argument)} or {nameof(Option)} for the parameter at position {index}. Did you mean to pass one of these?{NewLine}{candidatesDescription}");
             }
 
             throw new ArgumentException($"Service not found for type {typeof(T)}.");


### PR DESCRIPTION
This change improves the error message that occurs when a `SetHandler`-created command handler can't bind a parameter. Previously, the error assumed there was a missing registration in the service provider, but in most cases this happens because a symbol wasn't passed to bind to. 

The new error message suggests symbols that can be bound to the parameter. 