### PR TITLE
Updating HelpBuilder.WriteColumns to be easier to extend

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -312,7 +312,7 @@ System.CommandLine.Help
     public System.Void CustomizeSymbol(System.CommandLine.Symbol symbol, System.Func<HelpContext,System.String> firstColumnText = null, System.Func<HelpContext,System.String> secondColumnText = null, System.Func<HelpContext,System.String> defaultValue = null)
     public TwoColumnHelpRow GetTwoColumnRow(System.CommandLine.Symbol symbol, HelpContext context)
     public System.Void Write(HelpContext context)
-    public System.Void WriteColumns(System.Collections.Generic.IReadOnlyList<TwoColumnHelpRow> items, HelpContext context)
+    public System.Void WriteColumns(System.Collections.Generic.IReadOnlyList<TwoColumnHelpRow> items, System.IO.TextWriter output)
    static class Default
     public static HelpSectionDelegate AdditionalArgumentsSection()
     public static HelpSectionDelegate CommandArgumentsSection()

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -418,9 +418,9 @@ namespace System.CommandLine.Tests
             string result = console.Out.ToString();
             result.Should().Be($"  123  123{NewLine}  456  456{NewLine}  78   789{NewLine}       0{NewLine}{NewLine}{NewLine}");
 
-            IEnumerable<HelpSectionDelegate> CustomLayout(HelpContext _)
+            static IEnumerable<HelpSectionDelegate> CustomLayout(HelpContext _)
             {
-                yield return ctx => ctx.HelpBuilder.WriteColumns(new[] { new TwoColumnHelpRow("12345678", "1234567890") }, ctx);
+                yield return ctx => ctx.HelpBuilder.WriteColumns(new[] { new TwoColumnHelpRow("12345678", "1234567890") }, ctx.Output);
             }
         }
 

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -184,7 +184,7 @@ public partial class HelpBuilder
                 }
 
                 ctx.HelpBuilder.WriteHeading(ctx.HelpBuilder.LocalizationResources.HelpArgumentsTitle(), null, ctx.Output);
-                ctx.HelpBuilder.WriteColumns(commandArguments, ctx);
+                ctx.HelpBuilder.WriteColumns(commandArguments, ctx.Output);
             };
 
         ///  <summary>
@@ -242,7 +242,7 @@ public partial class HelpBuilder
                 }
 
                 ctx.HelpBuilder.WriteHeading(ctx.HelpBuilder.LocalizationResources.HelpOptionsTitle(), null, ctx.Output);
-                ctx.HelpBuilder.WriteColumns(options, ctx);
+                ctx.HelpBuilder.WriteColumns(options, ctx.Output);
                 ctx.Output.WriteLine();
             };
 

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -173,7 +173,7 @@ namespace System.CommandLine.Help
             }
 
             WriteHeading(LocalizationResources.HelpCommandsTitle(), null, context.Output);
-            WriteColumns(subcommands, context);
+            WriteColumns(subcommands, context.Output);
         }
 
         private void WriteAdditionalArguments(HelpContext context)
@@ -210,8 +210,8 @@ namespace System.CommandLine.Help
         /// Writes the specified help rows, aligning output in columns.
         /// </summary>
         /// <param name="items">The help items to write out in columns.</param>
-        /// <param name="context">The help context.</param>
-        public void WriteColumns(IReadOnlyList<TwoColumnHelpRow> items, HelpContext context)
+        /// <param name="output">The text write to output to.</param>
+        public void WriteColumns(IReadOnlyList<TwoColumnHelpRow> items, TextWriter output)
         {
             if (items.Count == 0)
             {
@@ -241,7 +241,7 @@ namespace System.CommandLine.Help
 
                 foreach (var (first, second) in ZipWithEmpty(firstColumnParts, secondColumnParts))
                 {
-                    context.Output.Write($"{Indent}{first}");
+                    output.Write($"{Indent}{first}");
                     if (!string.IsNullOrWhiteSpace(second))
                     {
                         int padSize = firstColumnWidth - first.Length;
@@ -251,10 +251,10 @@ namespace System.CommandLine.Help
                             padding = new string(' ', padSize);
                         }
 
-                        context.Output.Write($"{padding}{Indent}{second}");
+                        output.Write($"{padding}{Indent}{second}");
                     }
 
-                    context.Output.WriteLine();
+                    output.WriteLine();
                 }
             }
 


### PR DESCRIPTION
While updating ClangSharp to the latest System.CommandLine I ran into the issue of a custom HelpBuilder wanting to leverage the two column layout for some arbitrary items. This required building a HelpContext despite the method only needing a TextWriter to output to.

See: https://github.com/dotnet/ClangSharp/pull/343