### PR TITLE
Present error instead of throwing exception for empty argument to FileSystemInfo type

### DIFF
--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -5,8 +5,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.CommandLine.Utility;
 using System.IO;
-using System.Linq;
 using FluentAssertions;
+using System.Linq;
 using Xunit;
 
 namespace System.CommandLine.Tests.Binding

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -5,8 +5,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.CommandLine.Utility;
 using System.IO;
-using FluentAssertions;
 using System.Linq;
+using FluentAssertions;
 using Xunit;
 
 namespace System.CommandLine.Tests.Binding
@@ -63,6 +63,21 @@ namespace System.CommandLine.Tests.Binding
             result.GetValueForArgument(argument)
                   .Should()
                   .BeNull();
+        }
+
+        [Fact]
+        public void Argument_of_FileInfo_that_is_empty_results_in_an_informative_error()
+        {
+            var option = new Option<FileInfo>("--file");
+            var result = option.Parse(new string[] { "--file", "" });
+
+            result.Errors
+                  .Should()
+                  .ContainSingle()
+                  .Which
+                  .Message
+                  .Should()
+                  .Contain("Cannot parse argument '' for option '--file'");
         }
 
         [Fact]

--- a/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
@@ -62,6 +62,11 @@ internal static partial class ArgumentConverter
 
         [typeof(DirectoryInfo)] = (string path, out object? value) =>
         {
+            if (String.IsNullOrEmpty(path))
+            {
+                value = default;
+                return false;
+            }
             value = new DirectoryInfo(path);
             return true;
         },
@@ -80,12 +85,22 @@ internal static partial class ArgumentConverter
 
         [typeof(FileInfo)] = (string path, out object? value) =>
         {
+            if (String.IsNullOrEmpty(path))
+            {
+                value = default;
+                return false;
+            }
             value = new FileInfo(path);
             return true;
         },
 
         [typeof(FileSystemInfo)] = (string path, out object? value) =>
         {
+            if (String.IsNullOrEmpty(path))
+            {
+                value = default;
+                return false;
+            }
             if (Directory.Exists(path))
             {
                 value = new DirectoryInfo(path);


### PR DESCRIPTION
See also #1688. Included argument type conversions to FileSystemInfo, FileInfo, and DirectoryInfo do not use TryParse like other types; being passed an empty "path" argument results in exception:
<img width="1082" alt="Screen Shot 2022-04-09 at 17 28 45" src="https://user-images.githubusercontent.com/4241732/162592912-4c56a24f-5222-4d0c-9b06-e0ee445a78d4.png">

This PR replaces this with a conversion error:
<img width="1082" alt="Screen Shot 2022-04-09 at 17 29 59" src="https://user-images.githubusercontent.com/4241732/162592941-dd88c3a1-d48a-440b-9657-11dc5a3a9e0f.png">

