### PR TITLE
First name and aliases cleanup

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -148,7 +148,6 @@ System.CommandLine
   public interface IConsole : System.CommandLine.IO.IStandardError, System.CommandLine.IO.IStandardIn, System.CommandLine.IO.IStandardOut
   public abstract class IdentifierSymbol : Symbol
     public System.Collections.Generic.IReadOnlyCollection<System.String> Aliases { get; }
-    public System.String Name { get; set; }
     public System.Void AddAlias(System.String alias)
     public System.Boolean HasAlias(System.String alias)
   public class LocalizationResources

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -195,7 +195,6 @@ System.CommandLine
     public System.Boolean IsRequired { get; set; }
     public System.Type ValueType { get; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
-    public System.Boolean HasAliasIgnoringPrefix(System.String alias)
     public ParseResult Parse(System.String commandLine)
     public ParseResult Parse(System.String[] args)
   public class Option<T> : Option, IValueDescriptor<T>, System.CommandLine.Binding.IValueDescriptor

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -197,7 +197,7 @@ namespace System.CommandLine.DragonFruit
                     {
                         var kebabCasedParameterName = parameterDescription.Key.ToKebabCase();
 
-                        var option = builder.Command.Options.FirstOrDefault(o => o.HasAliasIgnoringPrefix(kebabCasedParameterName));
+                        var option = builder.Command.Options.FirstOrDefault(o => HasAliasIgnoringPrefix(o, kebabCasedParameterName));
 
                         if (option != null)
                         {
@@ -299,6 +299,40 @@ namespace System.CommandLine.DragonFruit
             }
 
             return string.Empty;
+        }
+
+        /// <summary>
+        /// Indicates whether a given alias exists on the option, regardless of its prefix.
+        /// </summary>
+        /// <param name="alias">The alias, which can include a prefix.</param>
+        /// <returns><see langword="true"/> if the alias exists; otherwise, <see langword="false"/>.</returns>
+        private static bool HasAliasIgnoringPrefix(Option option, string alias)
+        {
+            ReadOnlySpan<char> rawAlias = alias.AsSpan(GetPrefixLength(alias));
+
+            foreach (string existingAlias in option.Aliases)
+            {
+                if (MemoryExtensions.Equals(existingAlias.AsSpan(GetPrefixLength(existingAlias)), rawAlias, StringComparison.CurrentCulture))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+
+            static int GetPrefixLength(string alias)
+            {
+                if (alias[0] == '-')
+                {
+                    return alias.Length > 1 && alias[1] == '-' ? 2 : 1;
+                }
+                else if (alias[0] == '/')
+                {
+                    return 1;
+                }
+
+                return 0;
+            }
         }
     }
 }

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -64,7 +64,6 @@ namespace System.CommandLine.Tests
 
             option.AddAlias("-a");
 
-            option.HasAliasIgnoringPrefix("a").Should().BeTrue();
             option.HasAlias("-a").Should().BeTrue();
         }
 
@@ -85,27 +84,11 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void HasAliasIgnorePrefix_accepts_unprefixed_short_value()
-        {
-            var option = new Option<string>(new[] { "-o", "--option" });
-
-            option.HasAliasIgnoringPrefix("o").Should().BeTrue();
-        }
-
-        [Fact]
         public void HasAlias_accepts_prefixed_long_value()
         {
             var option = new Option<string>(new[] { "-o", "--option" });
 
             option.HasAlias("--option").Should().BeTrue();
-        }
-
-        [Fact]
-        public void HasAliasIgnorePrefix_accepts_unprefixed_long_value()
-        {
-            var option = new Option<string>(new[] { "-o", "--option" });
-
-            option.HasAliasIgnoringPrefix("option").Should().BeTrue();
         }
 
         [Fact]

--- a/src/System.CommandLine/Binding/ArgumentConversionResult.cs
+++ b/src/System.CommandLine/Binding/ArgumentConversionResult.cs
@@ -56,7 +56,7 @@ namespace System.CommandLine.Binding
             if (argument.FirstParent?.Symbol is IdentifierSymbol identifierSymbol &&
                 argument.FirstParent.Next is null)
             {
-                var alias = identifierSymbol.Aliases.First();
+                var alias = identifierSymbol.GetLongestAlias(removePrefix: false);
 
                 switch (identifierSymbol)
                 {

--- a/src/System.CommandLine/IdentifierSymbol.cs
+++ b/src/System.CommandLine/IdentifierSymbol.cs
@@ -12,7 +12,6 @@ namespace System.CommandLine
     public abstract class IdentifierSymbol : Symbol
     {
         private protected readonly HashSet<string> _aliases = new(StringComparer.Ordinal);
-        private string? _specifiedName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IdentifierSymbol"/> class.
@@ -42,19 +41,18 @@ namespace System.CommandLine
         /// <inheritdoc/>
         public override string Name
         {
-            get => _specifiedName ??= DefaultName;
             set
             {
-                if (_specifiedName is null || !string.Equals(_specifiedName, value, StringComparison.Ordinal))
+                if (_name is null || !string.Equals(_name, value, StringComparison.Ordinal))
                 {
                     AddAlias(value);
 
-                    if (_specifiedName is { })
+                    if (_name is { })
                     {
-                        RemoveAlias(_specifiedName);
+                        RemoveAlias(_name);
                     }
 
-                    _specifiedName = value;
+                    _name = value;
                 }
             }
         }

--- a/src/System.CommandLine/IdentifierSymbol.cs
+++ b/src/System.CommandLine/IdentifierSymbol.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine
     /// </summary>
     public abstract class IdentifierSymbol : Symbol
     {
-        private protected readonly HashSet<string> _aliases = new(StringComparer.Ordinal);
+        private readonly HashSet<string> _aliases = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IdentifierSymbol"/> class.

--- a/src/System.CommandLine/IdentifierSymbol.cs
+++ b/src/System.CommandLine/IdentifierSymbol.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.CommandLine.Parsing;
 using System.Diagnostics;
 
 namespace System.CommandLine
@@ -79,6 +80,19 @@ namespace System.CommandLine
         /// <param name="alias">The alias to search for.</param>
         /// <returns><see langword="true" /> if the alias has already been defined; otherwise <see langword="false" />.</returns>
         public bool HasAlias(string alias) => _aliases.Contains(alias);
+
+        internal string GetLongestAlias(bool removePrefix)
+        {
+            string max = "";
+            foreach (string alias in _aliases)
+            {
+                if (alias.Length > max.Length)
+                {
+                    max = alias;
+                }
+            }
+            return removePrefix ? max.RemovePrefix() : max;
+        }
 
         [DebuggerStepThrough]
         private void ThrowIfAliasIsInvalid(string alias)

--- a/src/System.CommandLine/LocalizationResources.cs
+++ b/src/System.CommandLine/LocalizationResources.cs
@@ -102,7 +102,7 @@ namespace System.CommandLine
         ///   Interpolates values into a localized string similar to Option '{0}' is required.
         /// </summary>
         public virtual string RequiredOptionWasNotProvided(Option option) =>
-            GetResourceString(Properties.Resources.RequiredOptionWasNotProvided, option.Aliases.OrderByDescending(x => x.Length).First());
+            GetResourceString(Properties.Resources.RequiredOptionWasNotProvided, option.GetLongestAlias(removePrefix: false));
 
         /// <summary>
         ///   Interpolates values into a localized string similar to Argument &apos;{0}&apos; not recognized. Must be one of:{1}.

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -101,26 +101,6 @@ namespace System.CommandLine
         internal bool HasValidators => _validators is not null && _validators.Count > 0;
 
         /// <summary>
-        /// Indicates whether a given alias exists on the option, regardless of its prefix.
-        /// </summary>
-        /// <param name="alias">The alias, which can include a prefix.</param>
-        /// <returns><see langword="true"/> if the alias exists; otherwise, <see langword="false"/>.</returns>
-        public bool HasAliasIgnoringPrefix(string alias)
-        {
-            ReadOnlySpan<char> rawAlias = alias.AsSpan(alias.GetPrefixLength());
-
-            foreach (string existingAlias in _aliases)
-            {
-                if (MemoryExtensions.Equals(existingAlias.AsSpan(existingAlias.GetPrefixLength()), rawAlias, StringComparison.CurrentCulture))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Gets a value that indicates whether multiple argument tokens are allowed for each option identifier token.
         /// </summary>
         /// <example>

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -155,20 +155,7 @@ namespace System.CommandLine
 
         object? IValueDescriptor.GetDefaultValue() => Argument.GetDefaultValue();
 
-        private protected override string DefaultName => GetLongestAlias();
-        
-        private string GetLongestAlias()
-        {
-            string max = "";
-            foreach (string alias in _aliases)
-            {
-                if (alias.Length > max.Length)
-                {
-                    max = alias;
-                }
-            }
-            return max.RemovePrefix();
-        }
+        private protected override string DefaultName => GetLongestAlias(true);
 
         /// <inheritdoc />
         public override IEnumerable<CompletionItem> GetCompletions(CompletionContext context)

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -15,7 +15,6 @@ namespace System.CommandLine
     /// <seealso cref="IdentifierSymbol" />
     public abstract class Option : IdentifierSymbol, IValueDescriptor
     {
-        private string? _name;
         private List<Action<OptionResult>>? _validators;
 
         private protected Option(string name, string? description) : base(description)
@@ -156,7 +155,7 @@ namespace System.CommandLine
 
         object? IValueDescriptor.GetDefaultValue() => Argument.GetDefaultValue();
 
-        private protected override string DefaultName => _name ??= GetLongestAlias();
+        private protected override string DefaultName => GetLongestAlias();
         
         private string GetLongestAlias()
         {

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -32,7 +32,7 @@ namespace System.CommandLine.Parsing
                        : alias;
         }
 
-        internal static int GetPrefixLength(this string alias)
+        private static int GetPrefixLength(this string alias)
         {
             if (alias[0] == '-')
             {

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine
     /// </summary>
     public abstract class Symbol
     {
-        private string? _name;
+        private protected string? _name;
         private ParentNode? _firstParent;
 
         private protected Symbol()


### PR DESCRIPTION
- Multiple types derived from `Symbol` were defining it's own name field. I've removed these and now all of them are just using `_name` defined by `Symbol`
- As agreed with Jon (not tagging him as he is on vacations) removing `Option.HasAliasIgnoringPrefix` as it's not for general purpose
- making `GetLongestAlias` part of base type and re-using it where possible
- encapsulating `_aliases` field, as it will most likely change once we introduce the concept of a hidden alias
