### PR TITLE
When an explicit max width is specified don't override with the terminal's width

### DIFF
--- a/src/System.CommandLine/CommandLineConfiguration.cs
+++ b/src/System.CommandLine/CommandLineConfiguration.cs
@@ -55,7 +55,7 @@ namespace System.CommandLine
         internal static HelpBuilder DefaultHelpBuilderFactory(BindingContext context, int? requestedMaxWidth = null)
         {
             int maxWidth = requestedMaxWidth ?? int.MaxValue;
-            if (context.Console is SystemConsole systemConsole)
+            if (requestedMaxWidth is null && context.Console is SystemConsole systemConsole)
             {
                 maxWidth = systemConsole.GetWindowWidth();
             }


### PR DESCRIPTION
Previously when outputting the system console it would override the requested maxWidth.
This change respects the requested max width when it is specified using the CommandLineBuilder.
```cs
var parser = new CommandLineBuilder(command)
                .UseHelp(maxWidth: 30)
                .UseDefaults()
                .Build();
```