### PR TITLE
Add TimeSpan string converter

### DIFF
--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -569,6 +569,28 @@ namespace System.CommandLine.Tests.Binding
         }
 
         [Fact]
+        public void Values_can_be_correctly_converted_to_TimeSpan_without_the_parser_specifying_a_custom_converter()
+        {
+            var timeSpanString = "30";
+            var option = new Option<TimeSpan>("-x");
+
+            var value = option.Parse($"-x {timeSpanString}").GetValueForOption(option);
+
+            value.Should().Be(TimeSpan.Parse(timeSpanString));
+        }
+
+        [Fact]
+        public void Values_can_be_correctly_converted_to_nullable_TimeSpan_without_the_parser_specifying_a_custom_converter()
+        {
+            var timeSpanString = "30";
+            var option = new Option<TimeSpan?>("-x");
+
+            var value = option.Parse($"-x {timeSpanString}").GetValueForOption(option);
+
+            value.Should().Be(TimeSpan.Parse(timeSpanString));
+        }
+
+        [Fact]
         public void Values_can_be_correctly_converted_to_Uri_without_the_parser_specifying_a_custom_converter()
         {
             var option = new Option<Uri>("-x");

--- a/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
@@ -255,5 +255,17 @@ internal static partial class ArgumentConverter
             value = default;
             return false;
         },
+
+        [typeof(TimeSpan)] = (string input, out object? value) =>
+        {
+            if (TimeSpan.TryParse(input, out var timeSpan))
+            {
+                value = timeSpan;
+                return true;
+            }
+
+            value = default;
+            return false;
+        },
     };
 }


### PR DESCRIPTION
Simple change to address issue #1717.

Adds an entry into the String Converters to parse TimeSpan's and a unit test to verify the functionality.