### PR TITLE
Rename members to GetValue

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -241,10 +241,10 @@ System.CommandLine
     public System.CommandLine.Parsing.SymbolResult FindResultFor(Symbol symbol)
     public System.CommandLine.Completions.CompletionContext GetCompletionContext()
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.Nullable<System.Int32> position = null)
-    public System.Object GetValueForArgument(Argument argument)
-    public T GetValueForArgument<T>(Argument<T> argument)
-    public System.Object GetValueForOption(Option option)
-    public T GetValueForOption<T>(Option<T> option)
+    public System.Object GetValue(Option option)
+    public System.Object GetValue(Argument argument)
+    public T GetValue<T>(Argument<T> argument)
+    public T GetValue<T>(Option<T> option)
     public System.String ToString()
   public class RootCommand : Command, System.Collections.Generic.IEnumerable<Symbol>, System.Collections.IEnumerable, System.CommandLine.Completions.ICompletionSource
     public static System.String ExecutableName { get; }
@@ -366,6 +366,10 @@ System.CommandLine.Invocation
     public System.CommandLine.Parsing.Parser Parser { get; }
     public System.CommandLine.ParseResult ParseResult { get; set; }
     public System.Threading.CancellationToken GetCancellationToken()
+    public System.Object GetValue(System.CommandLine.Option option)
+    public T GetValue<T>(Option<T> option)
+    public System.Object GetValue(System.CommandLine.Argument argument)
+    public T GetValue<T>(Argument<T> argument)
     public System.Void LinkToken(System.Threading.CancellationToken token)
   public delegate InvocationMiddleware : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
     .ctor(System.Object object, System.IntPtr method)
@@ -466,10 +470,10 @@ System.CommandLine.Parsing
     public ArgumentResult FindResultFor(System.CommandLine.Argument argument)
     public CommandResult FindResultFor(System.CommandLine.Command command)
     public OptionResult FindResultFor(System.CommandLine.Option option)
-    public T GetValueForArgument<T>(Argument<T> argument)
-    public System.Object GetValueForArgument(System.CommandLine.Argument argument)
-    public T GetValueForOption<T>(Option<T> option)
-    public System.Object GetValueForOption(System.CommandLine.Option option)
+    public T GetValue<T>(Argument<T> argument)
+    public System.Object GetValue(System.CommandLine.Argument argument)
+    public T GetValue<T>(Option<T> option)
+    public System.Object GetValue(System.CommandLine.Option option)
     public System.String ToString()
   public class Token, System.IEquatable<Token>
     public static System.Boolean op_Equality(Token left, Token right)

--- a/src/System.CommandLine.Generator/Parameters/ArgumentParameter.cs
+++ b/src/System.CommandLine.Generator/Parameters/ArgumentParameter.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Generator.Parameters
         }
 
         public override string GetValueFromContext()
-            => $"context.ParseResult.GetValueForArgument({LocalName})";
+            => $"context.ParseResult.GetValue({LocalName})";
 
         public override int GetHashCode() 
             => base.GetHashCode();

--- a/src/System.CommandLine.Generator/Parameters/OptionParameter.cs
+++ b/src/System.CommandLine.Generator/Parameters/OptionParameter.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Generator.Parameters
         }
 
         public override string GetValueFromContext()
-            => $"context.ParseResult.GetValueForOption({LocalName})";
+            => $"context.ParseResult.GetValue({LocalName})";
 
         public override int GetHashCode()
             => base.GetHashCode();

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ModelBinderTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ModelBinderTests.cs
@@ -774,6 +774,70 @@ public class ModelBinderTests
         boundOptions.BundleId.Should().Be("value");
     }
 
+    [Fact]
+    public void InvocationContext_GetValue_with_generic_option_returns_value()
+    {
+        Option<int> option = new("--number");
+        Command command = new("the-command")
+        {
+            option
+        };
+
+        InvocationContext invocationContext = new(command.Parse("the-command --number 42"));
+
+        invocationContext.GetValue(option)
+            .Should()
+            .Be(42);
+    }
+
+    [Fact]
+    public void InvocationContext_GetValue_with_non_generic_option_returns_value()
+    {
+        Option option = new Option<int>("--number");
+        Command command = new("the-command")
+        {
+            option
+        };
+
+        InvocationContext invocationContext = new(command.Parse("the-command --number 42"));
+
+        invocationContext.GetValue(option)
+            .Should()
+            .Be(42);
+    }
+
+    [Fact]
+    public void InvocationContext_GetValue_with_generic_argument_returns_value()
+    {
+        Argument<int> option = new();
+        Command command = new("the-command")
+        {
+            option
+        };
+
+        InvocationContext invocationContext = new(command.Parse("the-command 42"));
+
+        invocationContext.GetValue(option)
+            .Should()
+            .Be(42);
+    }
+
+    [Fact]
+    public void InvocationContext_GetValue_with_non_generic_argument_returns_value()
+    {
+        Argument option = new Argument<int>();
+        Command command = new("the-command")
+        {
+            option
+        };
+
+        InvocationContext invocationContext = new(command.Parse("the-command 42"));
+
+        invocationContext.GetValue(option)
+            .Should()
+            .Be(42);
+    }
+
     class DeployOptions
     {
         public string Bundle { get; set; }

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ParameterBindingTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ParameterBindingTests.cs
@@ -233,7 +233,7 @@ public class ParameterBindingTests
 
         await command.InvokeAsync("command -x 123", _console);
 
-        boundParseResult.GetValueForOption(option).Should().Be(123);
+        boundParseResult.GetValue(option).Should().Be(123);
     }
 
     [Fact]
@@ -250,7 +250,7 @@ public class ParameterBindingTests
 
         await command.InvokeAsync("command -x 123", _console);
 
-        boundContext.ParseResult.GetValueForOption(option).Should().Be(123);
+        boundContext.ParseResult.GetValue(option).Should().Be(123);
     }
 
     [Fact]
@@ -282,7 +282,7 @@ public class ParameterBindingTests
 
         await command.InvokeAsync("command -x 123", _console);
 
-        boundContext.ParseResult.GetValueForOption(option).Should().Be(123);
+        boundContext.ParseResult.GetValue(option).Should().Be(123);
     }
 
     private class ExecuteTestClass

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -33,7 +33,7 @@ namespace System.CommandLine.Suggest
             };
             CompleteScriptCommand.SetHandler(context =>
             {
-                SuggestionShellScriptHandler.Handle(context.Console, context.ParseResult.GetValueForArgument(shellTypeArgument));
+                SuggestionShellScriptHandler.Handle(context.Console, context.ParseResult.GetValue(shellTypeArgument));
             });
 
             ListCommand = new Command("list")
@@ -63,7 +63,7 @@ namespace System.CommandLine.Suggest
 
             RegisterCommand.SetHandler(context =>
             {
-                Register(context.ParseResult.GetValueForOption(commandPathOption), context.Console);
+                Register(context.ParseResult.GetValue(commandPathOption), context.Console);
                 return Task.FromResult(0);
             });
 
@@ -130,7 +130,7 @@ namespace System.CommandLine.Suggest
         private Task<int> Get(InvocationContext context)
         {
             var parseResult = context.ParseResult;
-            var commandPath = parseResult.GetValueForOption(ExecutableOption);
+            var commandPath = parseResult.GetValue(ExecutableOption);
 
             Registration suggestionRegistration;
             if (commandPath.FullName == DotnetMuxer.Path.FullName)
@@ -142,7 +142,7 @@ namespace System.CommandLine.Suggest
                 suggestionRegistration = _suggestionRegistration.FindRegistration(commandPath);
             }
 
-            var position = parseResult.GetValueForOption(PositionOption);
+            var position = parseResult.GetValue(PositionOption);
 
             if (suggestionRegistration is null)
             {

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -183,7 +183,7 @@ namespace System.CommandLine.Tests
                 var argument = new Argument<int>(result => int.Parse(result.Tokens.Single().Value));
 
                 argument.Parse("123")
-                        .GetValueForArgument(argument)
+                        .GetValue(argument)
                         .Should()
                         .Be(123);
             }
@@ -194,7 +194,7 @@ namespace System.CommandLine.Tests
                 var argument = new Argument<IEnumerable<int>>(result => result.Tokens.Single().Value.Split(',').Select(int.Parse));
 
                 argument.Parse("1,2,3")
-                        .GetValueForArgument(argument)
+                        .GetValue(argument)
                         .Should()
                         .BeEquivalentTo(new[] { 1, 2, 3 });
             }
@@ -208,7 +208,7 @@ namespace System.CommandLine.Tests
                 });
 
                 argument.Parse("1 2 3")
-                        .GetValueForArgument(argument)
+                        .GetValue(argument)
                         .Should()
                         .BeEquivalentTo(new[] { 1, 2, 3 });
             }
@@ -222,7 +222,7 @@ namespace System.CommandLine.Tests
                 };
 
                 argument.Parse("1 2 3")
-                        .GetValueForArgument(argument)
+                        .GetValue(argument)
                         .Should()
                         .Be(6);
             }
@@ -367,7 +367,7 @@ namespace System.CommandLine.Tests
 
                 var result = argument.Parse("");
 
-                result.GetValueForArgument(argument)
+                result.GetValue(argument)
                       .Should()
                       .Be(123);
             }
@@ -449,7 +449,7 @@ namespace System.CommandLine.Tests
                 var result = command.Parse("the-command -o not-an-int");
 
                 Action getValue = () => 
-                    result.GetValueForOption(option);
+                    result.GetValue(option);
 
                 getValue.Should()
                         .Throw<InvalidOperationException>()
@@ -511,7 +511,7 @@ namespace System.CommandLine.Tests
                     opt
                 };
 
-                rootCommand.Parse(commandLine).GetValueForOption(opt).Should().Be(expectedValue);
+                rootCommand.Parse(commandLine).GetValue(opt).Should().Be(expectedValue);
             }
 
             [Theory]
@@ -691,9 +691,9 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2 3");
 
-                result.GetValueForArgument(argument1).Should().BeEmpty();
+                result.GetValue(argument1).Should().BeEmpty();
 
-                result.GetValueForArgument(argument2).Should().BeEquivalentSequenceTo(1, 2, 3);
+                result.GetValue(argument2).Should().BeEquivalentSequenceTo(1, 2, 3);
             }
 
             [Fact] // https://github.com/dotnet/command-line-api/issues/1759 
@@ -714,9 +714,9 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2 3");
 
-                result.GetValueForArgument(scalar).Should().BeNull();
+                result.GetValue(scalar).Should().BeNull();
 
-                result.GetValueForArgument(multiple).Should().BeEquivalentSequenceTo(1, 2, 3);
+                result.GetValue(multiple).Should().BeEquivalentSequenceTo(1, 2, 3);
             }
 
 
@@ -759,9 +759,9 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2 3");
 
-                result.GetValueForArgument(first).Should().BeNull();
-                result.GetValueForArgument(second).Should().BeEmpty();
-                result.GetValueForArgument(third).Should().BeEquivalentSequenceTo("1", "2", "3");
+                result.GetValue(first).Should().BeNull();
+                result.GetValue(second).Should().BeEmpty();
+                result.GetValue(third).Should().BeEquivalentSequenceTo("1", "2", "3");
             }
         }
 

--- a/src/System.CommandLine.Tests/Binding/SetHandlerTests.cs
+++ b/src/System.CommandLine.Tests/Binding/SetHandlerTests.cs
@@ -63,8 +63,8 @@ namespace System.CommandLine.Tests.Binding
                 return new CustomType
                 {
                     Console = bindingContext.Console,
-                    IntValue = bindingContext.ParseResult.GetValueForOption(_intOption),
-                    StringValue = bindingContext.ParseResult.GetValueForArgument(_stringArg),
+                    IntValue = bindingContext.ParseResult.GetValue(_intOption),
+                    StringValue = bindingContext.ParseResult.GetValue(_stringArg),
                 };
             }
         }

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -22,7 +22,7 @@ namespace System.CommandLine.Tests.Binding
             var file = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "the-file.txt"));
             var result = option.Parse($"--file {file.FullName}");
 
-            result.GetValueForOption(option)
+            result.GetValue(option)
                   .Name
                   .Should()
                   .Be("the-file.txt");
@@ -41,7 +41,7 @@ namespace System.CommandLine.Tests.Binding
             var file = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "the-file.txt"));
             var result = command.Parse($"{file.FullName}");
 
-            result.GetValueForArgument(argument)
+            result.GetValue(argument)
                   .Name
                   .Should()
                   .Be("the-file.txt");
@@ -61,7 +61,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("");
 
-            result.GetValueForArgument(argument)
+            result.GetValue(argument)
                   .Should()
                   .BeNull();
         }
@@ -90,7 +90,7 @@ namespace System.CommandLine.Tests.Binding
             var file2 = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "file2.txt"));
             var result = option.Parse($"--file {file1.FullName} --file {file2.FullName}");
 
-            result.GetValueForOption(option)
+            result.GetValue(option)
                   .Select(fi => fi.Name)
                   .Should()
                   .BeEquivalentTo("file1.txt", "file2.txt");
@@ -146,7 +146,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.GetValueForOption(option).Should().Be(123);
+            result.GetValue(option).Should().Be(123);
         }
 
         [Fact]
@@ -161,7 +161,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something -x 456");
 
-            result.GetValueForOption(option).Should().Be(456);
+            result.GetValue(option).Should().Be(456);
         }
 
         [Theory]
@@ -180,7 +180,7 @@ namespace System.CommandLine.Tests.Binding
 
             command
                 .Parse(commandLine)
-                .GetValueForOption(option)
+                .GetValue(option)
                 .Should()
                 .BeTrue();
         }
@@ -201,7 +201,7 @@ namespace System.CommandLine.Tests.Binding
 
             command
                 .Parse(commandLine)
-                .GetValueForOption(option)
+                .GetValue(option)
                 .Should()
                 .BeTrue();
         }
@@ -221,7 +221,7 @@ namespace System.CommandLine.Tests.Binding
 
             command
                 .Parse(commandLine)
-                .GetValueForOption(option)
+                .GetValue(option)
                 .Should()
                 .BeFalse();
         }
@@ -233,7 +233,7 @@ namespace System.CommandLine.Tests.Binding
 
             option
                 .Parse("")
-                .GetValueForOption(option)
+                .GetValue(option)
                 .Should()
                 .Be(null);
         }
@@ -250,7 +250,7 @@ namespace System.CommandLine.Tests.Binding
 
             var parseResult = cmd.Parse("-b");
 
-            parseResult.GetValueForOption((Option)option).Should().Be(true);
+            parseResult.GetValue((Option)option).Should().Be(true);
         }
 
         [Fact]
@@ -265,7 +265,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("the-command -x");
 
-            Action getValue = () => result.GetValueForOption(option);
+            Action getValue = () => result.GetValue(option);
 
             getValue.Should()
                     .Throw<InvalidOperationException>()
@@ -294,7 +294,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse(commandLine);
 
-            result.GetValueForArgument(argument)
+            result.GetValue(argument)
                   .Should()
                   .BeEquivalentTo(new[] { "c", "c", "c" });
         }
@@ -312,7 +312,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("-x");
 
-            result.GetValueForOption(option)
+            result.GetValue(option)
                   .Should()
                   .Be(true);
         }
@@ -329,7 +329,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.GetValueForOption(option)
+            result.GetValue(option)
                   .Should()
                   .Be(false);
         }
@@ -346,7 +346,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.GetValueForOption(option)
+            result.GetValue(option)
                   .Should()
                   .Be("123");
         }
@@ -363,7 +363,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.GetValueForOption(option)
+            result.GetValue(option)
                   .Should()
                   .Be(null);
         }
@@ -379,7 +379,7 @@ namespace System.CommandLine.Tests.Binding
             };
 
             command.Parse("something")
-                   .GetValueForOption(option)
+                   .GetValue(option)
                    .Should()
                    .Be(123);
         }
@@ -398,7 +398,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something");
 
-            result.GetValueForOption(option).Should().Be(directoryInfo);
+            result.GetValue(option).Should().Be(directoryInfo);
         }
 
         [Fact]
@@ -417,7 +417,7 @@ namespace System.CommandLine.Tests.Binding
 
             result.Errors.Should().BeEmpty();
 
-            var value = result.GetValueForArgument(argument);
+            var value = result.GetValue(argument);
 
             value.Should().Be(directoryInfo);
         }
@@ -434,7 +434,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = command.Parse("something -x 456");
 
-            var value = result.GetValueForOption(option);
+            var value = result.GetValue(option);
 
             value.Should().Be(456);
         }
@@ -446,7 +446,7 @@ namespace System.CommandLine.Tests.Binding
             var option = new Option<DateTime>("-x");
 
             var dateString = "2022-02-06T01:46:03.0000000-08:00";
-            var value = option.Parse($"-x {dateString}").GetValueForOption(option);
+            var value = option.Parse($"-x {dateString}").GetValue(option);
 
             value.Should().Be(DateTime.Parse(dateString));
         }
@@ -458,7 +458,7 @@ namespace System.CommandLine.Tests.Binding
             var option = new Option<DateTime?>("-x");
 
             var dateString = "2022-02-06T01:46:03.0000000-08:00";
-            var value = option.Parse($"-x {dateString}").GetValueForOption(option);
+            var value = option.Parse($"-x {dateString}").GetValue(option);
 
             value.Should().Be(DateTime.Parse(dateString));
         }
@@ -469,7 +469,7 @@ namespace System.CommandLine.Tests.Binding
             var option = new Option<DateTimeOffset>("-x");
 
             var dateString = "2022-02-06T09:52:54.5275055-08:00";
-            var value = option.Parse($"-x {dateString}").GetValueForOption(option);
+            var value = option.Parse($"-x {dateString}").GetValue(option);
 
             value.Should().Be(DateTime.Parse(dateString));
         }
@@ -480,7 +480,7 @@ namespace System.CommandLine.Tests.Binding
             var option = new Option<DateTimeOffset?>("-x");
 
             var dateString = "2022-02-06T09:52:54.5275055-08:00";
-            var value = option.Parse($"-x {dateString}").GetValueForOption(option);
+            var value = option.Parse($"-x {dateString}").GetValue(option);
 
             value.Should().Be(DateTime.Parse(dateString));
         }
@@ -492,7 +492,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = option.Parse("-x 123.456");
 
-            var value = result.GetValueForOption(option);
+            var value = result.GetValue(option);
 
             value.Should().Be(123.456m);
         }
@@ -502,7 +502,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<decimal?>("-x");
 
-            var value = option.Parse("-x 123.456").GetValueForOption(option);
+            var value = option.Parse("-x 123.456").GetValue(option);
 
             value.Should().Be(123.456m);
         }
@@ -512,7 +512,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<double>("-x");
 
-            var value = option.Parse("-x 123.456").GetValueForOption(option);
+            var value = option.Parse("-x 123.456").GetValue(option);
 
             value.Should().Be(123.456d);
         }
@@ -522,7 +522,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<double?>("-x");
 
-            var value = option.Parse("-x 123.456").GetValueForOption(option);
+            var value = option.Parse("-x 123.456").GetValue(option);
 
             value.Should().Be(123.456d);
         }
@@ -532,7 +532,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<float>("-x");
 
-            var value = option.Parse("-x 123.456").GetValueForOption(option);
+            var value = option.Parse("-x 123.456").GetValue(option);
 
             value.Should().Be(123.456f);
         }
@@ -542,7 +542,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<float?>("-x");
 
-            var value = option.Parse("-x 123.456").GetValueForOption(option);
+            var value = option.Parse("-x 123.456").GetValue(option);
 
             value.Should().Be(123.456f);
         }
@@ -553,7 +553,7 @@ namespace System.CommandLine.Tests.Binding
             var guidString = "75517282-018F-46BB-B15F-1D8DBFE23F6E";
             var option = new Option<Guid>("-x");
 
-            var value = option.Parse($"-x {guidString}").GetValueForOption(option);
+            var value = option.Parse($"-x {guidString}").GetValue(option);
 
             value.Should().Be(Guid.Parse(guidString));
         }
@@ -564,7 +564,7 @@ namespace System.CommandLine.Tests.Binding
             var guidString = "75517282-018F-46BB-B15F-1D8DBFE23F6E";
             var option = new Option<Guid?>("-x");
 
-            var value = option.Parse($"-x {guidString}").GetValueForOption(option);
+            var value = option.Parse($"-x {guidString}").GetValue(option);
 
             value.Should().Be(Guid.Parse(guidString));
         }
@@ -575,7 +575,7 @@ namespace System.CommandLine.Tests.Binding
             var timeSpanString = "30";
             var option = new Option<TimeSpan>("-x");
 
-            var value = option.Parse($"-x {timeSpanString}").GetValueForOption(option);
+            var value = option.Parse($"-x {timeSpanString}").GetValue(option);
 
             value.Should().Be(TimeSpan.Parse(timeSpanString));
         }
@@ -586,7 +586,7 @@ namespace System.CommandLine.Tests.Binding
             var timeSpanString = "30";
             var option = new Option<TimeSpan?>("-x");
 
-            var value = option.Parse($"-x {timeSpanString}").GetValueForOption(option);
+            var value = option.Parse($"-x {timeSpanString}").GetValue(option);
 
             value.Should().Be(TimeSpan.Parse(timeSpanString));
         }
@@ -596,7 +596,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<Uri>("-x");
 
-            var value = option.Parse("-x http://example.com").GetValueForOption(option);
+            var value = option.Parse("-x http://example.com").GetValue(option);
 
             value.Should().BeEquivalentTo(new Uri("http://example.com"));
         }
@@ -606,8 +606,8 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<bool>("-x");
 
-            option.Parse("-x false").GetValueForOption(option).Should().BeFalse();
-            option.Parse("-x true").GetValueForOption(option).Should().BeTrue();
+            option.Parse("-x false").GetValue(option).Should().BeFalse();
+            option.Parse("-x true").GetValue(option).Should().BeTrue();
         }
 
         [Fact]
@@ -615,7 +615,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<long>("-x");
 
-            var value = option.Parse("-x 123456790").GetValueForOption(option);
+            var value = option.Parse("-x 123456790").GetValue(option);
 
             value.Should().Be(123456790L);
         }
@@ -625,7 +625,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<long?>("-x");
 
-            var value = option.Parse("-x 1234567890").GetValueForOption(option);
+            var value = option.Parse("-x 1234567890").GetValue(option);
 
             value.Should().Be(1234567890L);
         }
@@ -635,7 +635,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<short>("-s");
 
-            var value = option.Parse("-s 1234").GetValueForOption(option);
+            var value = option.Parse("-s 1234").GetValue(option);
 
             value.Should().Be(1234);
         }
@@ -645,7 +645,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<short?>("-s");
 
-            var value = option.Parse("-s 1234").GetValueForOption(option);
+            var value = option.Parse("-s 1234").GetValue(option);
 
             value.Should().Be(1234);
         }
@@ -655,7 +655,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<ulong>("-x");
 
-            var value = option.Parse("-x 1234").GetValueForOption(option);
+            var value = option.Parse("-x 1234").GetValue(option);
 
             value.Should().Be(1234);
         }
@@ -665,7 +665,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<ulong?>("-x");
 
-            var value = option.Parse("-x 1234").GetValueForOption(option);
+            var value = option.Parse("-x 1234").GetValue(option);
 
             value.Should().Be(1234);
         }
@@ -675,7 +675,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<ushort>("-x");
 
-            var value = option.Parse("-x 1234").GetValueForOption(option);
+            var value = option.Parse("-x 1234").GetValue(option);
 
             value.Should().Be(1234);
         }
@@ -685,7 +685,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<ushort?>("-x");
 
-            var value = option.Parse("-x 1234").GetValueForOption(option);
+            var value = option.Parse("-x 1234").GetValue(option);
 
             value.Should().Be(1234);
         }
@@ -695,7 +695,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<sbyte>("-us");
 
-            var value = option.Parse("-us 123").GetValueForOption(option);
+            var value = option.Parse("-us 123").GetValue(option);
 
             value.Should().Be(123);
         }
@@ -705,7 +705,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<sbyte?>("-x");
 
-            var value = option.Parse("-x 123").GetValueForOption(option);
+            var value = option.Parse("-x 123").GetValue(option);
 
             value.Should().Be(123);
         }
@@ -715,7 +715,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<IPAddress>("-us");
 
-            var value = option.Parse("-us 1.2.3.4").GetValueForOption(option);
+            var value = option.Parse("-us 1.2.3.4").GetValue(option);
 
             value.Should().Be(IPAddress.Parse("1.2.3.4"));
         }
@@ -726,7 +726,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<IPEndPoint>("-us");
 
-            var value = option.Parse("-us 1.2.3.4:56").GetValueForOption(option);
+            var value = option.Parse("-us 1.2.3.4:56").GetValue(option);
 
             value.Should().Be(IPEndPoint.Parse("1.2.3.4:56"));
         }
@@ -738,7 +738,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<DateOnly>("-us");
 
-            var value = option.Parse("-us 2022-03-02").GetValueForOption(option);
+            var value = option.Parse("-us 2022-03-02").GetValue(option);
 
             value.Should().Be(DateOnly.Parse("2022-03-02"));
         }
@@ -748,7 +748,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<DateOnly?>("-x");
 
-            var value = option.Parse("-x 2022-03-02").GetValueForOption(option);
+            var value = option.Parse("-x 2022-03-02").GetValue(option);
 
             value.Should().Be(DateOnly.Parse("2022-03-02"));
         }
@@ -758,7 +758,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<TimeOnly>("-us");
 
-            var value = option.Parse("-us 12:34:56").GetValueForOption(option);
+            var value = option.Parse("-us 12:34:56").GetValue(option);
 
             value.Should().Be(TimeOnly.Parse("12:34:56"));
         }
@@ -768,7 +768,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<TimeOnly?>("-x");
 
-            var value = option.Parse("-x 12:34:56").GetValueForOption(option);
+            var value = option.Parse("-x 12:34:56").GetValue(option);
 
             value.Should().Be(TimeOnly.Parse("12:34:56"));
         }
@@ -779,7 +779,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<byte>("-us");
 
-            var value = option.Parse("-us 123").GetValueForOption(option);
+            var value = option.Parse("-us 123").GetValue(option);
 
             value.Should().Be(123);
         }
@@ -789,7 +789,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<byte?>("-x");
 
-            var value = option.Parse("-x 123").GetValueForOption(option);
+            var value = option.Parse("-x 123").GetValue(option);
 
             value.Should().Be(123);
         }
@@ -799,7 +799,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<uint>("-us");
 
-            var value = option.Parse("-us 1234").GetValueForOption(option);
+            var value = option.Parse("-us 1234").GetValue(option);
 
             value.Should().Be(1234);
         }
@@ -809,7 +809,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<uint?>("-x");
 
-            var value = option.Parse("-x 1234").GetValueForOption(option);
+            var value = option.Parse("-x 1234").GetValue(option);
 
             value.Should().Be(1234);
         }
@@ -819,7 +819,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<int[]>("-x");
 
-            var value = option.Parse("-x 1 -x 2 -x 3").GetValueForOption(option);
+            var value = option.Parse("-x 1 -x 2 -x 3").GetValue(option);
 
             value.Should().BeEquivalentTo(1, 2, 3);
         }
@@ -870,7 +870,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<List<int>>("-x");
 
-            var value = option.Parse("-x 1 -x 2 -x 3").GetValueForOption(option);
+            var value = option.Parse("-x 1 -x 2 -x 3").GetValue(option);
 
             value.Should().BeEquivalentTo(1, 2, 3);
         }
@@ -880,7 +880,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var option = new Option<IEnumerable<int>>("-x");
 
-            var value = option.Parse("-x 1 -x 2 -x 3").GetValueForOption(option);
+            var value = option.Parse("-x 1 -x 2 -x 3").GetValue(option);
 
             value.Should().BeEquivalentTo(1, 2, 3);
         }
@@ -892,7 +892,7 @@ namespace System.CommandLine.Tests.Binding
 
             var parseResult = option.Parse("-x Monday");
 
-            var value = parseResult.GetValueForOption(option);
+            var value = parseResult.GetValue(option);
 
             value.Should().Be(DayOfWeek.Monday);
         }
@@ -904,7 +904,7 @@ namespace System.CommandLine.Tests.Binding
 
             var parseResult = option.Parse("-x Monday");
 
-            var value = parseResult.GetValueForOption(option);
+            var value = parseResult.GetValue(option);
 
             value.Should().Be(DayOfWeek.Monday);
         }
@@ -932,7 +932,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = option.Parse("-x not-an-int");
 
-            Action getValue = () => result.GetValueForOption(option);
+            Action getValue = () => result.GetValue(option);
 
             getValue.Should()
                     .Throw<InvalidOperationException>()
@@ -949,7 +949,7 @@ namespace System.CommandLine.Tests.Binding
 
             var result = option.Parse("-x not-an-int -x 2");
 
-            Action getValue = () => result.GetValueForOption(option);
+            Action getValue = () => result.GetValue(option);
 
             getValue.Should()
                     .Throw<InvalidOperationException>()
@@ -969,7 +969,7 @@ namespace System.CommandLine.Tests.Binding
             };
 
             var result = command.Parse("mycommand");
-            result.GetValueForArgument(argument)
+            result.GetValue(argument)
                   .Should()
                   .BeNull();
         }
@@ -1004,7 +1004,7 @@ namespace System.CommandLine.Tests.Binding
         {
             var result = argument.Parse("");
 
-            result.GetValueForArgument(argument)
+            result.GetValue(argument)
                   .Should()
                   .BeEmpty();
         }

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -218,7 +218,7 @@ namespace System.CommandLine.Tests
                     new Option<string>("--clone")
                         .AddCompletions(ctx =>
                         {
-                            var opt1Value = ctx.ParseResult.GetValueForOption(originOption);
+                            var opt1Value = ctx.ParseResult.GetValue(originOption);
                             return !string.IsNullOrWhiteSpace(opt1Value) ? new[] { opt1Value } : Array.Empty<string>();
                         })
                 });

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -92,9 +92,9 @@ namespace System.CommandLine.Tests
 
             root.AddCommand(child);
 
-            root.Parse("child --global 123").GetValueForOption(option).Should().Be(123);
+            root.Parse("child --global 123").GetValue(option).Should().Be(123);
 
-            child.Parse("--global 123").GetValueForOption(option).Should().Be(123);
+            child.Parse("--global 123").GetValue(option).Should().Be(123);
         }
 
         [Fact]
@@ -114,11 +114,11 @@ namespace System.CommandLine.Tests
             
             firstChild.AddCommand(secondChild);
             
-            root.Parse("first second --global 123").GetValueForOption(option).Should().Be(123);
+            root.Parse("first second --global 123").GetValue(option).Should().Be(123);
             
-            firstChild.Parse("second --global 123").GetValueForOption(option).Should().Be(123);
+            firstChild.Parse("second --global 123").GetValue(option).Should().Be(123);
             
-            secondChild.Parse("--global 123").GetValueForOption(option).Should().Be(123);
+            secondChild.Parse("--global 123").GetValue(option).Should().Be(123);
         }
     }
 }

--- a/src/System.CommandLine.Tests/OptionTests.MultipleArgumentsPerToken.cs
+++ b/src/System.CommandLine.Tests/OptionTests.MultipleArgumentsPerToken.cs
@@ -114,7 +114,7 @@ namespace System.CommandLine.Tests
 
                     var result = command.Parse(commandLine);
 
-                    var value = result.GetValueForOption(option);
+                    var value = result.GetValue(option);
 
                     value.Should().Be("2");
                 }
@@ -162,8 +162,8 @@ namespace System.CommandLine.Tests
                     _output.WriteLine(result.Diagram());
 
                     result.Errors.Should().BeEmpty();
-                    result.GetValueForOption(optionY).Should().Be("-x");
-                    result.GetValueForOption(optionX).Should().Be("-y");
+                    result.GetValue(optionY).Should().Be("-x");
+                    result.GetValue(optionX).Should().Be("-y");
                 }
             }
 
@@ -177,7 +177,7 @@ namespace System.CommandLine.Tests
 
                     var result = command.Parse("--option 1 2");
 
-                    var value = result.GetValueForOption(option);
+                    var value = result.GetValue(option);
 
                     value.Should().BeEquivalentTo(new[] { "1" });
                 }
@@ -202,7 +202,7 @@ namespace System.CommandLine.Tests
 
                     var result = command.Parse("--option 1 --option 2");
 
-                    var value = result.GetValueForOption(option);
+                    var value = result.GetValue(option);
 
                     value.Should().BeEquivalentTo(new[] { "1", "2" });
                     result.Errors.Should().BeEmpty();

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -218,9 +218,9 @@ namespace System.CommandLine.Tests
 
             var result = rootCommand.Parse(prefix + "c value-for-c " + prefix + "a value-for-a");
 
-            result.GetValueForOption(optionA).Should().Be("value-for-a");
+            result.GetValue(optionA).Should().Be("value-for-a");
             result.HasOption(optionB).Should().BeFalse();
-            result.GetValueForOption(optionC).Should().Be("value-for-c");
+            result.GetValue(optionC).Should().Be("value-for-c");
         }
 
         [Fact]
@@ -326,7 +326,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.GetValueForOption(option)
+            result.GetValue(option)
                 .Should()
                 .BeNull();
         }
@@ -353,7 +353,7 @@ namespace System.CommandLine.Tests
 
             var parseResult = option.Parse(parseInput);
 
-            parseResult.GetValueForOption(option).Should().Be("value");
+            parseResult.GetValue(option).Should().Be("value");
         }
 
         [Fact]
@@ -366,7 +366,7 @@ namespace System.CommandLine.Tests
             result.HasOption(option)
                 .Should()
                 .BeFalse();
-            result.GetValueForOption(option)
+            result.GetValue(option)
                 .Should()
                 .BeFalse();
         }

--- a/src/System.CommandLine.Tests/ParserTests.DoubleDash.cs
+++ b/src/System.CommandLine.Tests/ParserTests.DoubleDash.cs
@@ -29,9 +29,9 @@ namespace System.CommandLine.Tests
 
                 result.HasOption(option).Should().BeTrue();
 
-                result.GetValueForOption(option).Should().BeEquivalentTo("some stuff");
+                result.GetValue(option).Should().BeEquivalentTo("some stuff");
 
-                result.GetValueForArgument(argument).Should().BeEquivalentSequenceTo("-o", "--one", "-x", "-y", "-z", "-o:foo");
+                result.GetValue(argument).Should().BeEquivalentSequenceTo("-o", "--one", "-x", "-y", "-z", "-o:foo");
 
                 result.UnmatchedTokens.Should().BeEmpty();
             }
@@ -85,7 +85,7 @@ namespace System.CommandLine.Tests
                              .Build()
                              .Parse("a b c -- -- d");
 
-                var strings = result.GetValueForArgument(argument);
+                var strings = result.GetValue(argument);
 
                 strings.Should().BeEquivalentSequenceTo("a", "b", "c", "--", "d");
             }

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -38,10 +38,10 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2 3 4");
 
-                result.GetValueForArgument(multipleArityArg)
+                result.GetValue(multipleArityArg)
                       .Should()
                       .BeEquivalentSequenceTo("1", "2", "3");
-                result.GetValueForArgument(singleArityArg)
+                result.GetValue(singleArityArg)
                       .Should()
                       .BeEquivalentSequenceTo("4");
             }
@@ -66,8 +66,8 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("1 2");
 
-                result.GetValueForArgument(stringArg).Should().Be("1");
-                result.GetValueForArgument(intArg).Should().Be(2);
+                result.GetValue(stringArg).Should().Be("1");
+                result.GetValue(intArg).Should().Be(2);
             }
 
             [Theory]
@@ -101,22 +101,22 @@ namespace System.CommandLine.Tests
                 var parseResult = command.Parse(commandLine);
 
                 parseResult
-                    .GetValueForArgument(first)
+                    .GetValue(first)
                     .Should()
                     .Be("one");
 
                 parseResult
-                    .GetValueForArgument(second)
+                    .GetValue(second)
                     .Should()
                     .Be("two");
 
                 parseResult
-                    .GetValueForArgument(third)
+                    .GetValue(third)
                     .Should()
                     .BeEquivalentSequenceTo("three", "four", "five");
 
                 parseResult
-                    .GetValueForOption(verbose)
+                    .GetValue(verbose)
                     .Should()
                     .BeTrue();
             }
@@ -159,7 +159,7 @@ namespace System.CommandLine.Tests
 
                 var result = command.Parse("-e foo");
 
-                var optionResult = result.GetValueForOption(option);
+                var optionResult = result.GetValue(option);
 
                 optionResult.Should().Be("foo");
             }
@@ -180,12 +180,12 @@ namespace System.CommandLine.Tests
 
                 var _ = new AssertionScope();
 
-                result.GetValueForArgument(ints)
+                result.GetValue(ints)
                       .Should()
                       .BeEquivalentTo(new[] { 1, 2, 3 },
                                       options => options.WithStrictOrdering());
 
-                result.GetValueForArgument(strings)
+                result.GetValue(strings)
                       .Should()
                       .BeEquivalentTo(new[] { "one", "two" },
                                       options => options.WithStrictOrdering());
@@ -207,12 +207,12 @@ namespace System.CommandLine.Tests
 
                 var _ = new AssertionScope();
 
-                result.GetValueForArgument(ints)
+                result.GetValue(ints)
                       .Should()
                       .BeEquivalentTo(new[] { 1, 2, 3 },
                                       options => options.WithStrictOrdering());
 
-                result.GetValueForArgument(strings)
+                result.GetValue(strings)
                       .Should()
                       .Be("four");
 
@@ -244,8 +244,8 @@ namespace System.CommandLine.Tests
 
                 var result = rootCommand.Parse("value-1");
 
-                result.GetValueForArgument(arg1).Should().Be("value-1");
-                result.GetValueForArgument(arg2).Should().Be("the-default");
+                result.GetValue(arg1).Should().Be("value-1");
+                result.GetValue(arg2).Should().Be("the-default");
             }
 
             [Fact] // https://github.com/dotnet/command-line-api/issues/1403
@@ -263,7 +263,7 @@ namespace System.CommandLine.Tests
                 var result = rootCommand.Parse("");
 
                 result.FindResultFor(arg1).Should().BeNull();
-                result.GetValueForArgument(arg2).Should().Be("the-default");
+                result.GetValue(arg2).Should().Be("the-default");
             }
 
             [Fact] // https://github.com/dotnet/command-line-api/issues/1395
@@ -283,7 +283,7 @@ namespace System.CommandLine.Tests
 
                 result.Errors.Should().BeEmpty();
 
-                result.GetValueForArgument(argument1).Should().Be("one");
+                result.GetValue(argument1).Should().Be("one");
             }
 
             [Theory] // https://github.com/dotnet/command-line-api/issues/1711

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -824,7 +824,7 @@ namespace System.CommandLine.Tests
 
             ParseResult result = command.Parse("command");
 
-            result.GetValueForArgument(argument)
+            result.GetValue(argument)
                   .Should()
                   .Be("default");
         }
@@ -839,7 +839,7 @@ namespace System.CommandLine.Tests
             ParseResult result = command.Parse("command");
 
             result.HasOption(option).Should().BeTrue();
-            result.GetValueForOption(option).Should().Be("the-default");
+            result.GetValue(option).Should().Be("the-default");
         }
 
         [Fact]
@@ -914,7 +914,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("the-directory");
 
-            result.GetValueForArgument(argument)
+            result.GetValue(argument)
                   ?.Name
                   .Should()
                   .Be("the-directory");
@@ -1092,7 +1092,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse(input);
 
-            var valueForOption = result.GetValueForOption(optionX);
+            var valueForOption = result.GetValue(optionX);
 
             valueForOption.Should().Be("-y");
         }
@@ -1113,9 +1113,9 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-a -bc");
 
-            result.GetValueForOption(optionA).Should().Be("-bc");
-            result.GetValueForOption(optionB).Should().BeFalse();
-            result.GetValueForOption(optionC).Should().BeFalse();
+            result.GetValue(optionA).Should().Be("-bc");
+            result.GetValue(optionB).Should().BeFalse();
+            result.GetValue(optionC).Should().BeFalse();
         }
 
         [Fact]
@@ -1132,7 +1132,7 @@ namespace System.CommandLine.Tests
 
             _output.WriteLine(result.ToString());
 
-            result.GetValueForOption(optionA).Should().Be("subcommand");
+            result.GetValue(optionA).Should().Be("subcommand");
             result.CommandResult.Command.Should().BeSameAs(root);
         }
 
@@ -1153,7 +1153,7 @@ namespace System.CommandLine.Tests
 
             result.CommandResult.Command.Should().BeSameAs(subcommand);
 
-            result.GetValueForArgument(argument)
+            result.GetValue(argument)
                   .Should()
                   .BeEquivalentSequenceTo("one", "two", "three", "subcommand", "four");
         }
@@ -1173,7 +1173,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse(input);
 
-            var valueForOption = result.GetValueForOption(optionX);
+            var valueForOption = result.GetValue(optionX);
 
             result.Errors.Should().BeEmpty();
             valueForOption.Should().Be("-y");
@@ -1191,7 +1191,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-x -x");
 
-            result.GetValueForOption(optionX).Should().Be("-x");
+            result.GetValue(optionX).Should().Be("-x");
         }
 
         [Theory]
@@ -1218,8 +1218,8 @@ namespace System.CommandLine.Tests
 
             result.Errors.Should().BeEmpty();
 
-            result.GetValueForOption(optX).Should().BeTrue();
-            result.GetValueForOption(optY).Should().BeTrue();
+            result.GetValue(optX).Should().BeTrue();
+            result.GetValue(optY).Should().BeTrue();
         }
 
         [Fact]
@@ -1238,8 +1238,8 @@ namespace System.CommandLine.Tests
 
             _output.WriteLine(result.Diagram());
 
-            result.GetValueForOption(optionX).Should().BeEquivalentTo(new[] { "-x", "-y", "-y" });
-            result.GetValueForOption(optionY).Should().BeEquivalentTo(new[] { "-x", "-y", "-x" });
+            result.GetValue(optionX).Should().BeEquivalentTo(new[] { "-x", "-y", "-y" });
+            result.GetValue(optionY).Should().BeEquivalentTo(new[] { "-x", "-y", "-x" });
         }
 
         [Fact]
@@ -1256,7 +1256,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-yxx");
 
-            result.GetValueForOption(optionX).Should().Be("x");
+            result.GetValue(optionX).Should().Be("x");
         }
 
         [Fact]
@@ -1273,8 +1273,8 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("name one two three");
 
-            result.GetValueForArgument(nameArg).Should().Be("name");
-            result.GetValueForArgument(columnsArg).Should().BeEquivalentTo("one", "two", "three");
+            result.GetValue(nameArg).Should().Be("name");
+            result.GetValue(columnsArg).Should().BeEquivalentTo("one", "two", "three");
         }
 
         [Fact]
@@ -1299,7 +1299,7 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-v an-argument");
 
-            result.GetValueForOption(option).Should().BeTrue();
+            result.GetValue(option).Should().BeTrue();
         }
 
         [Fact]
@@ -1316,8 +1316,8 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse("-x 23 unmatched-token -y 42");
 
-            result.GetValueForOption(optionX).Should().Be("23");
-            result.GetValueForOption(optionY).Should().Be("42");
+            result.GetValue(optionX).Should().Be("23");
+            result.GetValue(optionY).Should().Be("42");
             result.UnmatchedTokens.Should().BeEquivalentTo("unmatched-token");
         }
 
@@ -1564,7 +1564,7 @@ namespace System.CommandLine.Tests
 
             var result = rootCommand.Parse(new[] { arg1, arg2 });
 
-            result.GetValueForOption(option).Should().BeEmpty();
+            result.GetValue(option).Should().BeEmpty();
         }
     }
 }

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -483,7 +483,7 @@ namespace System.CommandLine.Tests
             var errorMessage = "The value of option '-x' must be between 1 and 100.";
             argument.AddValidator(result =>
             {
-                var value = result.GetValueForArgument(argument);
+                var value = result.GetValue(argument);
 
                 if (value < 0 || value > 100)
                 {
@@ -507,7 +507,7 @@ namespace System.CommandLine.Tests
             var errorMessage = "The value of option '-x' must be between 1 and 100.";
             option.AddValidator(result =>
             {
-                var value = result.GetValueForOption(option);
+                var value = result.GetValue(option);
 
                 if (value < 0 || value > 100)
                 {
@@ -1094,8 +1094,8 @@ namespace System.CommandLine.Tests
             var result = parser.Parse("");
 
             result.Errors.Should().BeEmpty();
-            result.GetValueForOption(optionX).Should().Be(123);
-            result.GetValueForOption(optionY).Should().Be(456);
+            result.GetValue(optionX).Should().Be(123);
+            result.GetValue(optionY).Should().Be(456);
         }
 
         [Fact] // https://github.com/dotnet/command-line-api/issues/1505

--- a/src/System.CommandLine.Tests/ResponseFileTests.cs
+++ b/src/System.CommandLine.Tests/ResponseFileTests.cs
@@ -69,7 +69,7 @@ namespace System.CommandLine.Tests
                 .Parse($"@{responseFile}");
 
             result.HasOption(optionOne).Should().BeTrue();
-            result.GetValueForOption(optionTwo).Should().Be(123);
+            result.GetValue(optionTwo).Should().Be(123);
             result.Errors.Should().BeEmpty();
         }
 
@@ -179,7 +179,7 @@ namespace System.CommandLine.Tests
                 }
                 .Parse($"@{responseFile}");
 
-            result.GetValueForOption(option).Should().Be(123);
+            result.GetValue(option).Should().Be(123);
             result.Errors.Should().BeEmpty();
         }
 
@@ -292,8 +292,8 @@ namespace System.CommandLine.Tests
 
             var result = parser.Parse($"@{responseFile}");
 
-            result.GetValueForOption(optionOne).Should().Be("first value");
-            result.GetValueForOption(optionTwo).Should().Be(123);
+            result.GetValue(optionOne).Should().Be("first value");
+            result.GetValue(optionTwo).Should().Be(123);
         }
 
         [Fact]
@@ -338,10 +338,10 @@ namespace System.CommandLine.Tests
 
             var result = command.Parse($"@{file1}");
 
-            result.GetValueForOption(option1).Should().Be(1);
-            result.GetValueForOption(option1).Should().Be(1);
-            result.GetValueForOption(option2).Should().Be(2);
-            result.GetValueForOption(option3).Should().Be(3);
+            result.GetValue(option1).Should().Be(1);
+            result.GetValue(option1).Should().Be(1);
+            result.GetValue(option2).Should().Be(2);
+            result.GetValue(option3).Should().Be(3);
             result.Errors.Should().BeEmpty();
         }
 
@@ -354,8 +354,8 @@ namespace System.CommandLine.Tests
             var option2 = new Option<int>("--option2");
 
             var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
-            result.GetValueForOption(option1).Should().Be("value1");
-            result.GetValueForOption(option2).Should().Be(2);
+            result.GetValue(option1).Should().Be("value1");
+            result.GetValue(option2).Should().Be(2);
         }
 
         [Fact]
@@ -367,8 +367,8 @@ namespace System.CommandLine.Tests
             var option2 = new Option<int>("--option2");
 
             var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
-            result.GetValueForOption(option1).Should().Be("value1");
-            result.GetValueForOption(option2).Should().Be(2);
+            result.GetValue(option1).Should().Be("value1");
+            result.GetValue(option2).Should().Be(2);
             result.Errors.Should().BeEmpty();
         }
 
@@ -381,8 +381,8 @@ namespace System.CommandLine.Tests
             var option2 = new Option<int>("--option2");
 
             var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
-            result.GetValueForOption(option1).Should().Be("value1");
-            result.GetValueForOption(option2).Should().Be(2);
+            result.GetValue(option1).Should().Be("value1");
+            result.GetValue(option2).Should().Be(2);
             result.Errors.Should().BeEmpty();
         }
     }

--- a/src/System.CommandLine.Tests/TestApps/NativeAOT/Program.cs
+++ b/src/System.CommandLine.Tests/TestApps/NativeAOT/Program.cs
@@ -22,8 +22,8 @@ public class Program
 
         void Run(InvocationContext context)
         {
-            context.Console.WriteLine($"Bool option: {context.ParseResult.GetValueForOption(boolOption)}");
-            context.Console.WriteLine($"String option: {context.ParseResult.GetValueForOption(stringOption)}");
+            context.Console.WriteLine($"Bool option: {context.ParseResult.GetValue(boolOption)}");
+            context.Console.WriteLine($"String option: {context.ParseResult.GetValue(stringOption)}");
         }
     }
 }

--- a/src/System.CommandLine.Tests/TestApps/Trimming/Program.cs
+++ b/src/System.CommandLine.Tests/TestApps/Trimming/Program.cs
@@ -10,7 +10,7 @@ var command = new RootCommand
 
 command.SetHandler(context =>
 {
-    context.Console.Write($"The file you chose was: {context.ParseResult.GetValueForArgument(fileArgument)}");
+    context.Console.Write($"The file you chose was: {context.ParseResult.GetValue(fileArgument)}");
 });
 
 command.Invoke(args);

--- a/src/System.CommandLine.Tests/TokenReplacementTests.cs
+++ b/src/System.CommandLine.Tests/TokenReplacementTests.cs
@@ -54,7 +54,7 @@ public class TokenReplacementTests
 
         result.Errors.Should().BeEmpty();
 
-        result.GetValueForArgument(argument).Should().Be(123);
+        result.GetValue(argument).Should().Be(123);
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class TokenReplacementTests
 
         result.Errors.Should().BeEmpty();
 
-        result.GetValueForOption(option).Should().Be(123);
+        result.GetValue(option).Should().Be(123);
     }
 
     [Fact]
@@ -100,7 +100,7 @@ public class TokenReplacementTests
 
         result.Errors.Should().BeEmpty();
 
-        result.GetValueForOption(option).Should().Be(123);
+        result.GetValue(option).Should().Be(123);
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public class TokenReplacementTests
 
         var result = parser.Parse("@replace-me");
 
-        result.GetValueForArgument(argument).Should().Be("one two three");
+        result.GetValue(argument).Should().Be("one two three");
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public class TokenReplacementTests
 
         result.Errors.Should().BeEmpty();
 
-        result.GetValueForArgument(argument).Should().Be("@replace-me");
+        result.GetValue(argument).Should().Be("@replace-me");
     }
 
     [Fact]
@@ -190,7 +190,7 @@ public class TokenReplacementTests
 
         result.Errors.Should().BeEmpty();
 
-        result.GetValueForArgument(argument).Should().BeEmpty();
+        result.GetValue(argument).Should().BeEmpty();
     }
 
     [Fact]
@@ -213,6 +213,6 @@ public class TokenReplacementTests
 
         result.Errors.Should().BeEmpty();
 
-        result.GetValueForArgument(argument).Should().BeEmpty();
+        result.GetValue(argument).Should().BeEmpty();
     }
 }

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -123,6 +123,22 @@ namespace System.CommandLine.Invocation
             _registrations.AddLast(token.Register(Cancel));
         }
 
+        /// <inheritdoc cref="ParseResult.GetValue(Option)"/>
+        public object? GetValue(Option option) =>
+            ParseResult.GetValue(option);
+
+        /// <inheritdoc cref="ParseResult.GetValue(Option)"/>
+        public T? GetValue<T>(Option<T> option)
+            => ParseResult.GetValue(option);
+
+        /// <inheritdoc cref="ParseResult.GetValue(Argument)"/>
+        public object? GetValue(Argument argument) =>
+            ParseResult.GetValue(argument);
+
+        /// <inheritdoc cref="ParseResult.GetValue(Argument)"/>
+        public T GetValue<T>(Argument<T> argument)
+            => ParseResult.GetValue(argument);
+
         /// <inheritdoc />
         void IDisposable.Dispose()
         {

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -129,8 +129,8 @@ namespace System.CommandLine
         internal T? GetValueFor<T>(IValueDescriptor<T> symbol) =>
             symbol switch
             {
-                Argument<T> argument => GetValueForArgument(argument),
-                Option<T> option => GetValueForOption(option),
+                Argument<T> argument => GetValue(argument),
+                Option<T> option => GetValue(option),
                 _ => throw new ArgumentOutOfRangeException()
             };
 
@@ -139,24 +139,24 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="option">The option for which to get a value.</param>
         /// <returns>The parsed value or a configured default.</returns>
-        public object? GetValueForOption(Option option) =>
-            RootCommandResult.GetValueForOption(option);
+        public object? GetValue(Option option) =>
+            RootCommandResult.GetValue(option);
 
         /// <summary>
         /// Gets the parsed or default value for the specified argument.
         /// </summary>
         /// <param name="argument">The argument for which to get a value.</param>
         /// <returns>The parsed value or a configured default.</returns>
-        public object? GetValueForArgument(Argument argument) =>
-            RootCommandResult.GetValueForArgument(argument);
+        public object? GetValue(Argument argument) =>
+            RootCommandResult.GetValue(argument);
 
-        /// <inheritdoc cref="GetValueForArgument"/>
-        public T GetValueForArgument<T>(Argument<T> argument)
-            => RootCommandResult.GetValueForArgument(argument);
+        /// <inheritdoc cref="GetValue(Argument)"/>
+        public T GetValue<T>(Argument<T> argument)
+            => RootCommandResult.GetValue(argument);
         
-        /// <inheritdoc cref="GetValueForOption"/>
-        public T? GetValueForOption<T>(Option<T> option)
-            => RootCommandResult.GetValueForOption(option);
+        /// <inheritdoc cref="GetValue(Option)"/>
+        public T? GetValue<T>(Option<T> option)
+            => RootCommandResult.GetValue(option);
 
         /// <inheritdoc />
         public override string ToString() => $"{nameof(ParseResult)}: {this.Diagram()}";

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -128,8 +128,8 @@ namespace System.CommandLine.Parsing
         public virtual OptionResult? FindResultFor(Option option) =>
             Root?.FindResultFor(option);
 
-        /// <inheritdoc cref="ParseResult.GetValueForArgument"/>
-        public T GetValueForArgument<T>(Argument<T> argument)
+        /// <inheritdoc cref="ParseResult.GetValue(Argument)"/>
+        public T GetValue<T>(Argument<T> argument)
         {
             if (FindResultFor(argument) is { } result &&
                 result.GetValueOrDefault<T>() is { } t)
@@ -140,8 +140,8 @@ namespace System.CommandLine.Parsing
             return (T)ArgumentConverter.GetDefaultValue(argument.ValueType)!;
         }
 
-        /// <inheritdoc cref="ParseResult.GetValueForArgument"/>
-        public object? GetValueForArgument(Argument argument)
+        /// <inheritdoc cref="ParseResult.GetValue(Argument)"/>
+        public object? GetValue(Argument argument)
         {
             if (FindResultFor(argument) is { } result &&
                 result.GetValueOrDefault<object?>() is { } t)
@@ -152,8 +152,8 @@ namespace System.CommandLine.Parsing
             return ArgumentConverter.GetDefaultValue(argument.ValueType);
         }
 
-        /// <inheritdoc cref="ParseResult.GetValueForOption"/>
-        public T? GetValueForOption<T>(Option<T> option)
+        /// <inheritdoc cref="ParseResult.GetValue(Option)"/>
+        public T? GetValue<T>(Option<T> option)
         {
             if (FindResultFor(option) is { } result &&
                 result.GetValueOrDefault<T>() is { } t)
@@ -164,8 +164,8 @@ namespace System.CommandLine.Parsing
             return (T)ArgumentConverter.GetDefaultValue(option.Argument.ValueType)!;
         }
 
-        /// <inheritdoc cref="ParseResult.GetValueForOption"/>
-        public object? GetValueForOption(Option option)
+        /// <inheritdoc cref="ParseResult.GetValue(Option)"/>
+        public object? GetValue(Option option)
         {
             if (FindResultFor(option) is { } result && 
                 result.GetValueOrDefault<object?>() is { } t)


### PR DESCRIPTION
Added GetValue methods to InvocationContext
Renamed GetValueForOption and GetValueForArgument on ParseResult and SymbolResult classes

Fixes #1785 