### PR TITLE
Fix #1209

### DIFF
--- a/src/System.CommandLine.NamingConventionBinder/MethodInfoHandlerDescriptor.cs
+++ b/src/System.CommandLine.NamingConventionBinder/MethodInfoHandlerDescriptor.cs
@@ -40,7 +40,7 @@ internal class MethodInfoHandlerDescriptor : HandlerDescriptor
         }
     }
 
-    public override ModelDescriptor Parent => ModelDescriptor.FromType(_handlerMethodInfo.DeclaringType);
+    public override ModelDescriptor Parent => ModelDescriptor.FromType(_handlerMethodInfo.ReflectedType);
 
     private protected override IEnumerable<ParameterDescriptor> InitializeParameterDescriptors() =>
         _handlerMethodInfo.GetParameters()

--- a/src/System.CommandLine.NamingConventionBinder/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine.NamingConventionBinder/ModelBindingCommandHandler.cs
@@ -73,7 +73,7 @@ public class ModelBindingCommandHandler : ICommandHandler
         if (_handlerDelegate is null)
         {
             var invocationTarget = _invocationTarget ?? 
-                                   bindingContext.GetService(_handlerMethodInfo!.DeclaringType);
+                                   bindingContext.GetService(_handlerMethodInfo!.ReflectedType);
             if(invocationTarget is { })
             {
                 _invocationTargetBinder?.UpdateInstance(invocationTarget, bindingContext);


### PR DESCRIPTION
Using `ReflectedType` instead of `DeclaringType` in `ModelBindingCommandHandler` and `MethodInfoHandlerDescriptor`.
As suggested by aayjaychan.

fixes #1209 