### PR TITLE
introduce CompletionContext.Empty, remove Symbol.GetCompletions(void)

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -275,6 +275,7 @@ System.CommandLine.Binding
     public System.Boolean TryGetValue(IValueDescriptor valueDescriptor, BindingContext bindingContext, ref System.Object& boundValue)
 System.CommandLine.Completions
   public abstract class CompletionContext
+    public static CompletionContext Empty { get; }
     public System.CommandLine.ParseResult ParseResult { get; }
     public System.String WordToComplete { get; }
   public class CompletionItem

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -248,7 +248,6 @@ System.CommandLine
     public System.Boolean IsHidden { get; set; }
     public System.String Name { get; set; }
     public System.Collections.Generic.IEnumerable<Symbol> Parents { get; }
-    public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions()
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
     public System.String ToString()
 System.CommandLine.Binding

--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Suggestions.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Suggestions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.CommandLine.Completions;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
@@ -43,7 +44,7 @@ namespace System.CommandLine.Benchmarks.CommandLine
         [Benchmark]
         public void SuggestionsFromSymbol()
         {
-            _testSymbol.GetCompletions().Consume(new Consumer());
+            _testSymbol.GetCompletions(CompletionContext.Empty).Consume(new Consumer());
         }
 
         [GlobalSetup(Target = nameof(SuggestionsFromParseResult))]

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Completions;
 using System.CommandLine.Parsing;
 using System.CommandLine.Tests.Utility;
 using System.IO;
@@ -27,7 +28,7 @@ namespace System.CommandLine.Tests
             var option = new Option<string>("--hello")
                 .AddCompletions("one", "two", "three");
 
-            var completions = option.GetCompletions();
+            var completions = option.GetCompletions(CompletionContext.Empty);
 
             completions
                 .Select(item => item.Label)
@@ -45,7 +46,7 @@ namespace System.CommandLine.Tests
                 new Option<string>("--three", "option three")
             };
 
-            var completions = command.GetCompletions();
+            var completions = command.GetCompletions(CompletionContext.Empty);
 
             completions
                 .Select(item => item.Label)
@@ -69,7 +70,7 @@ namespace System.CommandLine.Tests
 
             rootCommand.AddGlobalOption(new Option<string>("--three", "option three"));
 
-            var completions = subcommand.GetCompletions();
+            var completions = subcommand.GetCompletions(CompletionContext.Empty);
 
             completions
                 .Select(item => item.Label)
@@ -87,7 +88,7 @@ namespace System.CommandLine.Tests
                 new Command("three")
             };
 
-            var completions = command.GetCompletions();
+            var completions = command.GetCompletions(CompletionContext.Empty);
 
             completions
                 .Select(item => item.Label)
@@ -104,7 +105,7 @@ namespace System.CommandLine.Tests
                 new Option<string>("--option")
             };
 
-            var completions = command.GetCompletions();
+            var completions = command.GetCompletions(CompletionContext.Empty);
 
             completions.Select(item => item.Label)
                        .Should()
@@ -125,7 +126,7 @@ namespace System.CommandLine.Tests
                 }
             };
 
-            var completions = command.GetCompletions();
+            var completions = command.GetCompletions(CompletionContext.Empty);
 
             completions.Select(item => item.Label)
                        .Should()
@@ -142,7 +143,7 @@ namespace System.CommandLine.Tests
                 new Command("andmyothersubcommand"),
             };
 
-            var completions = command.GetCompletions();
+            var completions = command.GetCompletions(CompletionContext.Empty);
 
             completions
                 .Select(item => item.Label)
@@ -158,7 +159,7 @@ namespace System.CommandLine.Tests
                 new Argument<string>("the-argument")
             };
 
-            var completions = command.GetCompletions();
+            var completions = command.GetCompletions(CompletionContext.Empty);
 
             completions
                 .Select(item => item.Label)
@@ -921,7 +922,7 @@ namespace System.CommandLine.Tests
             var description = "The option before -y.";
             var option = new Option<string>("-x", description);
 
-            var completions = new RootCommand { option }.GetCompletions();
+            var completions = new RootCommand { option }.GetCompletions(CompletionContext.Empty);
 
             completions.Should().ContainSingle()
                        .Which
@@ -936,7 +937,7 @@ namespace System.CommandLine.Tests
             var description = "The description for the subcommand";
             var subcommand = new Command("-x", description);
 
-            var completions = new RootCommand { subcommand }.GetCompletions();
+            var completions = new RootCommand { subcommand }.GetCompletions(CompletionContext.Empty);
 
             completions.Should().ContainSingle()
                        .Which

--- a/src/System.CommandLine/Completions/CompletionContext.cs
+++ b/src/System.CommandLine/Completions/CompletionContext.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Completions
     /// </summary>
     public abstract class CompletionContext
     {
-        private static CompletionContext _empty;
+        private static CompletionContext? _empty;
 
         internal CompletionContext(ParseResult parseResult, string wordToComplete)
         {

--- a/src/System.CommandLine/Completions/CompletionContext.cs
+++ b/src/System.CommandLine/Completions/CompletionContext.cs
@@ -11,6 +11,8 @@ namespace System.CommandLine.Completions
     /// </summary>
     public abstract class CompletionContext
     {
+        private static CompletionContext _empty;
+
         internal CompletionContext(ParseResult parseResult, string wordToComplete)
         {
             ParseResult = parseResult;
@@ -23,7 +25,11 @@ namespace System.CommandLine.Completions
         /// The parse result for which completions are being requested.
         public ParseResult ParseResult { get; }
 
-        internal static CompletionContext Empty() => new TokenCompletionContext(ParseResult.Empty());
+        /// <summary>
+        /// Gets an empty CompletionContext.
+        /// </summary>
+        /// <remarks>Can be used for testing purposes.</remarks>
+        public static CompletionContext Empty => _empty ??= new TokenCompletionContext(ParseResult.Empty());
 
         /// <summary>
         /// Gets the text to be matched for completion, which can be used to filter a list of completions.

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -64,11 +64,10 @@ public partial class HelpBuilder
             }
 
             string firstColumn;
-            var completions = (argument is { } a
-                                   ? a.GetCompletions(CompletionContext.Empty)
-                                   : Array.Empty<CompletionItem>())
-                              .Select(item => item.Label)
-                              .ToArray();
+            var completions = argument
+                .GetCompletions(CompletionContext.Empty)
+                .Select(item => item.Label)
+                .ToArray();
 
             var arg = argument;
             var helpName = arg?.HelpName ?? string.Empty;

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -65,7 +65,7 @@ public partial class HelpBuilder
 
             string firstColumn;
             var completions = (argument is { } a
-                                   ? a.GetCompletions()
+                                   ? a.GetCompletions(CompletionContext.Empty)
                                    : Array.Empty<CompletionItem>())
                               .Select(item => item.Label)
                               .ToArray();

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Binding;
+using System.CommandLine.Completions;
 using System.CommandLine.Help;
 using System.Linq;
 
@@ -522,7 +523,7 @@ namespace System.CommandLine.Parsing
             {
                 if (argument.FirstParent?.Symbol is Option option)
                 {
-                    var completions = option.GetCompletions().ToArray();
+                    var completions = option.GetCompletions(CompletionContext.Empty).ToArray();
 
                     if (completions.Length > 0)
                     {

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -80,10 +80,6 @@ namespace System.CommandLine
         /// <summary>
         /// Gets completions for the symbol.
         /// </summary>
-        public IEnumerable<CompletionItem> GetCompletions() => 
-            GetCompletions(CompletionContext.Empty());
-
-        /// <inheritdoc />
         public abstract IEnumerable<CompletionItem> GetCompletions(CompletionContext context);
 
         /// <inheritdoc/>


### PR DESCRIPTION
introduce static `CompletionContext.Empty`:

* cache it so it does not get created more than once
* make it public so it can be reused by our users who write tests (https://github.com/dotnet/command-line-api/issues/1891#issuecomment-1307575196)
* use it places where it can improve performance (including benchmarks, which should not include this allocation as this is not what they are supposed to benchmark)

remove Symbol.GetCompletions(void): mostly to simplify `Symbol`

@jonsequitur if we don't want to delete `Symbol.GetCompletions(void)` we should keep caching the empty completion context (perf gains in `HelpBuilder` and `ParseResultVisitor`)

