### PR TITLE
Added ZSH Completion Shim Script 

### DIFF
--- a/docs/dotnet-suggest.md
+++ b/docs/dotnet-suggest.md
@@ -14,6 +14,8 @@ On the machine where you'd like to enable completion, you'll need to do two thin
    
    * For bash, add the contents of [dotnet-suggest-shim.bash](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash) to `~/.bash_profile`.
    
+   * For zsh, add the contents of [dotnet-suggest-shim.zsh](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh) to `~/.zshrc`.
+  
    * For PowerShell, add the contents of [dotnet-suggest-shim.ps1](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1) to your PowerShell profile. You can find the expected path to your PowerShell profile by running the following in your console:
 
 ```console

--- a/src/System.CommandLine.Suggest.Tests/SuggestionShellScriptHandlerTest.cs
+++ b/src/System.CommandLine.Suggest.Tests/SuggestionShellScriptHandlerTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Threading.Tasks;
@@ -52,6 +51,16 @@ namespace System.CommandLine.Suggest.Tests
                 _console);
 
             _console.Out.ToString().Should().Contain("Register-ArgumentCompleter");
+        }
+
+        [Fact]
+        public async Task It_should_print_zsh_shell_script()
+        {
+            await _parser.InvokeAsync(
+                "script zsh",
+                _console);
+            
+            _console.Out.ToString().Should().Contain("_dotnet_zsh_complete()");
         }
     }
 }

--- a/src/System.CommandLine.Suggest/ShellType.cs
+++ b/src/System.CommandLine.Suggest/ShellType.cs
@@ -6,6 +6,7 @@ namespace System.CommandLine.Suggest
     public enum ShellType
     {
         Bash,
-        PowerShell
+        PowerShell,
+        Zsh
     }
 }

--- a/src/System.CommandLine.Suggest/SuggestionShellScriptHandler.cs
+++ b/src/System.CommandLine.Suggest/SuggestionShellScriptHandler.cs
@@ -18,6 +18,9 @@ namespace System.CommandLine.Suggest
                 case ShellType.PowerShell:
                     PrintToConsoleFrom(console, "dotnet-suggest-shim.ps1");
                     break;
+                case ShellType.Zsh:
+                    PrintToConsoleFrom(console, "dotnet-suggest-shim.zsh");
+                    break;
                 default:
                     throw new SuggestionShellScriptException($"Shell '{shellType}' is not supported.");
             }

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh
@@ -1,0 +1,15 @@
+# dotnet suggest shell complete script start
+_dotnet_zsh_complete()
+{
+    local fullpath=`which ${words[1]}`
+    local position line
+    read -nl position
+    position=$(($position-1))
+    read -l line
+    line=$(echo "${line}" | sed s/\"/'\\\"'/g)
+    local completions=`dotnet-suggest get --executable "$fullpath" --position ${position} -- "${line}"`
+    reply=( "${(ps:\n:)completions}" )
+}
+compctl -K _dotnet_zsh_complete + -f `dotnet-suggest list`
+export DOTNET_SUGGEST_SCRIPT_VERSION="1.0.0"
+# dotnet suggest shell complete script end

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh
@@ -1,15 +1,39 @@
 # dotnet suggest shell complete script start
 _dotnet_zsh_complete()
 {
-    local fullpath=`which ${words[1]}`
-    local position line
-    read -nl position
-    position=$(($position-1))
-    read -l line
-    line=$(echo "${line}" | sed s/\"/'\\\"'/g)
-    local completions=`dotnet-suggest get --executable "$fullpath" --position ${position} -- "${line}"`
-    reply=( "${(ps:\n:)completions}" )
+    # debug lines, uncomment to get state variables passed to this function
+    # echo "\n\n\nstate:\t'$state'"
+    # echo "line:\t'$line'"
+    # echo "words:\t$words"
+
+    # Get full path to script because dotnet-suggest needs it
+    # NOTE: this requires a command registered with dotnet-suggest be
+    # on the PATH
+    full_path=`which ${words[1]}` # zsh arrays are 1-indexed
+    # Get the full line
+    # $words array when quoted like this gets expanded out into the full line
+    full_line="$words"
+
+    # Get the completion results, will be newline-delimited
+    completions=$(dotnet suggest get --executable "$full_path" -- "$full_line")
+    # explode the completions by linefeed instead of by spaces into the descriptions for the
+    # _values helper function.
+    
+    exploded=(${(f)completions})
+    # for later - once we have descriptions from dotnet suggest, we can stitch them
+    # together like so:
+    # described=()
+    # for i in {1..$#exploded}; do
+    #     argument="${exploded[$i]}"
+    #     description="hello description $i"
+    #     entry=($argument"["$description"]")
+    #     described+=("$entry")
+    # done
+    _values 'suggestions' $exploded
 }
-compctl -K _dotnet_zsh_complete + -f `dotnet-suggest list`
+
+# apply this function to each command the dotnet-suggest knows about
+compdef _dotnet_zsh_complete $(dotnet-suggest list)
+
 export DOTNET_SUGGEST_SCRIPT_VERSION="1.0.0"
 # dotnet suggest shell complete script end

--- a/src/System.CommandLine.Suggest/dotnet-suggest.csproj
+++ b/src/System.CommandLine.Suggest/dotnet-suggest.csproj
@@ -37,6 +37,10 @@
     <Content Include="dotnet-suggest-shim.bash">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Remove="dotnet-suggest-shim.zsh" />
+    <Content Include="dotnet-suggest-shim.zsh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <!-- Workaround https://github.com/dotnet/arcade/issues/2233 -->


### PR DESCRIPTION
Added `dotnet-suggest` ZSH completion shim and associated support.

For original discussion see: https://github.com/dotnet/command-line-api/issues/1618