### PR TITLE
Componentize pipeline

### DIFF
--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -517,7 +517,7 @@ ERR:
         /// <returns>The same instance of <see cref="CommandLineBuilder"/>.</returns>
         public static CommandLineBuilder UseSuggestDirective(
             this CommandLineBuilder builder)
-            => AddMiddleware<ErrorReportingPipelineComponent>(builder);
+            => AddMiddleware<SuggestPipelineComponent>(builder);
 
         /// <summary>
         /// Configures the application to provide alternative suggestions when a parse error is detected.

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -326,7 +326,9 @@ ERR:
 
             builder.AddMiddleware(async (context, next) =>
             {
-                context = component.RunIfNeeded(context);
+                if (component.ShouldRun(context)) {
+                    context = component.RunIfNeeded(context);
+                }
                 if (!context.TerminationRequested)
                 {
                     await next(context);

--- a/src/System.CommandLine/Builder/ErrorReportingPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/ErrorReportingPipelineComponent.cs
@@ -28,16 +28,20 @@ namespace System.CommandLine.Builder
         public override void Initialize(CommandLineBuilder builder)
         { }
 
+
+        /// <inheritdoc/>
+        public override bool ShouldRun(InvocationContext context)
+            => context.ParseResult.Errors.Count > 0;
+
         /// <inheritdoc/>
         public override InvocationContext RunIfNeeded(InvocationContext context)
         {
-            if (context.ParseResult.Errors.Count > 0)
-            {
-                context.InvocationResult = new ParseErrorResult(ErrorExitCode);
-                context.TerminationRequested = true;
-            }
+
+            context.InvocationResult = new ParseErrorResult(ErrorExitCode);
+            context.TerminationRequested = true;
             return context;
         }
+
     }
 }
 

--- a/src/System.CommandLine/Builder/ErrorReportingPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/ErrorReportingPipelineComponent.cs
@@ -1,0 +1,43 @@
+﻿using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// A sample pipeline component
+    /// </summary>
+    public class ErrorReportingPipelineComponent : PipelineComponent
+    {
+
+        /// <summary>
+        /// Sets the aliases that are available for help, replacing the default aliases.
+        /// </summary>      
+        public int? ErrorExitCode { get; init; }        /// <summary>
+                                                        /// Constructor to provide default values
+                                                        /// </summary>
+        public ErrorReportingPipelineComponent()
+        {
+            MiddlewareOrder = (int)MiddlewareOrderInternal.ParseErrorReporting; // HACK: to allow compiling
+        }
+
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        { }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+        {
+            if (context.ParseResult.Errors.Count > 0)
+            {
+                context.InvocationResult = new ParseErrorResult(ErrorExitCode);
+                context.TerminationRequested = true;
+            }
+            return context;
+        }
+    }
+}
+

--- a/src/System.CommandLine/Builder/HelpBuilderPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/HelpBuilderPipelineComponent.cs
@@ -32,6 +32,10 @@ namespace System.CommandLine.Builder
         }
 
         /// <inheritdoc/>
+        public override bool ShouldRun(InvocationContext context)
+            => false;
+
+        /// <inheritdoc/>
         public override InvocationContext RunIfNeeded(InvocationContext context)
             => context;
 

--- a/src/System.CommandLine/Builder/HelpBuilderPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/HelpBuilderPipelineComponent.cs
@@ -1,0 +1,40 @@
+﻿using System.CommandLine.Binding;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// A sample pipeline component
+    /// </summary>
+    public class HelpBuilderPipelineComponent : PipelineComponent
+    {
+
+        /// <summary>
+        /// Sets the HelpBuilder
+        /// </summary>      
+        public Func<BindingContext, HelpBuilder>? GetHelpBuilder { get; init; }
+
+
+        /// <summary>
+        /// Constructor to provide default values
+        /// </summary>
+        public HelpBuilderPipelineComponent()
+        {
+            MiddlewareOrder = 0; // Not used
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        {
+            if (GetHelpBuilder is not null)
+            { builder.UseHelpBuilderFactory(GetHelpBuilder); }
+        }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+            => context;
+
+    }
+}
+

--- a/src/System.CommandLine/Builder/HelpPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/HelpPipelineComponent.cs
@@ -1,0 +1,71 @@
+﻿using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// Pipeline component that supplies help, using other Help things like HelpBuilderFactory
+    /// </summary>
+    public class HelpPipelineComponent : PipelineComponent
+    {
+        private HelpOption? helpOption;
+
+        /// <summary>
+        /// Sets the aliases that are available for help, replacing the default aliases.
+        /// </summary>
+        public string[]? Aliases { get; init; }
+
+        /// <summary>
+        /// Set ths masimum help width
+        /// </summary>
+        public int? MaxHelpWidth { get; init; }
+
+        /// <summary>
+        /// Allows setting of the help values in the builder object 
+        /// </summary>
+        public Action<HelpContext>? Customize { get; init; }
+
+        /// <summary>
+        /// Constructor to provide default values
+        /// </summary>
+        public HelpPipelineComponent()
+        {
+            MiddlewareOrder = (int)MiddlewareOrderInternal.HelpOption; // HACK: to allow compiling
+        }
+
+
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        {
+            // @jonsequitor This approach to reentrancy does not support new components. Can the builder decide not to rerun, rather than components checking?
+            if (helpOption is null)
+            {
+                helpOption = Aliases == null
+                        ? new HelpOption(() => builder.LocalizationResources)
+                        : new HelpOption(Aliases, () => builder.LocalizationResources);
+                builder.MaxHelpWidth = MaxHelpWidth;
+                builder.HelpOption = helpOption;
+                builder.Command.AddGlobalOption(helpOption);
+                if (Customize is not null)
+                { builder.CustomizeHelpLayout(Customize); }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+        {
+            // @jonsequitor We could avoid a closure if we allowed lookup on types when they are not a plain option/arg. Lookup on VersionOption.
+            if (helpOption is not null && context.ParseResult.FindResultFor(helpOption) is { })
+            {
+                if (context.ParseResult.FindResultFor(helpOption) is { })
+                {
+                    context.InvocationResult = new HelpResult();
+                    context.TerminationRequested = true;
+                }
+            }
+            return context;
+        }
+    }
+}
+

--- a/src/System.CommandLine/Builder/HelpPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/HelpPipelineComponent.cs
@@ -53,16 +53,16 @@ namespace System.CommandLine.Builder
         }
 
         /// <inheritdoc/>
+        public override bool ShouldRun(InvocationContext context)
+            => helpOption is not null && context.ParseResult.FindResultFor(helpOption) is { };
+
+        /// <inheritdoc/>
         public override InvocationContext RunIfNeeded(InvocationContext context)
         {
-            // @jonsequitor We could avoid a closure if we allowed lookup on types when they are not a plain option/arg. Lookup on VersionOption.
             if (helpOption is not null && context.ParseResult.FindResultFor(helpOption) is { })
             {
-                if (context.ParseResult.FindResultFor(helpOption) is { })
-                {
-                    context.InvocationResult = new HelpResult();
-                    context.TerminationRequested = true;
-                }
+                context.InvocationResult = new HelpResult();
+                context.TerminationRequested = true;
             }
             return context;
         }

--- a/src/System.CommandLine/Builder/LocalizationResourcesPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/LocalizationResourcesPipelineComponent.cs
@@ -1,0 +1,40 @@
+﻿using System.CommandLine.Binding;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// A sample pipeline component
+    /// </summary>
+    public class LocalizationResourcesPipelineComponent : PipelineComponent
+    {
+
+        /// <summary>
+        /// Sets the resources used to localize validation error messages.
+        /// </summary>      
+        public LocalizationResources? ValidationMessages  { get; init; }
+
+
+        /// <summary>
+        /// Constructor to provide default values
+        /// </summary>
+        public LocalizationResourcesPipelineComponent()
+        {
+            MiddlewareOrder = 0; // Not used
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        {
+            if (ValidationMessages is not null)
+            { builder.LocalizationResources = ValidationMessages; }
+        }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+            => context;
+
+    }
+}
+

--- a/src/System.CommandLine/Builder/LocalizationResourcesPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/LocalizationResourcesPipelineComponent.cs
@@ -25,6 +25,10 @@ namespace System.CommandLine.Builder
         }
 
         /// <inheritdoc/>
+        /// <inheritdoc/>
+        public override bool ShouldRun(InvocationContext context)
+            => false;
+
         public override void Initialize(CommandLineBuilder builder)
         {
             if (ValidationMessages is not null)

--- a/src/System.CommandLine/Builder/ParseDirectivePipelineComponent.cs
+++ b/src/System.CommandLine/Builder/ParseDirectivePipelineComponent.cs
@@ -1,0 +1,42 @@
+﻿using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// A pipeline component to support a directive that diagrams input
+    /// </summary>
+    public class ParseDirectivePipelineComponent : PipelineComponent
+    {
+
+        /// <summary>
+        /// Sets the aliases that are available for help, replacing the default aliases.
+        /// </summary>      
+        public int? ErrorExitCode { get; init; }
+
+        /// <summary>
+        /// Constructor to provide default values
+        /// </summary>
+        public ParseDirectivePipelineComponent()
+        {
+            MiddlewareOrder = (int)MiddlewareOrderInternal.ParseDirective; // HACK: to allow compiling
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        { }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+        {
+            if (context.ParseResult.Directives.Contains("parse"))
+            {
+                context.InvocationResult = new ParseDirectiveResult(ErrorExitCode);
+                context.TerminationRequested = true;
+            }
+            return context;
+        }
+
+    }
+}
+

--- a/src/System.CommandLine/Builder/ParseDirectivePipelineComponent.cs
+++ b/src/System.CommandLine/Builder/ParseDirectivePipelineComponent.cs
@@ -27,13 +27,14 @@ namespace System.CommandLine.Builder
         { }
 
         /// <inheritdoc/>
+        public override bool ShouldRun(InvocationContext context)
+            => context.ParseResult.Directives.Contains("parse");
+
+        /// <inheritdoc/>
         public override InvocationContext RunIfNeeded(InvocationContext context)
         {
-            if (context.ParseResult.Directives.Contains("parse"))
-            {
-                context.InvocationResult = new ParseDirectiveResult(ErrorExitCode);
-                context.TerminationRequested = true;
-            }
+            context.InvocationResult = new ParseDirectiveResult(ErrorExitCode);
+            context.TerminationRequested = true;
             return context;
         }
 

--- a/src/System.CommandLine/Builder/PipelineComponent.cs
+++ b/src/System.CommandLine/Builder/PipelineComponent.cs
@@ -21,6 +21,14 @@ namespace System.CommandLine.Builder
         /// </summary>
         /// <param name="builder">The current CommandLineBuilder, which offers access to the parser and root cmmand</param>
         public abstract void Initialize(CommandLineBuilder builder);
+
+        /// <summary>
+        /// Indicates whether the component should run based on the ParseResult and other InvocationContext details.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns>Returns `true` if the component should run, otherwise, false.</returns>
+        public abstract bool ShouldRun(InvocationContext context);
+
         /// <summary>
         /// When overridden, this method should test whether the component should run, run it if needed, and 
         /// set the InvocationContext parameters TerminationRequested to true if  this should terminate the pipeline.

--- a/src/System.CommandLine/Builder/PipelineComponent.cs
+++ b/src/System.CommandLine/Builder/PipelineComponent.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// An invocation pipeline middleware commponent. This allows access to middleware components 
+    /// outside the middleware pipeline, without altering the pipeline itself.
+    /// </summary>
+    public abstract class PipelineComponent
+    {
+        /// <summary>
+        /// Allows components to add options and arguments to the Command
+        /// </summary>
+        /// <param name="builder">The current CommandLineBuilder, which offers access to the parser and root cmmand</param>
+        public abstract void Initialize(CommandLineBuilder builder);
+        /// <summary>
+        /// When overridden, this method should test whether the component should run, run it if needed, and 
+        /// set the InvocationContext parameters TerminationRequested to true if  this should terminate the pipeline.
+        /// </summary>
+        /// <param name="context">The current invocation context, offering access to key data like the ParseResult.</param>
+        /// <returns>The same InvocationContext that was received as a parameter.</returns>
+        public abstract InvocationContext RunIfNeeded(InvocationContext context);
+
+        // @jonsequitor How does the internal middleware order work with new components?
+        /// <summary>
+        /// The order in which middleware will be initialized and executed. This is an int as a hack because I cannot figure out how to make the Middleware enums work.
+        /// </summary>
+        public int MiddlewareOrder { get; protected set; } = 0;
+
+
+    }
+}
+

--- a/src/System.CommandLine/Builder/SuggestPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/SuggestPipelineComponent.cs
@@ -1,0 +1,47 @@
+﻿using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+using System.Linq;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// A pipeline component to support a directive that diagrams input
+    /// </summary>
+    public class SuggestPipelineComponent : PipelineComponent
+    {
+        /// <summary>
+        /// Constructor to provide default values
+        /// </summary>
+        public SuggestPipelineComponent()
+        {
+            MiddlewareOrder = (int)MiddlewareOrderInternal.SuggestDirective; // HACK: to allow compiling
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        { }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+        {
+            if (context.ParseResult.Directives.TryGetValues("suggest", out var values))
+            {
+                int position;
+
+                if (values.FirstOrDefault() is { } positionString)
+                {
+                    position = int.Parse(positionString);
+                }
+                else
+                {
+                    position = context.ParseResult.CommandLineText?.Length ?? 0;
+                }
+
+                context.InvocationResult = new SuggestDirectiveResult(position);
+            }
+            return context;
+        }
+
+    }
+}
+

--- a/src/System.CommandLine/Builder/SuggestPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/SuggestPipelineComponent.cs
@@ -9,6 +9,8 @@ namespace System.CommandLine.Builder
     /// </summary>
     public class SuggestPipelineComponent : PipelineComponent
     {
+        private const string directiveName = "suggest";
+
         /// <summary>
         /// Constructor to provide default values
         /// </summary>
@@ -22,21 +24,17 @@ namespace System.CommandLine.Builder
         { }
 
         /// <inheritdoc/>
+        public override bool ShouldRun(InvocationContext context)
+            => context.ParseResult.Directives.Contains(directiveName);
+
+        /// <inheritdoc/>
         public override InvocationContext RunIfNeeded(InvocationContext context)
         {
-            if (context.ParseResult.Directives.TryGetValues("suggest", out var values))
+            if (context.ParseResult.Directives.TryGetValues(directiveName, out var values))
             {
-                int position;
-
-                if (values.FirstOrDefault() is { } positionString)
-                {
-                    position = int.Parse(positionString);
-                }
-                else
-                {
-                    position = context.ParseResult.CommandLineText?.Length ?? 0;
-                }
-
+                int position = values.FirstOrDefault() is { } positionString 
+                    ? int.Parse(positionString) 
+                    : context.ParseResult.CommandLineText?.Length ?? 0;
                 context.InvocationResult = new SuggestDirectiveResult(position);
 
                 context.TerminationRequested = true;

--- a/src/System.CommandLine/Builder/SuggestPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/SuggestPipelineComponent.cs
@@ -38,6 +38,8 @@ namespace System.CommandLine.Builder
                 }
 
                 context.InvocationResult = new SuggestDirectiveResult(position);
+
+                context.TerminationRequested = true;
             }
             return context;
         }

--- a/src/System.CommandLine/Builder/TokenReplacerPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/TokenReplacerPipelineComponent.cs
@@ -31,6 +31,10 @@ namespace System.CommandLine.Builder
         }
 
         /// <inheritdoc/>
+        public override bool ShouldRun(InvocationContext context)
+            => false;
+
+        /// <inheritdoc/>
         public override InvocationContext RunIfNeeded(InvocationContext context)
             => context;
 

--- a/src/System.CommandLine/Builder/TokenReplacerPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/TokenReplacerPipelineComponent.cs
@@ -1,0 +1,39 @@
+﻿using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// A sample pipeline component
+    /// </summary>
+    public class TokenReplacerPipelineComponent : PipelineComponent
+    {
+
+        /// <summary>
+        /// Sets the HelpBuilder
+        /// </summary>      
+        public TryReplaceToken? TokenReplacer { get; init; }
+
+
+        /// <summary>
+        /// Constructor to provide default values
+        /// </summary>
+        public TokenReplacerPipelineComponent()
+        {
+            MiddlewareOrder = 0; // Not used
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        {
+            if (TokenReplacer is not null)
+            { builder.TokenReplacer = TokenReplacer; }
+        }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+            => context;
+
+    }
+}
+

--- a/src/System.CommandLine/Builder/TypoCorrectionsPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/TypoCorrectionsPipelineComponent.cs
@@ -28,16 +28,15 @@ namespace System.CommandLine.Builder
         { }
 
         /// <inheritdoc/>
+        public override bool ShouldRun(InvocationContext context)
+            => context.ParseResult.CommandResult.Command.TreatUnmatchedTokensAsErrors &&
+                        context.ParseResult.UnmatchedTokens.Count > 0;
+
+        /// <inheritdoc/>
         public override InvocationContext RunIfNeeded(InvocationContext context)
         {
-            if (context.ParseResult.CommandResult.Command.TreatUnmatchedTokensAsErrors &&
-                        context.ParseResult.UnmatchedTokens.Count > 0)
-            {
-                var typoCorrection = new TypoCorrection(MaxLevenshteinDistance);
-
-                typoCorrection.ProvideSuggestions(context.ParseResult, context.Console);
-
-            }
+            var typoCorrection = new TypoCorrection(MaxLevenshteinDistance);
+            typoCorrection.ProvideSuggestions(context.ParseResult, context.Console);
             return context;
         }
 

--- a/src/System.CommandLine/Builder/TypoCorrectionsPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/TypoCorrectionsPipelineComponent.cs
@@ -1,0 +1,46 @@
+﻿using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+using System.Linq;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// A pipeline component to support a directive that diagrams input
+    /// </summary>
+    public class TypoCorrectionsPipelineComponent : PipelineComponent
+    {
+        /// <summary>
+        /// Sets the LevenshteinDistance which determines how close matches should be.
+        /// </summary>      
+        public int MaxLevenshteinDistance { get; init; } = 3;
+
+
+        /// <summary>
+        /// Constructor to provide default values
+        /// </summary>
+        public TypoCorrectionsPipelineComponent()
+        {
+            MiddlewareOrder = (int)MiddlewareOrderInternal.TypoCorrection; // HACK: to allow compiling
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        { }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+        {
+            if (context.ParseResult.CommandResult.Command.TreatUnmatchedTokensAsErrors &&
+                        context.ParseResult.UnmatchedTokens.Count > 0)
+            {
+                var typoCorrection = new TypoCorrection(MaxLevenshteinDistance);
+
+                typoCorrection.ProvideSuggestions(context.ParseResult, context.Console);
+
+            }
+            return context;
+        }
+
+    }
+}
+

--- a/src/System.CommandLine/Builder/VersionPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/VersionPipelineComponent.cs
@@ -28,6 +28,7 @@ namespace System.CommandLine.Builder
 
 
         /// <inheritdoc/>
+        /// <inheritdoc/>
         public override void Initialize(CommandLineBuilder builder)
         {
             // @jonsequitor This approach to reentrancy does not support new components. Can the builder decide not to rerun, rather than components checking?
@@ -41,22 +42,21 @@ namespace System.CommandLine.Builder
             }
         }
 
+        public override bool ShouldRun(InvocationContext context)
+            => versionOption is not null && context.ParseResult.FindResultFor(versionOption) is { };
+
         /// <inheritdoc/>
         public override InvocationContext RunIfNeeded(InvocationContext context)
         {
-            // @jonsequitor We could avoid a closure if we allowed lookup on types when they are not a plain option/arg. Lookup on VersionOption.
-            if (versionOption is not null && context.ParseResult.FindResultFor(versionOption) is { })
+            if (context.ParseResult.Errors.Any(e => e.SymbolResult?.Symbol is VersionOption))
             {
-                if (context.ParseResult.Errors.Any(e => e.SymbolResult?.Symbol is VersionOption))
-                {
-                    context.InvocationResult = new ParseErrorResult(null);
-                }
-                else
-                {
-                    context.Console.Out.WriteLine(_assemblyVersion.Value);
-                }
-                context.TerminationRequested = true;
+                context.InvocationResult = new ParseErrorResult(null);
             }
+            else
+            {
+                context.Console.Out.WriteLine(_assemblyVersion.Value);
+            }
+            context.TerminationRequested = true;
             return context;
         }
 

--- a/src/System.CommandLine/Builder/VersionPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/VersionPipelineComponent.cs
@@ -1,0 +1,83 @@
+﻿using System.CommandLine.Help;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace System.CommandLine.Builder
+{
+    /// <summary>
+    /// A sample pipeline component
+    /// </summary>
+    public class VersionPipelineComponent : PipelineComponent
+    {
+        private VersionOption? versionOption;
+
+        /// <summary>
+        /// Sets the aliases that are available for help, replacing the default aliases.
+        /// </summary>      
+        public string[]? Aliases { get; init; }
+
+        /// <summary>
+        /// Constructor to provide default values
+        /// </summary>
+        public VersionPipelineComponent()
+        {
+            MiddlewareOrder = (int)MiddlewareOrderInternal.VersionOption; // HACK: to allow compiling
+        }
+
+
+        /// <inheritdoc/>
+        public override void Initialize(CommandLineBuilder builder)
+        {
+            // @jonsequitor This approach to reentrancy does not support new components. Can the builder decide not to rerun, rather than components checking?
+            if (builder.VersionOption is null)
+            {
+                versionOption = Aliases == null
+                        ? new VersionOption(builder)
+                        : new VersionOption(builder);
+                builder.VersionOption = versionOption;
+                builder.Command.AddOption(versionOption);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override InvocationContext RunIfNeeded(InvocationContext context)
+        {
+            // @jonsequitor We could avoid a closure if we allowed lookup on types when they are not a plain option/arg. Lookup on VersionOption.
+            if (versionOption is not null && context.ParseResult.FindResultFor(versionOption) is { })
+            {
+                if (context.ParseResult.Errors.Any(e => e.SymbolResult?.Symbol is VersionOption))
+                {
+                    context.InvocationResult = new ParseErrorResult(null);
+                }
+                else
+                {
+                    context.Console.Out.WriteLine(_assemblyVersion.Value);
+                }
+                context.TerminationRequested = true;
+            }
+            return context;
+        }
+
+
+        private static readonly Lazy<string> _assemblyVersion =
+            new(() =>
+            {
+                var assembly = RootCommand.GetAssembly();
+
+                var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+                if (assemblyVersionAttribute is null)
+                {
+                    return assembly.GetName().Version?.ToString() ?? "";
+                }
+                else
+                {
+                    return assemblyVersionAttribute.InformationalVersion;
+                }
+
+            });
+    }
+}
+

--- a/src/System.CommandLine/Builder/VersionPipelineComponent.cs
+++ b/src/System.CommandLine/Builder/VersionPipelineComponent.cs
@@ -35,7 +35,7 @@ namespace System.CommandLine.Builder
             {
                 versionOption = Aliases == null
                         ? new VersionOption(builder)
-                        : new VersionOption(builder);
+                        : new VersionOption(Aliases, builder);
                 builder.VersionOption = versionOption;
                 builder.Command.AddOption(versionOption);
             }

--- a/src/System.CommandLine/Invocation/InvocationContext.cs
+++ b/src/System.CommandLine/Invocation/InvocationContext.cs
@@ -108,6 +108,11 @@ namespace System.CommandLine.Invocation
         public IInvocationResult? InvocationResult { get; set; }
 
         /// <summary>
+        /// When set to true, additional steps in a pipeline are not executed. Most components are terminal, so this should generally be set to true if a component executes.
+        /// </summary>
+        public bool TerminationRequested { get; set; }
+
+        /// <summary>
         /// Gets a cancellation token that can be used to check if cancellation has been requested.
         /// </summary>
         public CancellationToken GetCancellationToken() => _token;
@@ -118,6 +123,10 @@ namespace System.CommandLine.Invocation
             source?.Cancel();
         }
 
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="token"></param>
         public void LinkToken(CancellationToken token)
         {
             _registrations.AddLast(token.Register(Cancel));


### PR DESCRIPTION
Moved the work of pipeline elements into separate classes so the work could be accessed outside the pipeline. 

This is a draft because I am having trouble with tests on my local machine.

This is currently a refactoring PR to show that we could componentize the pipeline with no breaking changes. 

The failing tests are 👍 

* API Compatibility - right, it has not been reviewed and this is a draft.
* Generation? - It looks like this is an engineering break?
