### PR TITLE
Refs #1074 - Error message "Required argument {ARGUMENT NAME} missing for command {commandName}..."

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -307,7 +307,7 @@ namespace System.CommandLine.Tests
                 var numberOfMissingArgs =
                     result
                         .Errors
-                        .Count(e => e.Message == LocalizationResources.Instance.RequiredArgumentMissing(result.CommandResult));
+                        .Count(e => e.Message == LocalizationResources.Instance.RequiredArgumentMissing(command.Arguments.First(), result.CommandResult));
 
                 numberOfMissingArgs
                     .Should()

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1401,7 +1401,7 @@ namespace System.CommandLine.Tests
             result.Errors
                   .Select(e => e.Message)
                   .Should()
-                  .Contain(LocalizationResources.Instance.RequiredArgumentMissing(result.CommandResult));
+                  .Contain(LocalizationResources.Instance.RequiredArgumentMissing(command.Arguments.First(), result.CommandResult));
         }
 
         [Fact]
@@ -1489,7 +1489,7 @@ namespace System.CommandLine.Tests
             result.Errors
                   .Select(e => e.Message)
                   .Should()
-                  .Contain(LocalizationResources.Instance.RequiredArgumentMissing(result.CommandResult.FindResultFor(option)));
+                  .Contain(LocalizationResources.Instance.RequiredArgumentMissing(option.Argument, result.CommandResult.FindResultFor(option)));
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ResourceLocalizationTests.cs
+++ b/src/System.CommandLine.Tests/ResourceLocalizationTests.cs
@@ -62,7 +62,7 @@ namespace System.CommandLine.Tests
 
             public override string FileDoesNotExist(string filePath) => message;
 
-            public override string RequiredArgumentMissing(SymbolResult symbolResult) => message;
+            public override string RequiredArgumentMissing(Argument argument, SymbolResult symbolResult) => message;
 
             public override string RequiredCommandWasNotProvided() => message;
 

--- a/src/System.CommandLine.Tests/Utility/NonWindowsOnlyFactAttribute.cs
+++ b/src/System.CommandLine.Tests/Utility/NonWindowsOnlyFactAttribute.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Tests.Utility
     {
         public NonWindowsOnlyFactAttribute()
         {
-            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            if (RuntimeEnvironment.OperatingSystemPlatform == Microsoft.DotNet.PlatformAbstractions.Platform.Windows)
             {
                 Skip = "This test requires non-Windows to run";
             }

--- a/src/System.CommandLine.Tests/Utility/WindowsOnlyFactAttribute.cs
+++ b/src/System.CommandLine.Tests/Utility/WindowsOnlyFactAttribute.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Tests.Utility
     {
         public WindowsOnlyFactAttribute()
         {
-            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Windows)
+            if (RuntimeEnvironment.OperatingSystemPlatform != Microsoft.DotNet.PlatformAbstractions.Platform.Windows)
             {
                 Skip = "This test requires Windows to run";
             }

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -95,7 +95,7 @@ namespace System.CommandLine
 
                 return ArgumentConversionResult.Failure(
                     argument,
-                    symbolResult.LocalizationResources.RequiredArgumentMissing(symbolResult),
+                    symbolResult.LocalizationResources.RequiredArgumentMissing(argument, symbolResult),
                     ArgumentConversionResultType.FailedMissingArgument);
             }
 

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -195,7 +195,7 @@ namespace System.CommandLine.Binding
                 ArgumentConversionResultType.NoArgument when conversionResult.Argument.Arity.MinimumNumberOfValues > 0 =>
                     ArgumentConversionResult.Failure(
                         conversionResult.Argument,
-                        symbolResult.LocalizationResources.RequiredArgumentMissing(symbolResult),
+                        symbolResult.LocalizationResources.RequiredArgumentMissing(conversionResult.Argument, symbolResult),
                         ArgumentConversionResultType.FailedMissingArgument),
                         
                 _ => conversionResult

--- a/src/System.CommandLine/LocalizationResources.cs
+++ b/src/System.CommandLine/LocalizationResources.cs
@@ -85,11 +85,25 @@ namespace System.CommandLine
             GetResourceString(Properties.Resources.InvalidCharactersInFileName, invalidChar);
 
         /// <summary>
-        ///   Interpolates values into a localized string similar to Required argument missing for command: {0}.
+        ///   Interpolates values into a localized string similar to 
+        ///   Required argument {0} missing for command: {1}.
+        ///   or
+        ///   Required argument missing for option: {0}.
+        /// </summary>
+        public virtual string RequiredArgumentMissing(Argument argument, SymbolResult symbolResult) =>
+            symbolResult is CommandResult
+                ? GetResourceString(Properties.Resources.CommandRequiredArgumentMissing, argument.Name, symbolResult.Token().Value)
+                : GetResourceString(Properties.Resources.OptionRequiredArgumentMissing, symbolResult.Token().Value);
+
+        /// <summary>
+        ///   Interpolates values into a localized string similar to 
+        ///   Required argument {0} missing for command: {1}.
+        ///   or
+        ///   Required argument missing for option: {0}.
         /// </summary>
         public virtual string RequiredArgumentMissing(SymbolResult symbolResult) =>
             symbolResult is CommandResult
-                ? GetResourceString(Properties.Resources.CommandRequiredArgumentMissing, symbolResult.Token().Value)
+                ? GetResourceString(Properties.Resources.CommandRequiredArgumentMissing, "(unknown)", symbolResult.Token().Value)
                 : GetResourceString(Properties.Resources.OptionRequiredArgumentMissing, symbolResult.Token().Value);
 
         /// <summary>

--- a/src/System.CommandLine/Properties/Resources.Designer.cs
+++ b/src/System.CommandLine/Properties/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Required argument missing for command: &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Required argument &apos;{0}&apos; missing for command: &apos;{1}&apos;..
         /// </summary>
         internal static string CommandRequiredArgumentMissing {
             get {

--- a/src/System.CommandLine/Properties/Resources.resx
+++ b/src/System.CommandLine/Properties/Resources.resx
@@ -148,7 +148,7 @@
     <value>Character not allowed in a path: '{0}'.</value>
   </data>
   <data name="CommandRequiredArgumentMissing" xml:space="preserve">
-    <value>Required argument missing for command: '{0}'.</value>
+    <value>Required argument '{0}' missing for command: '{1}'.</value>
   </data>
   <data name="OptionRequiredArgumentMissing" xml:space="preserve">
     <value>Required argument missing for option: '{0}'.</value>

--- a/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.de.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.es.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.it.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
-        <source>Required argument missing for command: '{0}'.</source>
-        <target state="new">Required argument missing for command: '{0}'.</target>
+        <source>Required argument '{0}' missing for command: '{1}'.</source>
+        <target state="new">Required argument '{0}' missing for command: '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">

--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -52,6 +52,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="System.CommandLine.NamingConventionBinder" />
+    <InternalsVisibleTo Include="System.CommandLine.Tests" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Previously it was "Required argument missing for command: {commandname}" - now we have better clarity as to which argument is missing.