### PR TITLE
Fix short/ushort parsing

### DIFF
--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -681,6 +681,45 @@ namespace System.CommandLine.Tests.Binding
             value.Should().Be(1234567890L);
         }
 
+        [Fact]
+        public void Values_can_be_correctly_converted_to_short_without_the_parser_specifying_a_custom_converter()
+        {
+            var option = new Option<ushort>("-s");
+
+            var value = option.Parse("-s 1234").GetValueForOption(option);
+
+            value.Should().Be(1234);
+        }
+
+        [Fact]
+        public void Values_can_be_correctly_converted_to_nullable_short_without_the_parser_specifying_a_custom_converter()
+        {
+            var option = new Option<short?>("-s");
+
+            var value = option.Parse("-s 1234").GetValueForOption(option);
+
+            value.Should().Be(1234);
+        }
+
+        [Fact]
+        public void Values_can_be_correctly_converted_to_ushort_without_the_parser_specifying_a_custom_converter()
+        {
+            var option = new Option<ushort>("-us");
+
+            var value = option.Parse("-us 1234").GetValueForOption(option);
+
+            value.Should().Be(1234);
+        }
+
+        [Fact]
+        public void Values_can_be_correctly_converted_to_nullable_ushort_without_the_parser_specifying_a_custom_converter()
+        {
+            var option = new Option<ushort?>("-us");
+
+            var value = option.Parse("-us 1234").GetValueForOption(option);
+
+            value.Should().Be(1234);
+        }
 
         [Fact]
         public void Values_can_be_correctly_converted_to_array_of_int_without_the_parser_specifying_a_custom_converter()

--- a/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
@@ -234,6 +234,54 @@ internal static partial class ArgumentConverter
             return false;
         },
 
+        [typeof(short)] = (string token, out object? value) =>
+        {
+            if (short.TryParse(token, out var shortValue))
+            {
+                value = shortValue;
+                return true;
+            }
+
+            value = default;
+            return false;
+        },
+
+        [typeof(short?)] = (string token, out object? value) =>
+        {
+            if (short.TryParse(token, out var shortValue))
+            {
+                value = shortValue;
+                return true;
+            }
+
+            value = default;
+            return false;
+        },
+
+        [typeof(ushort)] = (string token, out object? value) =>
+        {
+            if (ushort.TryParse(token, out var ushortValue))
+            {
+                value = ushortValue;
+                return true;
+            }
+
+            value = default;
+            return false;
+        },
+
+        [typeof(ushort?)] = (string token, out object? value) =>
+        {
+            if (ushort.TryParse(token, out var ushortValue))
+            {
+                value = ushortValue;
+                return true;
+            }
+
+            value = default;
+            return false;
+        },
+
         [typeof(string)] = (string input, out object? value) =>
         {
             value = input;


### PR DESCRIPTION
This used to work in 2.0.0-beta1.21308.1. I have added similar changes to https://github.com/dotnet/command-line-api/pull/1617.