### PR TITLE
Issue 833: Help Line Wrap

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
@@ -47,7 +47,7 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Fact]
-        public async Task It_shows_help_text_based_on_XML_documentation_comments_without_para()
+        public async Task It_shows_help_text_based_on_XML_documentation_comments()
         {
             int exitCode = await CommandLine.InvokeMethodAsync(
                                new[] { "--help" },
@@ -67,11 +67,11 @@ namespace System.CommandLine.DragonFruit.Tests
                 .ContainAll("--name <name>", "Specifies the name option")
                 .And.Contain("Options:");
             stdOut.Should()
-                .Contain("Description:\n  Normal summary");
+                .Contain($"Description:{Environment.NewLine}  Normal summary");
         }
         
         [Fact]
-        public async Task It_shows_help_text_based_on_XML_documentation_comments_with_para()
+        public async Task When_XML_documentation_comment_contains_a_para_tag_then_help_is_written_with_a_newline()
         {
             int exitCode = await CommandLine.InvokeMethodAsync(
                 new[] { "--help" },
@@ -91,7 +91,7 @@ namespace System.CommandLine.DragonFruit.Tests
                 .ContainAll("--name <name>", "Specifies the name option")
                 .And.Contain("Options:");
             stdOut.Should()
-                .Contain("Description:\n  Help for the test program\n  More help for the test program\n");
+                .Contain($"Description:{Environment.NewLine}  Help for the test program{Environment.NewLine}  More help for the test program{Environment.NewLine}");
         }
 
         [Fact]

--- a/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Rendering;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
@@ -24,7 +25,7 @@ namespace System.CommandLine.DragonFruit.Tests
         {
             int exitCode = await CommandLine.InvokeMethodAsync(
                                new[] { "--name", "Wayne" },
-                               TestProgram.TestMainMethodInfo,
+                               TestProgram.TestMainMethodInfoWithoutPara,
                                null,
                                _testProgram,
                                _terminal);
@@ -37,7 +38,7 @@ namespace System.CommandLine.DragonFruit.Tests
         {
             int exitCode = CommandLine.InvokeMethod(
                 new[] { "--name", "Wayne" },
-                TestProgram.TestMainMethodInfo,
+                TestProgram.TestMainMethodInfoWithoutPara,
                 null,
                 _testProgram,
                 _terminal);
@@ -46,11 +47,11 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Fact]
-        public async Task It_shows_help_text_based_on_XML_documentation_comments()
+        public async Task It_shows_help_text_based_on_XML_documentation_comments_without_para()
         {
             int exitCode = await CommandLine.InvokeMethodAsync(
                                new[] { "--help" },
-                               TestProgram.TestMainMethodInfo,
+                               TestProgram.TestMainMethodInfoWithoutPara,
                                null,
                                _testProgram, 
                                _terminal);
@@ -60,23 +61,23 @@ namespace System.CommandLine.DragonFruit.Tests
             var stdOut = _terminal.Out.ToString();
 
             stdOut.Should()
-                  .Contain("<args>  These are arguments")
-                  .And.Contain("Arguments:");
+                .Contain("<args>  These are arguments")
+                .And.Contain("Arguments:");
             stdOut.Should()
-                  .ContainAll("--name <name>", "Specifies the name option")
-                  .And.Contain("Options:");
+                .ContainAll("--name <name>", "Specifies the name option")
+                .And.Contain("Options:");
             stdOut.Should()
-                  .Contain("Help for the test program");
+                .Contain("Description:\n  Normal summary");
         }
-
+        
         [Fact]
-        public void It_synchronously_shows_help_text_based_on_XML_documentation_comments()
+        public async Task It_shows_help_text_based_on_XML_documentation_comments_with_para()
         {
-            int exitCode = CommandLine.InvokeMethod(
+            int exitCode = await CommandLine.InvokeMethodAsync(
                 new[] { "--help" },
-                TestProgram.TestMainMethodInfo,
+                TestProgram.TestMainMethodInfoWithPara,
                 null,
-                _testProgram,
+                _testProgram, 
                 _terminal);
 
             exitCode.Should().Be(0);
@@ -87,10 +88,32 @@ namespace System.CommandLine.DragonFruit.Tests
                 .Contain("<args>  These are arguments")
                 .And.Contain("Arguments:");
             stdOut.Should()
-                .ContainAll("--name <name>","Specifies the name option")
+                .ContainAll("--name <name>", "Specifies the name option")
                 .And.Contain("Options:");
             stdOut.Should()
-                .Contain("Help for the test program");
+                .Contain("Description:\n  Help for the test program\n  More help for the test program\n");
+        }
+
+        [Fact]
+        public void It_synchronously_shows_help_text_based_on_XML_documentation_comments()
+        {
+            int exitCode = CommandLine.InvokeMethod(
+                new[] { "--help" },
+                TestProgram.TestMainMethodInfoWithDefault,
+                null,
+                _testProgram,
+                _terminal);
+
+            exitCode.Should().Be(0);
+
+            var stdOut = _terminal.Out.ToString();
+
+            stdOut.Should()
+                .ContainAll("ReSharperTestRunner","[options]")
+                .And.Contain("Usage:");
+            stdOut.Should()
+                .ContainAll("--name <name>","name [default: Bruce]")
+                .And.Contain("Options:");
         }
 
         [Fact]

--- a/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
@@ -109,9 +109,6 @@ namespace System.CommandLine.DragonFruit.Tests
             var stdOut = _terminal.Out.ToString();
 
             stdOut.Should()
-                .ContainAll("ReSharperTestRunner","[options]")
-                .And.Contain("Usage:");
-            stdOut.Should()
                 .ContainAll("--name <name>","name [default: Bruce]")
                 .And.Contain("Options:");
         }

--- a/src/System.CommandLine.DragonFruit.Tests/TestProgram.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/TestProgram.cs
@@ -7,23 +7,37 @@ namespace System.CommandLine.DragonFruit.Tests
 {
     public class TestProgram
     {
-        public static readonly MethodInfo TestMainMethodInfo = typeof(TestProgram).GetMethod(nameof(TestMain));
+        public static readonly MethodInfo TestMainMethodInfoWithoutPara = typeof(TestProgram).GetMethod(nameof(TestMainWithoutPara));
+        
+        public static readonly MethodInfo TestMainMethodInfoWithPara = typeof(TestProgram).GetMethod(nameof(TestMainWithPara));
 
         public static readonly MethodInfo TestMainMethodInfoWithDefault = typeof(TestProgram).GetMethod(nameof(TestMainWithDefault));
 
         /// <summary>
-        /// Help for the test program
+        /// <para>Help for the test program</para>
+        /// <para>More help for the test program</para>
         /// </summary>
         /// <param name="name">Specifies the name option</param>
         /// <param name="console"></param>
         /// <param name="args">These are arguments</param>
-        public void TestMain(string name, IConsole console, string[] args = null)
+        public void TestMainWithPara(string name, IConsole console, string[] args = null)
         {
             console.Out.Write(name);
             if (args != null && args.Length > 0)
             {
                 console.Out.Write($"args: { string.Join(",", args) }");
             }
+        }
+
+        /// <summary>
+        /// Normal summary
+        /// </summary>
+        /// <param name="name">Specifies the name option</param>
+        /// <param name="console"></param>
+        /// <param name="args">These are arguments</param>
+        public void TestMainWithoutPara(string name, IConsole console, string[] args = null)
+        {
+            console.Out.Write(name);
         }
 
         public void TestMainWithDefault(string name = "Bruce", IConsole console = null)

--- a/src/System.CommandLine.DragonFruit/XmlDocReader.cs
+++ b/src/System.CommandLine.DragonFruit/XmlDocReader.cs
@@ -97,7 +97,7 @@ namespace System.CommandLine.DragonFruit
                             var val = string.Join(string.Empty,
                                 element.Elements().Select(e =>
                                     e.Value + (e.Name.ToString().ToLower() == "para" ? Environment.NewLine : string.Empty)));
-                            commandHelpMetadata.Description = val.TrimEnd(Convert.ToChar("\n"));
+                            commandHelpMetadata.Description = val.TrimEnd(Environment.NewLine.ToCharArray());
                         }
                         else
                         {

--- a/src/System.CommandLine.DragonFruit/XmlDocReader.cs
+++ b/src/System.CommandLine.DragonFruit/XmlDocReader.cs
@@ -92,10 +92,23 @@ namespace System.CommandLine.DragonFruit
                 switch (element.Name.ToString())
                 {
                     case "summary":
-                        commandHelpMetadata.Description = element.Value?.Trim();
+                        if (element.HasElements)
+                        {
+                            var val = string.Join(string.Empty,
+                                element.Elements().Select(e =>
+                                    e.Value + (e.Name.ToString().ToLower() == "para" ? Environment.NewLine : string.Empty)));
+                            commandHelpMetadata.Description = val.TrimEnd(Convert.ToChar("\n"));
+                        }
+                        else
+                        {
+                            commandHelpMetadata.Description = element.Value.Trim();
+                        }
                         break;
                     case "param":
-                        commandHelpMetadata.ParameterDescriptions.Add(element.Attribute("name")?.Value, element.Value?.Trim());
+                        var value = element.Attribute("name")?.Value;
+                        if (value != null)
+                            commandHelpMetadata.ParameterDescriptions.Add(value,
+                                element.Value.Trim());
                         break;
                 }
             }


### PR DESCRIPTION
Fixes #833 
- Add support for multiple <para> tags in help text xml documentation
- Update command line tests to support no xml, xml without para tags, and xml with para tags