### PR TITLE
Add support for IPAddress and IPEndpoint arguments

### DIFF
--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -710,6 +710,7 @@ namespace System.CommandLine.Tests.Binding
             value.Should().Be(123);
         }
 
+        [Fact]
         public void Values_can_be_correctly_converted_to_ipaddress_without_the_parser_specifying_a_custom_converter()
         {
             var option = new Option<IPAddress>("-us");
@@ -730,6 +731,7 @@ namespace System.CommandLine.Tests.Binding
         }
 
 #if NETCOREAPP3_0_OR_GREATER
+        [Fact]
         public void Values_can_be_correctly_converted_to_ipendpoint_without_the_parser_specifying_a_custom_converter()
         {
             var option = new Option<IPEndPoint>("-us");
@@ -749,7 +751,7 @@ namespace System.CommandLine.Tests.Binding
             value.Should().Be(IPEndPoint.Parse("192.168.1.7:8080"));
         }
 #endif
-        
+
         [Fact]
         public void Values_can_be_correctly_converted_to_byte_without_the_parser_specifying_a_custom_converter()
         {

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using FluentAssertions;
 using System.Linq;
 using Xunit;
+using System.Net;
 
 namespace System.CommandLine.Tests.Binding
 {
@@ -707,6 +708,44 @@ namespace System.CommandLine.Tests.Binding
             var value = option.Parse("-x 123").GetValueForOption(option);
 
             value.Should().Be(123);
+        }
+
+        public void Values_can_be_correctly_converted_to_ipaddress_without_the_parser_specifying_a_custom_converter()
+        {
+            var option = new Option<IPAddress>("-us");
+
+            var value = option.Parse("-us 1.2.3.4").GetValueForOption(option);
+
+            value.Should().Be(IPAddress.Parse("1.2.3.4"));
+        }
+        
+        [Fact]
+        public void Values_can_be_correctly_converted_to_nullable_ipaddress_without_the_parser_specifying_a_custom_converter()
+        {
+            var option = new Option<IPAddress?>("-x");
+
+            var value = option.Parse("-x 192.168.1.7").GetValueForOption(option);
+
+            value.Should().Be(IPAddress.Parse("192.168.1.7"));
+        }
+
+        public void Values_can_be_correctly_converted_to_ipendpoint_without_the_parser_specifying_a_custom_converter()
+        {
+            var option = new Option<IPEndPoint>("-us");
+
+            var value = option.Parse("-us 1.2.3.4:56").GetValueForOption(option);
+
+            value.Should().Be(IPEndPoint.Parse("1.2.3.4:56"));
+        }
+        
+        [Fact]
+        public void Values_can_be_correctly_converted_to_nullable_ipendpoint_without_the_parser_specifying_a_custom_converter()
+        {
+            var option = new Option<IPEndPoint?>("-x");
+
+            var value = option.Parse("-x 192.168.1.7:8080").GetValueForOption(option);
+
+            value.Should().Be(IPEndPoint.Parse("192.168.1.7:8080"));
         }
         
         [Fact]

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -719,16 +719,6 @@ namespace System.CommandLine.Tests.Binding
 
             value.Should().Be(IPAddress.Parse("1.2.3.4"));
         }
-        
-        [Fact]
-        public void Values_can_be_correctly_converted_to_nullable_ipaddress_without_the_parser_specifying_a_custom_converter()
-        {
-            var option = new Option<IPAddress?>("-x");
-
-            var value = option.Parse("-x 192.168.1.7").GetValueForOption(option);
-
-            value.Should().Be(IPAddress.Parse("192.168.1.7"));
-        }
 
 #if NETCOREAPP3_0_OR_GREATER
         [Fact]
@@ -739,16 +729,6 @@ namespace System.CommandLine.Tests.Binding
             var value = option.Parse("-us 1.2.3.4:56").GetValueForOption(option);
 
             value.Should().Be(IPEndPoint.Parse("1.2.3.4:56"));
-        }
-        
-        [Fact]
-        public void Values_can_be_correctly_converted_to_nullable_ipendpoint_without_the_parser_specifying_a_custom_converter()
-        {
-            var option = new Option<IPEndPoint?>("-x");
-
-            var value = option.Parse("-x 192.168.1.7:8080").GetValueForOption(option);
-
-            value.Should().Be(IPEndPoint.Parse("192.168.1.7:8080"));
         }
 #endif
 

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -729,6 +729,7 @@ namespace System.CommandLine.Tests.Binding
             value.Should().Be(IPAddress.Parse("192.168.1.7"));
         }
 
+#if NETCOREAPP3_0_OR_GREATER
         public void Values_can_be_correctly_converted_to_ipendpoint_without_the_parser_specifying_a_custom_converter()
         {
             var option = new Option<IPEndPoint>("-us");
@@ -747,6 +748,7 @@ namespace System.CommandLine.Tests.Binding
 
             value.Should().Be(IPEndPoint.Parse("192.168.1.7:8080"));
         }
+#endif
         
         [Fact]
         public void Values_can_be_correctly_converted_to_byte_without_the_parser_specifying_a_custom_converter()

--- a/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 
 namespace System.CommandLine.Binding;
 
@@ -147,6 +148,30 @@ internal static partial class ArgumentConverter
             if (int.TryParse(token, out var intValue))
             {
                 value = intValue;
+                return true;
+            }
+
+            value = default;
+            return false;
+        },
+
+        [typeof(IPAddress)] = (string token, out object? value) =>
+        {
+            if (IPAddress.TryParse(token, out var ip))
+            {
+                value = ip;
+                return true;
+            }
+
+            value = default;
+            return false;
+        },
+
+        [typeof(IPEndPoint)] = (string token, out object? value) =>
+        {
+            if (IPEndPoint.TryParse(token, out var ipendpoint))
+            {
+                value = ipendpoint;
                 return true;
             }
 

--- a/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
@@ -167,18 +167,19 @@ internal static partial class ArgumentConverter
             return false;
         },
 
+#if NETCOREAPP3_0_OR_GREATER
         [typeof(IPEndPoint)] = (string token, out object? value) =>
         {
-            try {
-                value = IPEndPoint.Parse(token);
+            if (IPEndPoint.TryParse(token, out var ipendpoint))
+            {
+                value = ipendpoint;
                 return true;
             }
-            catch (FormatException)
-            {
-                value = default;
-                return false;
-            }
+
+            value = default;
+            return false;
         },
+#endif
 
         [typeof(long)] = (string token, out object? value) =>
         {

--- a/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.StringConverters.cs
@@ -169,14 +169,15 @@ internal static partial class ArgumentConverter
 
         [typeof(IPEndPoint)] = (string token, out object? value) =>
         {
-            if (IPEndPoint.TryParse(token, out var ipendpoint))
-            {
-                value = ipendpoint;
+            try {
+                value = IPEndPoint.Parse(token);
                 return true;
             }
-
-            value = default;
-            return false;
+            catch (FormatException)
+            {
+                value = default;
+                return false;
+            }
         },
 
         [typeof(long)] = (string token, out object? value) =>


### PR DESCRIPTION
As in #1734, but this time for `IPAddress` and `IPEndpoint`, both common types I find myself passing to commandline utilities.