### PR TITLE
Make Token.Symbol property public

### DIFF
--- a/src/System.CommandLine/Parsing/Token.cs
+++ b/src/System.CommandLine/Parsing/Token.cs
@@ -46,7 +46,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The Symbol represented by the token (if any).
         /// </summary>
-        internal Symbol? Symbol { get; }
+        public Symbol? Symbol { get; }
 
         /// <inheritdoc />
         public override bool Equals(object? obj) => obj is Token other && Equals(other);


### PR DESCRIPTION
Motivation:
 - Inside custom middleware, it may be desirable to understand relative order of symbols in the parsed command line (for e.g. in the case of several option types that influence a shared setting and that have a "last option specified wins" semantic).
 - Best way to do understand sequence order is by inspecting the `ParseResult.Tokens` list. This gives `Token`s, which contain embedded symbol references.
 - From there, we'd like to compare the token's `Symbol` directly against predefined `Argument` and `Option` objects to ease identification.
 - Doing this from non-`internal` code today requires something like `if (tokenOfInterest == new Token(tokenOfInterest.Value, TokenType.Option, optionOfInterest)) { /* match */ ... }`, which works because of the overridden `Token.Equals` method.
 - It'd be much easier to say `if (tokenOfInterest.Symbol == optionOfInterest) { /* match */ ... }`
 - No clear reason why `Token.Symbol` needs to be `internal`