### PR TITLE
remove System.Memory dependency from .NET 6.0

### DIFF
--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -28,8 +28,8 @@
     <Compile Include="..\System.Diagnostics.CodeAnalysis.cs" Link="System.Diagnostics.CodeAnalysis\System.Diagnostics.CodeAnalysis.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="system.memory" Version="4.5.4" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This dependency is needed for .NET Standard 2.0 only.