### PR TITLE
Rename getDefaultValue to defaultValueFactory in Argument and Option

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -9,14 +9,14 @@ System.CommandLine
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
     public System.Object GetDefaultValue()
     public System.Void SetDefaultValue(System.Object value)
-    public System.Void SetDefaultValueFactory(System.Func<System.Object> getDefaultValue)
-    public System.Void SetDefaultValueFactory(System.Func<System.CommandLine.Parsing.ArgumentResult,System.Object> getDefaultValue)
+    public System.Void SetDefaultValueFactory(System.Func<System.Object> defaultValueFactory)
+    public System.Void SetDefaultValueFactory(System.Func<System.CommandLine.Parsing.ArgumentResult,System.Object> defaultValueFactory)
     public System.String ToString()
   public class Argument<T> : Argument, IValueDescriptor<T>, System.CommandLine.Binding.IValueDescriptor, System.CommandLine.Completions.ICompletionSource
     .ctor()
     .ctor(System.String name, System.String description = null)
-    .ctor(System.String name, Func<T> getDefaultValue, System.String description = null)
-    .ctor(Func<T> getDefaultValue)
+    .ctor(System.String name, Func<T> defaultValueFactory, System.String description = null)
+    .ctor(Func<T> defaultValueFactory)
     .ctor(System.String name, Func<System.CommandLine.Parsing.ArgumentResult,T> parse, System.Boolean isDefault = False, System.String description = null)
     .ctor(Func<System.CommandLine.Parsing.ArgumentResult,T> parse, System.Boolean isDefault = False)
     public System.Type ValueType { get; }
@@ -198,14 +198,14 @@ System.CommandLine
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
     public System.Boolean HasAliasIgnoringPrefix(System.String alias)
     public System.Void SetDefaultValue(System.Object value)
-    public System.Void SetDefaultValueFactory(System.Func<System.Object> getDefaultValue)
+    public System.Void SetDefaultValueFactory(System.Func<System.Object> defaultValueFactory)
   public class Option<T> : Option, IValueDescriptor<T>, System.CommandLine.Binding.IValueDescriptor, System.CommandLine.Completions.ICompletionSource
     .ctor(System.String name, System.String description = null)
     .ctor(System.String[] aliases, System.String description = null)
     .ctor(System.String name, Func<System.CommandLine.Parsing.ArgumentResult,T> parseArgument, System.Boolean isDefault = False, System.String description = null)
     .ctor(System.String[] aliases, Func<System.CommandLine.Parsing.ArgumentResult,T> parseArgument, System.Boolean isDefault = False, System.String description = null)
-    .ctor(System.String name, Func<T> getDefaultValue, System.String description = null)
-    .ctor(System.String[] aliases, Func<T> getDefaultValue, System.String description = null)
+    .ctor(System.String name, Func<T> defaultValueFactory, System.String description = null)
+    .ctor(System.String[] aliases, Func<T> defaultValueFactory, System.String description = null)
     public ArgumentArity Arity { get; set; }
   public static class OptionExtensions
     public static TOption AddCompletions<TOption>(this TOption option, System.String[] values)

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -97,7 +97,7 @@ namespace System.CommandLine.Suggest
 
         private Option<int> PositionOption { get; } = new(new[] { "-p", "--position" },
                                                           description: "The current character position on the command line",
-                                                          getDefaultValue: () => short.MaxValue);
+                                                          defaultValueFactory: () => short.MaxValue);
 
         private Command RegisterCommand { get; }
 

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -189,7 +189,7 @@ namespace System.CommandLine.Tests
         {
             var parser = new RootCommand
             {
-                new Option<string>("--apple", getDefaultValue: () => "cortland"),
+                new Option<string>("--apple", defaultValueFactory: () => "cortland"),
                 new Option<string>("--banana"),
                 new Option<string>("--cherry")
             };

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
@@ -35,7 +35,7 @@ namespace System.CommandLine.Tests.Help
             [Fact]
             public void Option_can_customize_default_value()
             {
-                var option = new Option<string>("--the-option", getDefaultValue: () => "not 42");
+                var option = new Option<string>("--the-option", defaultValueFactory: () => "not 42");
                 var command = new Command("the-command", "command help")
                 {
                     option
@@ -188,7 +188,7 @@ namespace System.CommandLine.Tests.Help
             [Fact]
             public void Command_arguments_can_customize_second_column_text()
             {
-                var argument = new Argument<string>("some-arg", description: "Default description", getDefaultValue: () => "not 42");
+                var argument = new Argument<string>("some-arg", description: "Default description", defaultValueFactory: () => "not 42");
                 var command = new Command("the-command", "command help")
                 {
                     argument
@@ -207,7 +207,7 @@ namespace System.CommandLine.Tests.Help
             [Fact]
             public void Command_arguments_can_customize_default_value()
             {
-                var argument = new Argument<string>("some-arg", getDefaultValue: () => "not 42");
+                var argument = new Argument<string>("some-arg", defaultValueFactory: () => "not 42");
                 var command = new Command("the-command", "command help")
                 {
                     argument

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -921,7 +921,7 @@ namespace System.CommandLine.Tests.Help
             var command = new Command("the-command", "command help")
             {
                 new Argument<List<int>>("filter-size",
-                    getDefaultValue: () => new List<int>() { 0, 2, 4 })
+                    defaultValueFactory: () => new List<int>() { 0, 2, 4 })
             };
 
             _helpBuilder.Write(command, _console);
@@ -1149,7 +1149,7 @@ namespace System.CommandLine.Tests.Help
             var command = new Command("test-command", "Help text for the command")
             {
                 new Option<string>("-x", "Option with a short description"),
-                new Option<string>(new[] { "-a", "--aaa" }, description: longOptionText, getDefaultValue: () => "the quick brown fox jumps over the lazy dog"),
+                new Option<string>(new[] { "-a", "--aaa" }, description: longOptionText, defaultValueFactory: () => "the quick brown fox jumps over the lazy dog"),
                 new Option<string>("-y", "Option with a short description"),
             };
 
@@ -1313,7 +1313,7 @@ namespace System.CommandLine.Tests.Help
         {
             var command = new Command("the-command", "command help")
             {
-                new Option<string>(new[] { "-arg"}, getDefaultValue: () => "the-arg-value")
+                new Option<string>(new[] { "-arg"}, defaultValueFactory: () => "the-arg-value")
                 {
                     ArgumentHelpName = "the-arg"
                 }
@@ -1335,7 +1335,7 @@ namespace System.CommandLine.Tests.Help
             {
                 new Option<List<int>>(
                     "--filter-size",
-                    getDefaultValue: () => new List<int> { 0, 2, 4 })
+                    defaultValueFactory: () => new List<int> { 0, 2, 4 })
                 { }
             };
 
@@ -1354,7 +1354,7 @@ namespace System.CommandLine.Tests.Help
             {
                 new Option<string[]>(
                     "--prefixes",
-                    getDefaultValue: () => new[]{ "^(TODO|BUG)", "^HACK" })
+                    defaultValueFactory: () => new[]{ "^(TODO|BUG)", "^HACK" })
                 { }
             };
 

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -252,7 +252,7 @@ namespace System.CommandLine.Tests
             public void Unsatisfied_subsequent_argument_with_min_arity_1_parses_as_default_value()
             {
                 Argument<string> arg1 = new(name: "arg1");
-                Argument<string> arg2 = new(name: "arg2", getDefaultValue: () => "the-default");
+                Argument<string> arg2 = new(name: "arg2", defaultValueFactory: () => "the-default");
 
                 var rootCommand = new RootCommand
                 {

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1556,7 +1556,7 @@ namespace System.CommandLine.Tests
         [InlineData("--exec-prefix=", "")]
         public void Parsed_value_of_empty_string_arg_is_an_empty_string(string arg1, string arg2)
         {
-            var option = new Option<string>("--exec-prefix", getDefaultValue: () => "/usr/local");
+            var option = new Option<string>("--exec-prefix", defaultValueFactory: () => "/usr/local");
             var rootCommand = new RootCommand
             {
                 option

--- a/src/System.CommandLine.Tests/VersionOptionTests.cs
+++ b/src/System.CommandLine.Tests/VersionOptionTests.cs
@@ -93,7 +93,7 @@ namespace System.CommandLine.Tests
         {
             var rootCommand = new RootCommand
             {
-                new Argument<bool>("x", getDefaultValue: () => true)
+                new Argument<bool>("x", defaultValueFactory: () => true)
             };
             rootCommand.SetHandler(() => { });
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -144,26 +144,26 @@ namespace System.CommandLine
         /// <summary>
         /// Sets a delegate to invoke when the default value for the argument is required.
         /// </summary>
-        /// <param name="getDefaultValue">The delegate to invoke to return the default value.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="getDefaultValue"/> is null.</exception>
-        public void SetDefaultValueFactory(Func<object?> getDefaultValue)
+        /// <param name="defaultValueFactory">The delegate to invoke to return the default value.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="defaultValueFactory"/> is null.</exception>
+        public void SetDefaultValueFactory(Func<object?> defaultValueFactory)
         {
-            if (getDefaultValue is null)
+            if (defaultValueFactory is null)
             {
-                throw new ArgumentNullException(nameof(getDefaultValue));
+                throw new ArgumentNullException(nameof(defaultValueFactory));
             }
 
-            SetDefaultValueFactory(_ => getDefaultValue());
+            SetDefaultValueFactory(_ => defaultValueFactory());
         }
         
         /// <summary>
         /// Sets a delegate to invoke when the default value for the argument is required.
         /// </summary>
-        /// <param name="getDefaultValue">The delegate to invoke to return the default value.</param>
+        /// <param name="defaultValueFactory">The delegate to invoke to return the default value.</param>
         /// <remarks>In this overload, the <see cref="ArgumentResult"/> is provided to the delegate.</remarks>
-        public void SetDefaultValueFactory(Func<ArgumentResult, object?> getDefaultValue)
+        public void SetDefaultValueFactory(Func<ArgumentResult, object?> defaultValueFactory)
         {
-            _defaultValueFactory = getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue));
+            _defaultValueFactory = defaultValueFactory ?? throw new ArgumentNullException(nameof(defaultValueFactory));
         }
 
         /// <summary>

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -29,35 +29,35 @@ namespace System.CommandLine
         /// Initializes a new instance of the Argument class.
         /// </summary>
         /// <param name="name">The name of the argument.</param>
-        /// <param name="getDefaultValue">The delegate to invoke to return the default value.</param>
+        /// <param name="defaultValueFactory">The delegate to invoke to return the default value.</param>
         /// <param name="description">The description of the argument, shown in help.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="getDefaultValue"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="defaultValueFactory"/> is null.</exception>
         public Argument(
             string name, 
-            Func<T> getDefaultValue, 
+            Func<T> defaultValueFactory, 
             string? description = null) : this(name, description)
         {
-            if (getDefaultValue is null)
+            if (defaultValueFactory is null)
             {
-                throw new ArgumentNullException(nameof(getDefaultValue));
+                throw new ArgumentNullException(nameof(defaultValueFactory));
             }
 
-            SetDefaultValueFactory(() => getDefaultValue());
+            SetDefaultValueFactory(() => defaultValueFactory());
         }
 
         /// <summary>
         /// Initializes a new instance of the Argument class.
         /// </summary>
-        /// <param name="getDefaultValue">The delegate to invoke to return the default value.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="getDefaultValue"/> is null.</exception>
-        public Argument(Func<T> getDefaultValue) : this()
+        /// <param name="defaultValueFactory">The delegate to invoke to return the default value.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="defaultValueFactory"/> is null.</exception>
+        public Argument(Func<T> defaultValueFactory) : this()
         {
-            if (getDefaultValue is null)
+            if (defaultValueFactory is null)
             {
-                throw new ArgumentNullException(nameof(getDefaultValue));
+                throw new ArgumentNullException(nameof(defaultValueFactory));
             }
 
-            SetDefaultValueFactory(() => getDefaultValue());
+            SetDefaultValueFactory(() => defaultValueFactory());
         }
 
         /// <summary>

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -152,10 +152,10 @@ namespace System.CommandLine
         /// <summary>
         /// Sets a delegate to invoke when the default value for the option is required.
         /// </summary>
-        /// <param name="getDefaultValue">The delegate to invoke to return the default value.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="getDefaultValue"/> is null.</exception>
-        public void SetDefaultValueFactory(Func<object?> getDefaultValue) =>
-            Argument.SetDefaultValueFactory(getDefaultValue);
+        /// <param name="defaultValueFactory">The delegate to invoke to return the default value.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="defaultValueFactory"/> is null.</exception>
+        public void SetDefaultValueFactory(Func<object?> defaultValueFactory) =>
+            Argument.SetDefaultValueFactory(defaultValueFactory);
 
         /// <summary>
         /// Gets a value that indicates whether multiple argument tokens are allowed for each option identifier token.

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -46,18 +46,18 @@ namespace System.CommandLine
         /// <inheritdoc/>
         public Option(
             string name,
-            Func<T> getDefaultValue,
+            Func<T> defaultValueFactory,
             string? description = null) 
             : base(name, description, 
-                  new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))))
+                  new Argument<T>(defaultValueFactory ?? throw new ArgumentNullException(nameof(defaultValueFactory))))
         { }
 
         /// <inheritdoc/>
         public Option(
             string[] aliases,
-            Func<T> getDefaultValue,
+            Func<T> defaultValueFactory,
             string? description = null)
-            : base(aliases, description, new Argument<T>(getDefaultValue ?? throw new ArgumentNullException(nameof(getDefaultValue))))
+            : base(aliases, description, new Argument<T>(defaultValueFactory ?? throw new ArgumentNullException(nameof(defaultValueFactory))))
         {
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/command-line-api/issues/1894