### PR TITLE
[1653] remove the legacy double dash behavior and ParseResult.UnparsedTokens

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -79,7 +79,6 @@ System.CommandLine
     public static CommandLineBuilder AddMiddleware(this CommandLineBuilder builder, System.Action<System.CommandLine.Invocation.InvocationContext> onInvoke, System.CommandLine.Invocation.MiddlewareOrder order = Default)
     public static CommandLineBuilder CancelOnProcessTermination(this CommandLineBuilder builder, System.Nullable<System.TimeSpan> timeout = null)
     public static CommandLineBuilder EnableDirectives(this CommandLineBuilder builder, System.Boolean value = True)
-    public static CommandLineBuilder EnableLegacyDoubleDashBehavior(this CommandLineBuilder builder, System.Boolean value = True)
     public static CommandLineBuilder EnablePosixBundling(this CommandLineBuilder builder, System.Boolean value = True)
     public static CommandLineBuilder RegisterWithDotnetSuggest(this CommandLineBuilder builder)
     public static CommandLineBuilder UseDefaults(this CommandLineBuilder builder)
@@ -98,9 +97,8 @@ System.CommandLine
     public static CommandLineBuilder UseVersionOption(this CommandLineBuilder builder)
     public static CommandLineBuilder UseVersionOption(this CommandLineBuilder builder, System.String[] aliases)
   public class CommandLineConfiguration
-    .ctor(Command command, System.Boolean enablePosixBundling = True, System.Boolean enableDirectives = True, System.Boolean enableLegacyDoubleDashBehavior = False, System.Boolean enableTokenReplacement = True, LocalizationResources resources = null, System.Collections.Generic.IReadOnlyList<System.CommandLine.Invocation.InvocationMiddleware> middlewarePipeline = null, System.Func<System.CommandLine.Binding.BindingContext,System.CommandLine.Help.HelpBuilder> helpBuilderFactory = null, System.CommandLine.Parsing.TryReplaceToken tokenReplacer = null)
+    .ctor(Command command, System.Boolean enablePosixBundling = True, System.Boolean enableDirectives = True, System.Boolean enableTokenReplacement = True, LocalizationResources resources = null, System.Collections.Generic.IReadOnlyList<System.CommandLine.Invocation.InvocationMiddleware> middlewarePipeline = null, System.Func<System.CommandLine.Binding.BindingContext,System.CommandLine.Help.HelpBuilder> helpBuilderFactory = null, System.CommandLine.Parsing.TryReplaceToken tokenReplacer = null)
     public System.Boolean EnableDirectives { get; }
-    public System.Boolean EnableLegacyDoubleDashBehavior { get; }
     public System.Boolean EnablePosixBundling { get; }
     public System.Boolean EnableTokenReplacement { get; }
     public LocalizationResources LocalizationResources { get; }
@@ -236,7 +234,6 @@ System.CommandLine
     public System.CommandLine.Parsing.CommandResult RootCommandResult { get; }
     public System.Collections.Generic.IReadOnlyList<System.CommandLine.Parsing.Token> Tokens { get; }
     public System.Collections.Generic.IReadOnlyList<System.String> UnmatchedTokens { get; }
-    public System.Collections.Generic.IReadOnlyList<System.String> UnparsedTokens { get; }
     public System.CommandLine.Parsing.ArgumentResult FindResultFor(Argument argument)
     public System.CommandLine.Parsing.CommandResult FindResultFor(Command command)
     public System.CommandLine.Parsing.OptionResult FindResultFor(Option option)
@@ -487,8 +484,7 @@ System.CommandLine.Parsing
     Command=1
     Option=2
     DoubleDash=3
-    Unparsed=4
-    Directive=5
+    Directive=4
   public delegate TryReplaceToken : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
     .ctor(System.Object object, System.IntPtr method)
     public System.IAsyncResult BeginInvoke(System.String tokenToReplace, ref System.Collections.Generic.IReadOnlyList<System.String> replacementTokens, ref System.String& errorMessage, System.AsyncCallback callback, System.Object object)

--- a/src/System.CommandLine.Hosting.Tests/HostingTests.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingTests.cs
@@ -91,11 +91,11 @@ namespace System.CommandLine.Hosting.Tests
         }
 
         [Fact]
-        public static void UseHost_UnparsedTokens_can_propagate_to_Host_Configuration()
+        public static void UseHost_UnmatchedTokens_can_propagate_to_Host_Configuration()
         {
             const string testArgument = "test";
-            const string testKey = "unparsed-config";
-            string commandLineArgs = $"-- --{testKey} {testArgument}";
+            const string testKey = "unmatched-config";
+            string commandLineArgs = $"--{testKey} {testArgument}";
 
             string testConfigValue = null;
 
@@ -110,11 +110,10 @@ namespace System.CommandLine.Hosting.Tests
                 {
                     Handler = CommandHandler.Create<IHost>(Execute),
                 })
-                .EnableLegacyDoubleDashBehavior()
                 .UseHost(host =>
                 {
                     var invocation = (InvocationContext)host.Properties[typeof(InvocationContext)];
-                    var args = invocation.ParseResult.UnparsedTokens.ToArray();
+                    var args = invocation.ParseResult.UnmatchedTokens.ToArray();
                     host.ConfigureHostConfiguration(config =>
                     {
                         config.AddCommandLine(args);
@@ -129,11 +128,11 @@ namespace System.CommandLine.Hosting.Tests
         }
 
         [Fact]
-        public static void UseHost_UnparsedTokens_are_available_in_HostBuilder_factory()
+        public static void UseHost_UnmatchedTokens_are_available_in_HostBuilder_factory()
         {
             const string testArgument = "test";
-            const string testKey = "unparsed-config";
-            string commandLineArgs = $"-- --{testKey} {testArgument}";
+            const string testKey = "unmatched-config";
+            string commandLineArgs = $"--{testKey} {testArgument}";
 
             string testConfigValue = null;
 
@@ -148,7 +147,6 @@ namespace System.CommandLine.Hosting.Tests
                 {
                     Handler = CommandHandler.Create<IHost>(Execute),
                 })
-                .EnableLegacyDoubleDashBehavior()
                 .UseHost(args =>
                 {
                     var host = new HostBuilder();

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -20,7 +20,7 @@ namespace System.CommandLine.Hosting
             Action<IHostBuilder> configureHost = null) =>
             builder.AddMiddleware(async (invocation, next) =>
             {
-                var argsRemaining = invocation.ParseResult.UnparsedTokens.ToArray();
+                var argsRemaining = invocation.ParseResult.UnmatchedTokens.ToArray();
                 var hostBuilder = hostBuilderFactory?.Invoke(argsRemaining)
                     ?? new HostBuilder();
                 hostBuilder.Properties[typeof(InvocationContext)] = invocation;

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -74,9 +74,8 @@ namespace System.CommandLine.Suggest
                 RegisterCommand,
                 CompleteScriptCommand
             };
-
+            root.TreatUnmatchedTokensAsErrors = false;
             Parser = new CommandLineBuilder(root)
-                     .EnableLegacyDoubleDashBehavior()
                      .UseVersionOption()
                      .UseHelp()
                      .UseParseDirective()
@@ -207,7 +206,7 @@ namespace System.CommandLine.Suggest
             int position,
             string targetExeName)
         {
-            var tokens = parseResult.UnparsedTokens;
+            var tokens = parseResult.UnmatchedTokens;
 
             var commandLine = tokens.FirstOrDefault() ?? "";
 

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -559,7 +559,7 @@ namespace System.CommandLine.Tests
             }
 
             [Fact]
-            public void When_tokens_are_passed_on_by_custom_parser_on_last_argument_then_they_become_unparsed_tokens()
+            public void When_tokens_are_passed_on_by_custom_parser_on_last_argument_then_they_become_unmatched_tokens()
             {
 
                 var argument1 = new Argument<int[]>(
@@ -583,7 +583,7 @@ namespace System.CommandLine.Tests
 
                 var parseResult = command.Parse("1 2 3 4 5 6 7 8");
 
-                parseResult.UnparsedTokens
+                parseResult.UnmatchedTokens
                            .Should()
                            .BeEquivalentTo(new[] { "4", "5", "6", "7", "8" },
                                            options => options.WithStrictOrdering());

--- a/src/System.CommandLine.Tests/ParserTests.DoubleDash.cs
+++ b/src/System.CommandLine.Tests/ParserTests.DoubleDash.cs
@@ -24,7 +24,6 @@ namespace System.CommandLine.Tests
                 };
 
                 var result = new CommandLineBuilder(rootCommand)
-                             .EnableLegacyDoubleDashBehavior(false)
                              .Build()
                              .Parse("-o \"some stuff\" -- -o --one -x -y -z -o:foo");
 
@@ -34,11 +33,11 @@ namespace System.CommandLine.Tests
 
                 result.GetValueForArgument(argument).Should().BeEquivalentSequenceTo("-o", "--one", "-x", "-y", "-z", "-o:foo");
 
-                result.UnparsedTokens.Should().BeEmpty();
+                result.UnmatchedTokens.Should().BeEmpty();
             }
 
             [Fact]
-            public void Unparsed_tokens_is_empty()
+            public void Unmatched_tokens_is_empty()
             {
                 var option = new Option<string[]>(new[] { "-o", "--one" });
                 var argument = new Argument<string[]>();
@@ -49,11 +48,10 @@ namespace System.CommandLine.Tests
                 };
 
                 var result = new CommandLineBuilder(rootCommand)
-                             .EnableLegacyDoubleDashBehavior(false)
                              .Build()
                              .Parse("-o \"some stuff\" -- --one -x -y -z -o:foo");
 
-                result.UnparsedTokens.Should().BeEmpty();
+                result.UnmatchedTokens.Should().BeEmpty();
             }
 
             [Fact] // https://github.com/dotnet/command-line-api/issues/1631
@@ -68,7 +66,6 @@ namespace System.CommandLine.Tests
                 };
 
                 var result = new CommandLineBuilder(rootCommand)
-                             .EnableLegacyDoubleDashBehavior(false)
                              .Build()
                              .Parse("-o \"some stuff\" -- -o --one -x -y -z -o:foo");
 
@@ -85,77 +82,12 @@ namespace System.CommandLine.Tests
                 };
 
                 var result = new CommandLineBuilder(rootCommand)
-                             .EnableLegacyDoubleDashBehavior(false)
                              .Build()
                              .Parse("a b c -- -- d");
 
                 var strings = result.GetValueForArgument(argument);
 
                 strings.Should().BeEquivalentSequenceTo("a", "b", "c", "--", "d");
-            }
-        }
-
-        public class LegacyDoubleDashBehavior
-        {
-            [Fact]
-            public void The_portion_of_the_command_line_following_a_double_is_treated_as_unparsed_tokens()
-            {
-                var result = new CommandLineBuilder(new RootCommand { new Option<string>("-o") })
-                             .EnableLegacyDoubleDashBehavior()
-                             .Build()
-                             .Parse("-o \"some stuff\" -- x y z");
-
-                result.UnparsedTokens
-                      .Should()
-                      .BeEquivalentSequenceTo("x", "y", "z");
-            }
-
-            [Fact]
-            public void Subsequent_tokens_matching_options_will_be_treated_as_unparsed_tokens()
-            {
-                var optionO = new Option<string>(new[] { "-o" });
-                var optionX = new Option<bool>(new[] { "-x" });
-                var optionY = new Option<bool>(new[] { "-y" });
-                var optionZ = new Option<bool>(new[] { "-z" });
-                var rootCommand = new RootCommand
-                {
-                    optionO,
-                    optionX,
-                    optionY,
-                    optionZ
-                };
-                var result = new CommandLineBuilder(rootCommand)
-                             .EnableLegacyDoubleDashBehavior()
-                             .Build()
-                             .Parse("-o \"some stuff\" -- -x -y -z -o:foo");
-
-                result.HasOption(optionO).Should().BeTrue();
-                result.HasOption(optionX).Should().BeFalse();
-                result.HasOption(optionY).Should().BeFalse();
-                result.HasOption(optionZ).Should().BeFalse();
-
-                result.UnparsedTokens
-                      .Should()
-                      .BeEquivalentSequenceTo("-x",
-                                              "-y",
-                                              "-z",
-                                              "-o:foo");
-            }
-
-            [Fact]
-            public void Subsequent_tokens_matching_argument_will_be_treated_as_unparsed_tokens()
-            {
-                var argument = new Argument<int[]>();
-                var rootCommand = new RootCommand
-                {
-                    argument
-                };
-                var result = new CommandLineBuilder(rootCommand)
-                             .EnableLegacyDoubleDashBehavior()
-                             .Build()
-                             .Parse("1 2 3 -- 4 5 6 7");
-
-                result.GetValueForArgument(argument).Should().BeEquivalentSequenceTo(1, 2, 3);
             }
         }
     }

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -216,7 +216,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .Be("four");
 
-                result.UnparsedTokens
+                result.UnmatchedTokens
                       .Should()
                       .ContainSingle()
                       .Which

--- a/src/System.CommandLine/Builder/CommandLineBuilder.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilder.cs
@@ -45,12 +45,6 @@ namespace System.CommandLine
         internal bool EnablePosixBundling { get; set; } = true;
         
         internal bool EnableTokenReplacement { get; set; } = true;
-
-        /// <summary>
-        /// Determines the behavior when parsing a double dash (<c>--</c>) in a command line.
-        /// </summary>
-        /// <remarks>When set to <see langword="true"/>, all tokens following <c>--</c> will be placed into the <see cref="ParseResult.UnparsedTokens"/> collection. When set to <see langword="false"/>, all tokens following <c>--</c> will be treated as command arguments, even if they match an existing option.</remarks>
-        internal bool EnableLegacyDoubleDashBehavior { get; set; }
         
         internal void CustomizeHelpLayout(Action<HelpContext> customize) => 
             _customizeHelpBuilder = customize;
@@ -97,7 +91,6 @@ namespace System.CommandLine
                     Command,
                     enablePosixBundling: EnablePosixBundling,
                     enableDirectives: EnableDirectives,
-                    enableLegacyDoubleDashBehavior: EnableLegacyDoubleDashBehavior,
                     enableTokenReplacement: EnableTokenReplacement,
                     resources: LocalizationResources,
                     middlewarePipeline: _middlewareList is null

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -165,19 +165,6 @@ namespace System.CommandLine
         }
 
         /// <summary>
-        /// Determines the behavior when parsing a double dash (<c>--</c>) in a command line.
-        /// </summary>
-        /// <param name="builder">A command line builder.</param>
-        /// <param name="value"><see langword="true" /> to place all tokens following <c>--</c> into the <see cref="ParseResult.UnparsedTokens"/> collection. <see langword="false" /> to treat all tokens following <c>--</c> as command arguments, even if they match an existing option.</param>
-        public static CommandLineBuilder EnableLegacyDoubleDashBehavior(
-            this CommandLineBuilder builder,
-            bool value = true)
-        {
-            builder.EnableLegacyDoubleDashBehavior = value;
-            return builder;
-        }
-
-        /// <summary>
         /// Enables the parser to recognize and expand POSIX-style bundled options.
         /// </summary>
         /// <param name="builder">A command line builder.</param>

--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -25,7 +25,6 @@ namespace System.CommandLine
         /// <param name="command">The root command for the parser.</param>
         /// <param name="enablePosixBundling"><see langword="true"/> to enable POSIX bundling; otherwise, <see langword="false"/>.</param>
         /// <param name="enableDirectives"><see langword="true"/> to enable directive parsing; otherwise, <see langword="false"/>.</param>
-        /// <param name="enableLegacyDoubleDashBehavior">Enables the legacy behavior of the <c>--</c> token, which is to ignore parsing of subsequent tokens and place them in the <see cref="ParseResult.UnparsedTokens"/> list.</param>
         /// <param name="enableTokenReplacement"><see langword="true"/> to enable token replacement; otherwise, <see langword="false"/>.</param>
         /// <param name="resources">Provide custom validation messages.</param>
         /// <param name="middlewarePipeline">Provide a custom middleware pipeline.</param>
@@ -35,7 +34,6 @@ namespace System.CommandLine
             Command command,
             bool enablePosixBundling = true,
             bool enableDirectives = true,
-            bool enableLegacyDoubleDashBehavior = false,
             bool enableTokenReplacement = true,
             LocalizationResources? resources = null,
             IReadOnlyList<InvocationMiddleware>? middlewarePipeline = null,
@@ -43,8 +41,6 @@ namespace System.CommandLine
             TryReplaceToken? tokenReplacer = null)
         {
             RootCommand = command ?? throw new ArgumentNullException(nameof(command));
-
-            EnableLegacyDoubleDashBehavior = enableLegacyDoubleDashBehavior;
             EnableTokenReplacement = enableTokenReplacement;
             EnablePosixBundling = enablePosixBundling;
             EnableDirectives = enableDirectives;
@@ -71,11 +67,6 @@ namespace System.CommandLine
         /// Gets whether directives are enabled.
         /// </summary>
         public bool EnableDirectives { get; }
-
-        /// <summary>
-        /// Enables the legacy behavior of the <c>--</c> token, which is to ignore parsing of subsequent tokens and place them in the <see cref="ParseResult.UnparsedTokens"/> list.
-        /// </summary>
-        public bool EnableLegacyDoubleDashBehavior { get; }
 
         /// <summary>
         /// Gets a value indicating whether POSIX bundling is enabled.

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -16,7 +16,6 @@ namespace System.CommandLine
     {
         private readonly List<ParseError> _errors;
         private readonly RootCommandResult _rootCommandResult;
-        private readonly IReadOnlyList<Token> _unparsedTokens;
         private readonly IReadOnlyList<Token> _unmatchedTokens;
         private CompletionContext? _completionContext;
 
@@ -26,7 +25,6 @@ namespace System.CommandLine
             CommandResult commandResult,
             DirectiveCollection directives,
             TokenizeResult tokenizeResult,
-            IReadOnlyList<Token>? unparsedTokens,
             IReadOnlyList<Token>? unmatchedTokens,
             List<ParseError>? errors,
             string? commandLineText = null)
@@ -53,7 +51,6 @@ namespace System.CommandLine
                 Tokens = Array.Empty<Token>();
             }
 
-            _unparsedTokens = unparsedTokens ?? Array.Empty<Token>();
             _errors = errors ?? new List<ParseError>();
             CommandLineText = commandLineText;
 
@@ -119,12 +116,6 @@ namespace System.CommandLine
         /// Gets the list of tokens used on the command line that were not matched by the parser.
         /// </summary>
         public IReadOnlyList<string> UnmatchedTokens => _unmatchedTokens.Select(t => t.Value).ToArray();
-
-        /// <summary>
-        /// Gets the list of tokens used on the command line that were ignored by the parser.
-        /// </summary>
-        /// <remarks>This list will contain all of the tokens following the first occurrence of a <c>--</c> token if <see cref="CommandLineConfiguration.EnableLegacyDoubleDashBehavior"/> is set to <see langword="true"/>.</remarks>
-        public IReadOnlyList<string> UnparsedTokens => _unparsedTokens.Select(t => t.Value).ToArray();
 
         /// <summary>
         /// Gets the completion context for the parse result.

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -54,8 +54,6 @@ namespace System.CommandLine.Parsing
 
             ParseCommandChildren(rootCommandNode);
 
-            ParseRemainingTokens();
-
             return rootCommandNode;
         }
 
@@ -218,25 +216,6 @@ namespace System.CommandLine.Parsing
                 var directiveNode = new DirectiveNode(token, parent, key, value);
 
                 parent.AddChildNode(directiveNode);
-
-                Advance();
-            }
-        }
-
-        private void ParseRemainingTokens()
-        {
-            var foundEndOfArguments = false;
-
-            while (More(out TokenType currentTokenType))
-            {
-                if (currentTokenType == TokenType.DoubleDash)
-                {
-                    foundEndOfArguments = true;
-                }
-                else if (foundEndOfArguments)
-                {
-                    AddCurrentTokenToUnmatched();
-                }
 
                 Advance();
             }

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -27,8 +27,6 @@ namespace System.CommandLine.Parsing
 
         public List<Token>? UnmatchedTokens { get; private set; }
 
-        public List<Token>? UnparsedTokens { get; private set; } 
-
         private void Advance() => _index++;
 
         private bool More(out TokenType currentTokenType)
@@ -79,12 +77,6 @@ namespace System.CommandLine.Parsing
 
             while (More(out TokenType currentTokenType))
             {
-                if (_configuration.EnableLegacyDoubleDashBehavior &&
-                    currentTokenType == TokenType.DoubleDash)
-                {
-                    return;
-                }
-
                 if (currentTokenType == TokenType.Command)
                 {
                     ParseSubcommand(parent);
@@ -243,7 +235,7 @@ namespace System.CommandLine.Parsing
                 }
                 else if (foundEndOfArguments)
                 {
-                    AddCurrentTokenToUnparsed();
+                    AddCurrentTokenToUnmatched();
                 }
 
                 Advance();
@@ -259,7 +251,5 @@ namespace System.CommandLine.Parsing
 
             (UnmatchedTokens ??= new()).Add(CurrentToken);
         }
-
-        private void AddCurrentTokenToUnparsed() => (UnparsedTokens ??= new()).Add(CurrentToken);
     }
 }

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -15,8 +15,7 @@ namespace System.CommandLine.Parsing
         private readonly string? _rawInput;
 
         private readonly DirectiveCollection _directives = new();
-        private List<Token>? _unparsedTokens;
-        private readonly List<Token>? _unmatchedTokens;
+        private List<Token>? _unmatchedTokens;
         private readonly List<ParseError> _errors;
 
         private readonly Dictionary<Symbol, SymbolResult> _symbolResults = new();
@@ -31,13 +30,11 @@ namespace System.CommandLine.Parsing
         public ParseResultVisitor(
             Parser parser,
             TokenizeResult tokenizeResult,
-            List<Token>? unparsedTokens,
             List<Token>? unmatchedTokens,
             string? rawInput)
         {
             _parser = parser;
             _tokenizeResult = tokenizeResult;
-            _unparsedTokens = unparsedTokens;
             _unmatchedTokens = unmatchedTokens;
             _rawInput = rawInput;
             _errors = new List<ParseError>(_tokenizeResult.Errors.Count);
@@ -301,8 +298,8 @@ namespace System.CommandLine.Parsing
                     if (argumentResult.PassedOnTokens is { } &&
                         i == arguments.Count - 1)
                     {
-                        _unparsedTokens ??= new List<Token>();
-                        _unparsedTokens.AddRange(argumentResult.PassedOnTokens);
+                        _unmatchedTokens ??= new List<Token>();
+                        _unmatchedTokens.AddRange(argumentResult.PassedOnTokens);
                     }
                 }
             }
@@ -620,7 +617,6 @@ namespace System.CommandLine.Parsing
                 _innermostCommandResult ?? throw new InvalidOperationException("No command was found"),
                 _directives,
                 _tokenizeResult,
-                _unparsedTokens,
                 _unmatchedTokens,
                 _errors,
                 _rawInput);

--- a/src/System.CommandLine/Parsing/Parser.cs
+++ b/src/System.CommandLine/Parsing/Parser.cs
@@ -57,7 +57,6 @@ namespace System.CommandLine.Parsing
             var visitor = new ParseResultVisitor(
                 this,
                 tokenizeResult,
-                operation.UnparsedTokens,
                 operation.UnmatchedTokens,
                 rawInput);
 

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -27,8 +27,8 @@ namespace System.CommandLine.Parsing
         internal static string RemovePrefix(this string alias)
         {
             int prefixLength = GetPrefixLength(alias);
-            return prefixLength > 0 
-                       ? alias.Substring(prefixLength) 
+            return prefixLength > 0
+                       ? alias.Substring(prefixLength)
                        : alias;
         }
 
@@ -36,8 +36,8 @@ namespace System.CommandLine.Parsing
         {
             if (alias[0] == '-')
             {
-                return alias.Length > 1 && alias[1] == '-' 
-                           ? 2 
+                return alias.Length > 1 && alias[1] == '-'
+                           ? 2
                            : 1;
             }
 
@@ -80,7 +80,7 @@ namespace System.CommandLine.Parsing
             var foundEndOfDirectives = !configuration.EnableDirectives;
 
             var argList = NormalizeRootCommand(args, configuration.RootCommand, inferRootCommand);
-            
+
             var tokenList = new List<Token>(argList.Count);
 
             var knownTokens = configuration.RootCommand.ValidTokens();
@@ -88,21 +88,15 @@ namespace System.CommandLine.Parsing
             for (var i = 0; i < argList.Count; i++)
             {
                 var arg = argList[i];
-                
+
                 if (foundDoubleDash)
                 {
-                    if (configuration.EnableLegacyDoubleDashBehavior)
-                    {
-                        tokenList.Add(Unparsed(arg));
-                    }
-                    else
-                    {
-                        tokenList.Add(CommandArgument(arg, currentCommand!));
-                    }
+                    tokenList.Add(CommandArgument(arg, currentCommand!));
+
                     continue;
                 }
 
-                if (!foundDoubleDash && 
+                if (!foundDoubleDash &&
                     arg == "--")
                 {
                     tokenList.Add(DoubleDash());
@@ -181,8 +175,8 @@ namespace System.CommandLine.Parsing
                         }
                     }
                 }
-                else if (arg.TrySplitIntoSubtokens(out var first, out var rest) && 
-                         knownTokens.TryGetValue(first, out var subtoken) && 
+                else if (arg.TrySplitIntoSubtokens(out var first, out var rest) &&
+                         knownTokens.TryGetValue(first, out var subtoken) &&
                          subtoken.Type == TokenType.Option)
                 {
                     tokenList.Add(Option(first, (Option)subtoken.Symbol!));
@@ -198,11 +192,11 @@ namespace System.CommandLine.Parsing
                 {
                     tokenList.Add(Argument(arg));
                 }
-              
+
                 Token Argument(string value) => new(value, TokenType.Argument, default, i);
 
                 Token CommandArgument(string value, Command command) => new(value, TokenType.Argument, command, i);
-                
+
                 Token OptionArgument(string value, Option option) => new(value, TokenType.Argument, option, i);
 
                 Token Command(string value, Command cmd) => new(value, TokenType.Command, cmd, i);
@@ -211,17 +205,15 @@ namespace System.CommandLine.Parsing
 
                 Token DoubleDash() => new("--", TokenType.DoubleDash, default, i);
 
-                Token Unparsed(string value) => new(value, TokenType.Unparsed, default, i);
-
                 Token Directive(string value) => new(value, TokenType.Directive, default, i);
             }
 
             return new TokenizeResult(tokenList, errorList);
 
             bool CanBeUnbundled(string arg)
-                => arg.Length > 2 
+                => arg.Length > 2
                     && arg[0] == '-'
-                    && arg[1]  != '-'// don't check for "--" prefixed args
+                    && arg[1] != '-'// don't check for "--" prefixed args
                     && arg[2] != ':' && arg[2] != '=' // handled by TrySplitIntoSubtokens
                     && !PreviousTokenIsAnOptionExpectingAnArgument(out _);
 
@@ -439,7 +431,7 @@ namespace System.CommandLine.Parsing
 
         private static Dictionary<string, Token> ValidTokens(this Command command)
         {
-            Dictionary<string, Token> tokens = new (StringComparer.Ordinal);
+            Dictionary<string, Token> tokens = new(StringComparer.Ordinal);
 
             foreach (string commandAlias in command.Aliases)
             {

--- a/src/System.CommandLine/Parsing/TokenType.cs
+++ b/src/System.CommandLine/Parsing/TokenType.cs
@@ -29,14 +29,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// A double dash (<c>--</c>) token, which changes the meaning of subsequent tokens.
         /// </summary>
-        /// <see cref="CommandLineConfiguration.EnableLegacyDoubleDashBehavior"/>
         DoubleDash,
-
-        /// <summary>
-        /// A token following <see cref="DoubleDash"/> when <see cref="CommandLineConfiguration.EnableLegacyDoubleDashBehavior"/> is set to <see langword="true"/>.
-        /// </summary>
-        /// <see cref="CommandLineConfiguration.EnableLegacyDoubleDashBehavior"/>
-        Unparsed,
         
         /// <summary>
         /// A directive token.


### PR DESCRIPTION
This PR fixes an issue https://github.com/dotnet/command-line-api/issues/1653