### PR TITLE
Fix #1209

### DIFF
--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -108,6 +108,12 @@ namespace System.CommandLine.Hosting
                 && command.GetType() == commandType)
             {
                 invocation.BindingContext.AddService(handlerType, c => c.GetService<IHost>().Services.GetService(handlerType));
+                var baseType = handlerType.BaseType;
+                while (baseType != null && baseType != typeof(object))
+                {
+                    invocation.BindingContext.AddService(baseType, c => c.GetService<IHost>().Services.GetService(handlerType));
+                    baseType = baseType.BaseType;
+                }
                 builder.ConfigureServices(services =>
                 {
                     services.AddTransient(handlerType);


### PR DESCRIPTION
`UseCommandHandler(...)` binds base-classes of the CommandHandler-type, to allow implementing ICommandHandler in a base-class.
fixes #1209 