### PR TITLE
Add support for timeout in process termination handling

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -240,7 +240,7 @@ System.CommandLine.Builder
   public static class CommandLineBuilderExtensions
     public static CommandLineBuilder AddMiddleware(this CommandLineBuilder builder, System.CommandLine.Invocation.InvocationMiddleware middleware, System.CommandLine.Invocation.MiddlewareOrder order = Default)
     public static CommandLineBuilder AddMiddleware(this CommandLineBuilder builder, System.Action<System.CommandLine.Invocation.InvocationContext> onInvoke, System.CommandLine.Invocation.MiddlewareOrder order = Default)
-    public static CommandLineBuilder CancelOnProcessTermination(this CommandLineBuilder builder)
+    public static CommandLineBuilder CancelOnProcessTermination(this CommandLineBuilder builder, System.Nullable<System.TimeSpan> cancelationProcessingTimeout = null)
     public static CommandLineBuilder EnableDirectives(this CommandLineBuilder builder, System.Boolean value = True)
     public static CommandLineBuilder EnableLegacyDoubleDashBehavior(this CommandLineBuilder builder, System.Boolean value = True)
     public static CommandLineBuilder EnablePosixBundling(this CommandLineBuilder builder, System.Boolean value = True)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -240,7 +240,7 @@ System.CommandLine.Builder
   public static class CommandLineBuilderExtensions
     public static CommandLineBuilder AddMiddleware(this CommandLineBuilder builder, System.CommandLine.Invocation.InvocationMiddleware middleware, System.CommandLine.Invocation.MiddlewareOrder order = Default)
     public static CommandLineBuilder AddMiddleware(this CommandLineBuilder builder, System.Action<System.CommandLine.Invocation.InvocationContext> onInvoke, System.CommandLine.Invocation.MiddlewareOrder order = Default)
-    public static CommandLineBuilder CancelOnProcessTermination(this CommandLineBuilder builder, System.Nullable<System.TimeSpan> cancelationProcessingTimeout = null)
+    public static CommandLineBuilder CancelOnProcessTermination(this CommandLineBuilder builder, System.Nullable<System.TimeSpan> timeout = null)
     public static CommandLineBuilder EnableDirectives(this CommandLineBuilder builder, System.Boolean value = True)
     public static CommandLineBuilder EnableLegacyDoubleDashBehavior(this CommandLineBuilder builder, System.Boolean value = True)
     public static CommandLineBuilder EnablePosixBundling(this CommandLineBuilder builder, System.Boolean value = True)

--- a/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
@@ -211,13 +211,19 @@ namespace System.CommandLine.Tests.Invocation
                         await Task.Yield();
 
                         context.ExitCode = CancelledExitCode;
+
+                        // This is an example of bad pattern and reason why we need a timeout on termination processing
+                        await Task.Delay(TimeSpan.FromMilliseconds(1000));
+
+                        // Execution should newer get here as termination processing has a timeout of 100ms
+                        Environment.Exit(123);
                     }
 
                     // This is an example of bad pattern and reason why we need a timeout on termination processing
-                    await Task.Delay(TimeSpan.FromMilliseconds(2000));
+                    await Task.Delay(TimeSpan.FromMilliseconds(1000));
 
                     // Execution should newer get here as termination processing has a timeout of 100ms
-                    context.ExitCode = 123;
+                    Environment.Exit(123);
                 });
 
                 return new CommandLineBuilder(new RootCommand

--- a/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
@@ -98,7 +98,6 @@ namespace System.CommandLine.Tests.Invocation
         {
             const string ChildProcessWaiting = "Waiting for the command to be cancelled";
             const int CancelledExitCode = 42;
-            const int ForceTerminationCode = 130;
 
             Func<string[], Task<int>> childProgram = (string[] args) =>
             {

--- a/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
@@ -22,7 +22,7 @@ namespace System.CommandLine.Tests.Invocation
         [LinuxOnlyTheory]
         [InlineData(SIGINT/*, Skip = "https://github.com/dotnet/command-line-api/issues/1206"*/)]  // Console.CancelKeyPress
         [InlineData(SIGTERM)] // AppDomain.CurrentDomain.ProcessExit
-        public async Task CancelOnProcessTermination_cancels_on_process_termination(int signo)
+        public async Task CancelOnProcessTermination_provides_CancellationToken_that_signals_termination_when_no_timeout_is_specified(int signo)
         {
             const string ChildProcessWaiting = "Waiting for the command to be cancelled";
             const int CancelledExitCode = 42;
@@ -94,7 +94,7 @@ namespace System.CommandLine.Tests.Invocation
         [LinuxOnlyTheory]
         [InlineData(SIGINT)]
         [InlineData(SIGTERM)]
-        public async Task CancelOnProcessTermination_null_timeout_on_cancel_processing(int signo)
+        public async Task CancelOnProcessTermination_provides_CancellationToken_that_signals_termination_when_null_timeout_is_specified(int signo)
         {
             const string ChildProcessWaiting = "Waiting for the command to be cancelled";
             const int CancelledExitCode = 42;
@@ -173,7 +173,7 @@ namespace System.CommandLine.Tests.Invocation
         [LinuxOnlyTheory]
         [InlineData(SIGINT)]
         [InlineData(SIGTERM)]
-        public async Task CancelOnProcessTermination_timeout_on_cancel_processing(int signo)
+        public async Task CancelOnProcessTermination_provides_CancellationToken_that_signals_termination_and_execution_is_terminated_at_the_specified_timeout(int signo)
         {
             const string ChildProcessWaiting = "Waiting for the command to be cancelled";
             const int CancelledExitCode = 42;

--- a/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
@@ -92,12 +92,10 @@ namespace System.CommandLine.Tests.Invocation
         }
 
         [LinuxOnlyTheory]
-        [InlineData(null, SIGINT)]
-        [InlineData(null, SIGTERM)]
-        public async Task CancelOnProcessTermination_null_timeout_on_cancel_processing(int? timeOutMs, int signo)
+        [InlineData(SIGINT)]
+        [InlineData(SIGTERM)]
+        public async Task CancelOnProcessTermination_null_timeout_on_cancel_processing(int signo)
         {
-            TimeSpan? timeOut = timeOutMs.HasValue ? TimeSpan.FromMilliseconds(timeOutMs.Value) : null; 
-
             const string ChildProcessWaiting = "Waiting for the command to be cancelled";
             const int CancelledExitCode = 42;
             const int ForceTerminationCode = 130;
@@ -170,16 +168,14 @@ namespace System.CommandLine.Tests.Invocation
             processExited.Should().Be(true);
 
             // Verify the process exit code
-            process.ExitCode.Should().Be(timeOutMs.HasValue ? ForceTerminationCode : CancelledExitCode);
+            process.ExitCode.Should().Be(CancelledExitCode);
         }
 
         [LinuxOnlyTheory]
-        [InlineData(100, SIGINT)]
-        [InlineData(100, SIGTERM)]
-        public async Task CancelOnProcessTermination_timeout_on_cancel_processing(int? timeOutMs, int signo)
+        [InlineData(SIGINT)]
+        [InlineData(SIGTERM)]
+        public async Task CancelOnProcessTermination_timeout_on_cancel_processing(int signo)
         {
-            TimeSpan? timeOut = timeOutMs.HasValue ? TimeSpan.FromMilliseconds(timeOutMs.Value) : null;
-
             const string ChildProcessWaiting = "Waiting for the command to be cancelled";
             const int CancelledExitCode = 42;
             const int ForceTerminationCode = 130;
@@ -257,7 +253,7 @@ namespace System.CommandLine.Tests.Invocation
             processExited.Should().Be(true);
 
             // Verify the process exit code
-            process.ExitCode.Should().Be(timeOutMs.HasValue ? ForceTerminationCode : CancelledExitCode);
+            process.ExitCode.Should().Be(ForceTerminationCode);
         }
 
         [DllImport("libc", SetLastError = true)]

--- a/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
@@ -93,10 +93,8 @@ namespace System.CommandLine.Tests.Invocation
 
         [LinuxOnlyTheory]
         [InlineData(null, SIGINT)]
-        [InlineData(100, SIGINT, Skip = "Doesn't work under RemoteExecutor - process not terminated after Environment.Exit")]
         [InlineData(null, SIGTERM)]
-        [InlineData(100, SIGTERM, Skip = "Doesn't work under RemoteExecutor - process not terminated after ExitProcess event")]
-        public async Task CancelOnProcessTermination_timeout_on_cancel_processing(int? timeOutMs, int signo)
+        public async Task CancelOnProcessTermination_null_timeout_on_cancel_processing(int? timeOutMs, int signo)
         {
             TimeSpan? timeOut = timeOutMs.HasValue ? TimeSpan.FromMilliseconds(timeOutMs.Value) : null; 
 
@@ -124,22 +122,110 @@ namespace System.CommandLine.Tests.Invocation
                         // command is executed.
                         // We are currently blocking that event because CancellationTokenSource.Cancel
                         // is called from the event handler.
-                        // We'll do an async Task.Delay now. This means the Cancel call will return
+                        // We'll do an async Yield now. This means the Cancel call will return
                         // and we're no longer actively blocking the event.
                         // The event handler is responsible to continue blocking until the command
                         // has finished executing. If it doesn't we won't get the CancelledExitCode.
-                        await Task.Delay(TimeSpan.FromMilliseconds(2000));
+                        await Task.Yield();
 
-                        context.ExitCode = CancelledExitCode;
+                        // Exit code gets set here - but then execution continues and is let run till code voluntarily returns
+                        //  hence exit code gets overwritten below
+                        context.ExitCode = 123;
                     }
 
+                    // This is an example of bad pattern and reason why we need a timeout on termination processing
+                    await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+                    context.ExitCode = CancelledExitCode;
                 });
 
                 return new CommandLineBuilder(new RootCommand
                        {
                            command
                        })
-                       .CancelOnProcessTermination(/*timeOut*/TimeSpan.FromSeconds(100))
+                       // Unfortunately we cannot use test parameter here - RemoteExecutor currently doesn't capture the closure
+                       .CancelOnProcessTermination(null)
+                       .Build()
+                       .InvokeAsync("the-command");
+            };
+
+            using RemoteExecution program = RemoteExecutor.Execute(childProgram, psi: new ProcessStartInfo { RedirectStandardOutput = true });
+
+            Process process = program.Process;
+
+            // Wait for the child to be in the command handler.
+            string childState = await process.StandardOutput.ReadLineAsync();
+            childState.Should().Be(ChildProcessWaiting);
+
+            // Request termination
+            kill(process.Id, signo).Should().Be(0);
+
+            // Verify the process terminates timely
+            bool processExited = process.WaitForExit(10000);
+            if (!processExited)
+            {
+                process.Kill();
+                process.WaitForExit();
+            }
+            processExited.Should().Be(true);
+
+            // Verify the process exit code
+            process.ExitCode.Should().Be(timeOutMs.HasValue ? ForceTerminationCode : CancelledExitCode);
+        }
+
+        [LinuxOnlyTheory]
+        [InlineData(100, SIGINT)]
+        [InlineData(100, SIGTERM)]
+        public async Task CancelOnProcessTermination_timeout_on_cancel_processing(int? timeOutMs, int signo)
+        {
+            TimeSpan? timeOut = timeOutMs.HasValue ? TimeSpan.FromMilliseconds(timeOutMs.Value) : null;
+
+            const string ChildProcessWaiting = "Waiting for the command to be cancelled";
+            const int CancelledExitCode = 42;
+            const int ForceTerminationCode = 130;
+
+            Func<string[], Task<int>> childProgram = (string[] args) =>
+            {
+                var command = new Command("the-command");
+
+                command.SetHandler(async context =>
+                {
+                    var cancellationToken = context.GetCancellationToken();
+
+                    try
+                    {
+                        context.Console.WriteLine(ChildProcessWaiting);
+                        await Task.Delay(int.MaxValue, cancellationToken);
+                        context.ExitCode = 1;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // For Process.Exit handling the event must remain blocked as long as the
+                        // command is executed.
+                        // We are currently blocking that event because CancellationTokenSource.Cancel
+                        // is called from the event handler.
+                        // We'll do an async Yield now. This means the Cancel call will return
+                        // and we're no longer actively blocking the event.
+                        // The event handler is responsible to continue blocking until the command
+                        // has finished executing. If it doesn't we won't get the CancelledExitCode.
+                        await Task.Yield();
+
+                        context.ExitCode = CancelledExitCode;
+                    }
+
+                    // This is an example of bad pattern and reason why we need a timeout on termination processing
+                    await Task.Delay(TimeSpan.FromMilliseconds(2000));
+
+                    // Execution should newer get here as termination processing has a timeout of 100ms
+                    context.ExitCode = 123;
+                });
+
+                return new CommandLineBuilder(new RootCommand
+                       {
+                           command
+                       })
+                        // Unfortunately we cannot use test parameter here - RemoteExecutor currently doesn't capture the closure
+                       .CancelOnProcessTermination(TimeSpan.FromMilliseconds(100))
                        .Build()
                        .InvokeAsync("the-command");
             };


### PR DESCRIPTION
**Background:**

related to https://github.com/dotnet/templating/issues/4799

It would be helpfull to be able to specify optional maximum timeout for handling the process termination - in order to prevent unwanted 'unkillable' command - especially for cases where command builder and and actual implementation of the command have different maintainers (e.g. a case of dotnet sdk).

The process that don't repond to Ctrl-C can still be killed by other means - but it may create unpleasant and inconsistent experience to users. The idea is to have top level handler that gives command chance to perform cleanup in correct way, but bail out if they do not return in timely manner (e.g. due to not using the cancellation patter at all).

If the optinal timeout is not specified, the original behavior remains (no timeout enforced).

