### PR TITLE
default completions should be used only when user did not provide any

### DIFF
--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -888,7 +888,25 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Default_completions_can_be_appended_to()
+        public void Default_completions_are_not_used_when_user_provides_their_own()
+        {
+            var argument = new Argument<DayOfWeek>();
+            argument.Completions.Add(new[] { "mon", "tues", "wed", "thur", "fri", "sat", "sun" });
+            var command = new Command("the-command")
+            {
+                argument
+            };
+
+            var completions = command.Parse("the-command s")
+                                     .GetCompletions();
+
+            completions.Select(item => item.Label)
+                       .Should()
+                       .BeEquivalentTo("sat", "sun", "tues");
+        }
+
+        [Fact]
+        public void Default_completions_can_not_be_appended_to()
         {
             var command = new Command("the-command")
             {
@@ -906,13 +924,8 @@ namespace System.CommandLine.Tests
                 .Should()
                 .BeEquivalentTo(
                     "sat",
-                    nameof(DayOfWeek.Saturday),
                     "sun", 
-                    nameof(DayOfWeek.Sunday),
-                    "tues",
-                    nameof(DayOfWeek.Tuesday),
-                    nameof(DayOfWeek.Thursday),
-                    nameof(DayOfWeek.Wednesday));
+                    "tues");
         }
 
         [Fact]

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -74,11 +74,7 @@ namespace System.CommandLine
         /// <summary>
         /// Gets the collection of completion sources for the argument.
         /// </summary>
-        public ICollection<ICompletionSource> Completions =>
-            _completions ??= new ()
-            {
-                CompletionSource.ForType(ValueType)
-            };
+        public ICollection<ICompletionSource> Completions => _completions ??= new();
 
         /// <summary>
         /// Gets or sets the <see cref="Type" /> that the argument token(s) will be converted to.
@@ -191,7 +187,12 @@ namespace System.CommandLine
         /// <inheritdoc />
         public override IEnumerable<CompletionItem> GetCompletions(CompletionContext context)
         {
-            return Completions
+            var completions = _completions ?? new()
+            {
+                CompletionSource.ForType(ValueType)
+            };
+
+            return completions
                    .SelectMany(source => source.GetCompletions(context))
                    .Distinct()
                    .OrderBy(c => c.SortText, StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
My proposal for fixing #1884: use the default completions only when user has not provided their own.

Cons: we lose the possibility to extend the default completions with custom ones.

fixes #1884

cc @KalleOlaviNiemitalo