### PR TITLE
Handle left Token being null in == and !=.

### DIFF
--- a/src/System.CommandLine/Parsing/Token.cs
+++ b/src/System.CommandLine/Parsing/Token.cs
@@ -6,7 +6,7 @@ namespace System.CommandLine.Parsing
     /// <summary>
     /// A unit of significant text on the command line.
     /// </summary>
-    public class Token : IEquatable<Token>
+    public sealed class Token : IEquatable<Token>
     {
         internal const int ImplicitPosition = -1;
 

--- a/src/System.CommandLine/Parsing/Token.cs
+++ b/src/System.CommandLine/Parsing/Token.cs
@@ -66,7 +66,7 @@ namespace System.CommandLine.Parsing
         /// <param name="left">The first <see cref="Token"/>.</param>
         /// <param name="right">The second <see cref="Token"/>.</param>
         /// <returns><see langword="true" /> if the objects are equal.</returns>
-        public static bool operator ==(Token left, Token right) => left.Equals(right);
+        public static bool operator ==(Token left, Token right) => left?.Equals(right) ?? right is null;
 
         /// <summary>
         /// Checks if two specified <see cref="Token"/> instances have different values.
@@ -74,6 +74,6 @@ namespace System.CommandLine.Parsing
         /// <param name="left">The first <see cref="Token"/>.</param>
         /// <param name="right">The second <see cref="Token"/>.</param>
         /// <returns><see langword="true" /> if the objects are not equal.</returns>
-        public static bool operator !=(Token left, Token right) => !left.Equals(right);
+        public static bool operator !=(Token left, Token right) => !(left == right);
     }
 }


### PR DESCRIPTION
Fixes #1797.  This seems the simplest change to get things working correctly.

Marking as sealed is important to avoid potential complications with derived classes.

Personally I find it fairly natural to have == and != defined for something implementing IEquatable<T> - it provides a natural way to check for equality including nulls.