### PR TITLE
update required msbuild version

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
         "6.0.7"
       ]
     },
-    "xcopy-msbuild": "17.1.0"
+    "xcopy-msbuild": "17.2.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22554.2"


### PR DESCRIPTION
One of the internal validation builds is failing because dotnet 7 requires MSBuild >=17.2, so I'm copying from Roslyn which is using 17.2.1.