### PR TITLE
Fix IsOptional method for arguments

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -250,6 +250,34 @@ namespace System.CommandLine.Tests.Help
         }
 
         [Fact]
+        public void Usage_section_for_subcommand_shows_arguments_for_subcommand_and_parent_command_not_optional()
+        {
+            var arg = new Argument<string[]>
+            {
+                Name = "shared-args",
+                Arity = ArgumentArity.OneOrMore
+            };
+
+            var inner = new Command("inner", "command help")
+            {
+                arg
+            };
+            _ = new Command("outer", "command help")
+            {
+                inner,
+                arg
+            };
+
+            _helpBuilder.Write(inner, _console);
+
+            var expected =
+                $"Usage:{NewLine}" +
+                $"{_indentation}outer <shared-args>... inner <shared-args>...";
+
+            _console.ToString().Should().Contain(expected);
+        }
+
+        [Fact]
         public void Usage_section_does_not_show_additional_arguments_when_TreatUnmatchedTokensAsErrors_is_not_specified()
         {
             var command = new Command(

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -960,7 +960,38 @@ namespace System.CommandLine.Tests.Help
             _console.ToString().Should().Contain(expected);
         }
 
+        [Fact]
+        public void Command_shared_arguments_with_one_or_more_arity_are_required()
+        {
+            var arg = new Argument<string[]>
+            {
+                Name = "shared-args",
+                Arity = ArgumentArity.OneOrMore
+            };
 
+            var inner = new Command("inner", "command help")
+            {
+                arg
+            };
+            _ = new Command("outer", "command help")
+            {
+                inner,
+                arg
+            };
+            _ = new Command("unused", "command help")
+            {
+                arg
+            };
+
+            _helpBuilder.Write(inner, _console);
+
+            var expected =
+                $"Usage:{NewLine}" +
+                $"{_indentation}outer <shared-args>... inner <shared-args>...";
+
+            _console.ToString().Should().Contain(expected);
+        }
+        
         #endregion Arguments
 
         #region Options

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -933,7 +933,7 @@ namespace System.CommandLine.Tests.Help
         }
 
         [Fact]
-        public void Command_shared_arguments_with_one_or_more_arity_are_required()
+        public void Command_shared_arguments_with_one_or_more_arity_are_displayed_as_being_required()
         {
             var arg = new Argument<string[]>
             {

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -250,34 +250,6 @@ namespace System.CommandLine.Tests.Help
         }
 
         [Fact]
-        public void Usage_section_for_subcommand_shows_arguments_for_subcommand_and_parent_command_not_optional()
-        {
-            var arg = new Argument<string[]>
-            {
-                Name = "shared-args",
-                Arity = ArgumentArity.OneOrMore
-            };
-
-            var inner = new Command("inner", "command help")
-            {
-                arg
-            };
-            _ = new Command("outer", "command help")
-            {
-                inner,
-                arg
-            };
-
-            _helpBuilder.Write(inner, _console);
-
-            var expected =
-                $"Usage:{NewLine}" +
-                $"{_indentation}outer <shared-args>... inner <shared-args>...";
-
-            _console.ToString().Should().Contain(expected);
-        }
-
-        [Fact]
         public void Usage_section_does_not_show_additional_arguments_when_TreatUnmatchedTokensAsErrors_is_not_specified()
         {
             var command = new Command(

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -325,12 +325,8 @@ namespace System.CommandLine.Help
             {
                 StringBuilderPool.Default.ReturnToPool(sb);
             }
-
-            bool IsMultiParented(Argument a) =>
-                a.FirstParent is not null && a.FirstParent.Next is not null;
-
+            
             bool IsOptional(Argument argument) =>
-                IsMultiParented(argument) ||
                 argument.Arity.MinimumNumberOfValues == 0;
         }
 


### PR DESCRIPTION
Fixes #1748 

This bug is causing confusion on what it optional and what it not. Reusing args between commands has nothing to do with them being optional or required.