### PR TITLE
Localizing required option not provided message

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -188,6 +188,7 @@ System.CommandLine
     public System.String NoArgumentProvided(System.CommandLine.Parsing.SymbolResult symbolResult)
     public System.String RequiredArgumentMissing(System.CommandLine.Parsing.SymbolResult symbolResult)
     public System.String RequiredCommandWasNotProvided()
+    public System.String RequiredOptionWasNotProvided(Option option)
     public System.String ResponseFileNotFound(System.String filePath)
     public System.String SuggestionsTokenNotMatched(System.String token)
     public System.String UnrecognizedArgument(System.String unrecognizedArg, System.Collections.Generic.IReadOnlyCollection<System.String> allowedValues)

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -43,7 +43,25 @@ namespace System.CommandLine.Tests
                   .ContainSingle()
                   .Which.Message.Should().Be("Option '--i-must-be-set' is required.");
         }
-        
+
+        [Fact] 
+        public void When_a_required_global_option_has_multiple_aliases_the_error_message_uses_longest()
+        {
+            var rootCommand = new RootCommand();
+            var requiredOption = new Option<bool>(new[] { "-i", "--i-must-be-set" })
+            {
+                IsRequired = true
+            };
+            rootCommand.AddGlobalOption(requiredOption);
+
+            var result = rootCommand.Parse("");
+
+            result.Errors
+                  .Should()
+                  .ContainSingle()
+                  .Which.Message.Should().Be("Option '--i-must-be-set' is required.");
+        }
+
         [Fact]
         public void When_a_required_global_option_is_present_on_child_of_command_it_was_added_to_it_does_not_result_in_an_error()
         {

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -177,6 +177,30 @@ namespace System.CommandLine.Tests
                   .Be("Option '-x' is required.");
         }
 
+        [Fact]
+        public void When_a_required_option_has_multiple_aliases_the_error_message_uses_longest()
+        {
+            var command = new Command("command")
+            {
+                new Option<string>(new[] {"-x", "--xray" })
+                {
+                    IsRequired = true
+                }
+            };
+
+            var result = command.Parse("");
+
+            result.Errors
+                  .Should()
+                  .HaveCount(1)
+                  .And
+                  .Contain(e => e.SymbolResult.Symbol == command)
+                  .Which
+                  .Message
+                  .Should()
+                  .Be("Option '--xray' is required.");
+        }
+
         [Theory]
         [InlineData("subcommand -x arg")]
         [InlineData("-x arg subcommand")]

--- a/src/System.CommandLine/LocalizationResources.cs
+++ b/src/System.CommandLine/LocalizationResources.cs
@@ -99,6 +99,12 @@ namespace System.CommandLine
             GetResourceString(Properties.Resources.RequiredCommandWasNotProvided);
 
         /// <summary>
+        ///   Interpolates values into a localized string similar to Option '{0}' is required.
+        /// </summary>
+        public virtual string RequiredOptionWasNotProvided(Option option) =>
+            GetResourceString(Properties.Resources.RequiredOptionWasNotProvided, option.Aliases.OrderByDescending(x => x.Length).First());
+
+        /// <summary>
         ///   Interpolates values into a localized string similar to Argument &apos;{0}&apos; not recognized. Must be one of:{1}.
         /// </summary>
         public virtual string UnrecognizedArgument(string unrecognizedArg, IReadOnlyCollection<string> allowedValues) =>

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -360,8 +360,9 @@ namespace System.CommandLine.Parsing
                         {
                             AddErrorToResult(
                                 _innermostCommandResult,
-                                new ParseError($"Option '{option.Aliases.First()}' is required.",
-                                               _innermostCommandResult));
+                                new ParseError(
+                                    _rootCommandResult.LocalizationResources.RequiredOptionWasNotProvided(option),
+                                    _innermostCommandResult));
                         }
                     }
                 }

--- a/src/System.CommandLine/Properties/Resources.Designer.cs
+++ b/src/System.CommandLine/Properties/Resources.Designer.cs
@@ -349,6 +349,15 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Option &apos;{0}&apos; is required..
+        /// </summary>
+        internal static string RequiredOptionWasNotProvided {
+            get {
+                return ResourceManager.GetString("RequiredOptionWasNotProvided", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Response file not found &apos;{0}&apos;..
         /// </summary>
         internal static string ResponseFileNotFound {

--- a/src/System.CommandLine/Properties/Resources.resx
+++ b/src/System.CommandLine/Properties/Resources.resx
@@ -231,4 +231,7 @@
   <data name="ArgumentConversionCannotParseForOption" xml:space="preserve">
     <value>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</value>
   </data>
+  <data name="RequiredOptionWasNotProvided" xml:space="preserve">
+    <value>Option '{0}' is required.</value>
+  </data>
 </root>

--- a/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.de.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.de.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.es.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.es.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.it.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.it.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
@@ -162,6 +162,11 @@
         <target state="new">Required command was not provided.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredOptionWasNotProvided">
+        <source>Option '{0}' is required.</source>
+        <target state="new">Option '{0}' is required.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
         <target state="new">Response file not found '{0}'.</target>


### PR DESCRIPTION
There is a slight behavior change for options that have multiple aliases as it will select the longest alias. This is to make it more consistent with how the Name property on the option works.