### PR TITLE
Fluent APIs are not allowed in non-builder types

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -199,7 +199,7 @@ System.CommandLine
     .ctor(System.String name, Func<T> defaultValueFactory, System.String description = null)
     .ctor(System.String[] aliases, Func<T> defaultValueFactory, System.String description = null)
     public Option<T> AcceptLegalFileNamesOnly()
-    public Option<T> AcceptLegalFilePathsOnly()
+    public System.Void AcceptLegalFilePathsOnly()
     public System.Void AcceptOnlyFromAmong(System.String[] values)
     public System.Void SetDefaultValue(T value)
     public System.Void SetDefaultValueFactory(Func<T> defaultValueFactory)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -198,7 +198,7 @@ System.CommandLine
     .ctor(System.String[] aliases, Func<System.CommandLine.Parsing.ArgumentResult,T> parseArgument, System.Boolean isDefault = False, System.String description = null)
     .ctor(System.String name, Func<T> defaultValueFactory, System.String description = null)
     .ctor(System.String[] aliases, Func<T> defaultValueFactory, System.String description = null)
-    public Option<T> AcceptLegalFileNamesOnly()
+    public System.Void AcceptLegalFileNamesOnly()
     public System.Void AcceptLegalFilePathsOnly()
     public System.Void AcceptOnlyFromAmong(System.String[] values)
     public System.Void SetDefaultValue(T value)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -23,7 +23,7 @@ System.CommandLine
     public System.Type ValueType { get; }
     public Argument<T> AcceptLegalFileNamesOnly()
     public Argument<T> AcceptLegalFilePathsOnly()
-    public Argument<T> AcceptOnlyFromAmong(System.String[] values)
+    public System.Void AcceptOnlyFromAmong(System.String[] values)
     public System.Void SetDefaultValue(T value)
     public System.Void SetDefaultValueFactory(Func<T> defaultValueFactory)
     public System.Void SetDefaultValueFactory(Func<System.CommandLine.Parsing.ArgumentResult,T> defaultValueFactory)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -21,7 +21,7 @@ System.CommandLine
     .ctor(Func<System.CommandLine.Parsing.ArgumentResult,T> parse, System.Boolean isDefault = False)
     public System.Boolean HasDefaultValue { get; }
     public System.Type ValueType { get; }
-    public Argument<T> AcceptLegalFileNamesOnly()
+    public System.Void AcceptLegalFileNamesOnly()
     public System.Void AcceptLegalFilePathsOnly()
     public System.Void AcceptOnlyFromAmong(System.String[] values)
     public System.Void SetDefaultValue(T value)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -200,7 +200,7 @@ System.CommandLine
     .ctor(System.String[] aliases, Func<T> defaultValueFactory, System.String description = null)
     public Option<T> AcceptLegalFileNamesOnly()
     public Option<T> AcceptLegalFilePathsOnly()
-    public Option<T> AcceptOnlyFromAmong(System.String[] values)
+    public System.Void AcceptOnlyFromAmong(System.String[] values)
     public System.Void SetDefaultValue(T value)
     public System.Void SetDefaultValueFactory(Func<T> defaultValueFactory)
   public static class OptionValidation

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -22,7 +22,7 @@ System.CommandLine
     public System.Boolean HasDefaultValue { get; }
     public System.Type ValueType { get; }
     public Argument<T> AcceptLegalFileNamesOnly()
-    public Argument<T> AcceptLegalFilePathsOnly()
+    public System.Void AcceptLegalFilePathsOnly()
     public System.Void AcceptOnlyFromAmong(System.String[] values)
     public System.Void SetDefaultValue(T value)
     public System.Void SetDefaultValueFactory(Func<T> defaultValueFactory)

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -785,15 +785,6 @@ namespace System.CommandLine.Tests
                 .BeEquivalentTo(new[] { $"Argument 'Fuschia' not recognized. Must be one of:\n\t'Red'\n\t'Green'" });
         }
 
-        [Fact]
-        public void Argument_of_T_fluent_APIs_return_Argument_of_T()
-        {
-            Argument<string> argument = new Argument<string>("--path");
-            argument.AcceptLegalFileNamesOnly();
-
-            argument.Should().BeOfType<Argument<string>>();
-        }
-
         protected override Symbol CreateSymbol(string name)
         {
             return new Argument<string>(name);

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -788,8 +788,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Argument_of_T_fluent_APIs_return_Argument_of_T()
         {
-            Argument<string> argument = new Argument<string>("--path")
-                .AcceptLegalFileNamesOnly();
+            Argument<string> argument = new Argument<string>("--path");
+            argument.AcceptLegalFileNamesOnly();
 
             argument.Should().BeOfType<Argument<string>>();
         }

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -789,8 +789,7 @@ namespace System.CommandLine.Tests
         public void Argument_of_T_fluent_APIs_return_Argument_of_T()
         {
             Argument<string> argument = new Argument<string>("--path")
-                .AcceptLegalFileNamesOnly()
-                .AcceptLegalFilePathsOnly();
+                .AcceptLegalFileNamesOnly();
 
             argument.Should().BeOfType<Argument<string>>();
         }

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -769,8 +769,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Argument_of_enum_can_limit_enum_members_as_valid_values()
         {
-            var argument = new Argument<ConsoleColor>()
-                .AcceptOnlyFromAmong(ConsoleColor.Red.ToString(), ConsoleColor.Green.ToString());
+            var argument = new Argument<ConsoleColor>();
+            argument.AcceptOnlyFromAmong(ConsoleColor.Red.ToString(), ConsoleColor.Green.ToString());
+
             Command command = new("set-color")
             {
                 argument
@@ -788,7 +789,6 @@ namespace System.CommandLine.Tests
         public void Argument_of_T_fluent_APIs_return_Argument_of_T()
         {
             Argument<string> argument = new Argument<string>("--path")
-                .AcceptOnlyFromAmong("text")
                 .AcceptLegalFileNamesOnly()
                 .AcceptLegalFilePathsOnly();
 

--- a/src/System.CommandLine.Tests/CompletionContextTests.cs
+++ b/src/System.CommandLine.Tests/CompletionContextTests.cs
@@ -109,10 +109,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_greater_than_input_length_in_a_string_command_line_then_it_returns_empty()
         {
+            Option<string> option1 = new ("--option1");
+            option1.AcceptOnlyFromAmong("apple", "banana", "cherry", "durian");
+
             var command = new Command("the-command")
             {
                 new Argument<string>(),
-                new Option<string>("--option1").AcceptOnlyFromAmong("apple", "banana", "cherry", "durian"),
+                option1,
                 new Option<string>("--option2")
             };
 
@@ -176,9 +179,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_unspecified_in_array_command_line_and_final_token_matches_an_argument_then_it_returns_the_argument_value()
         {
+            Option<string> option1 = new("--option1");
+            option1.AcceptOnlyFromAmong("apple", "banana", "cherry", "durian");
+
             var command = new Command("the-command")
             {
-                new Option<string>("--option1").AcceptOnlyFromAmong("apple", "banana", "cherry", "durian"),
+                option1,
                 new Option<string>("--option2"),
                 new Argument<string>()
             };

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -972,9 +972,9 @@ namespace System.CommandLine.Tests
 
         private static Option<string> CreateOptionWithAcceptOnlyFromAmong(string name, params string[] values)
         {
-            Option<string> argument = new(name);
-            argument.AcceptOnlyFromAmong(values);
-            return argument;
+            Option<string> option = new(name);
+            option.AcceptOnlyFromAmong(values);
+            return option;
         }
     }
 }

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -698,15 +698,15 @@ namespace System.CommandLine.Tests
             {
                 new Command("one")
                 {
-                    new Argument<string>().AcceptOnlyFromAmong("one-a", "one-b", "one-c")
+                    CreateArgumentWithAcceptOnlyFromAmong("one-a", "one-b", "one-c")
                 },
                 new Command("two")
                 {
-                    new Argument<string>().AcceptOnlyFromAmong("two-a", "two-b", "two-c")
+                    CreateArgumentWithAcceptOnlyFromAmong("two-a", "two-b", "two-c")
                 },
                 new Command("three")
                 {
-                    new Argument<string>().AcceptOnlyFromAmong("three-a", "three-b", "three-c")
+                    CreateArgumentWithAcceptOnlyFromAmong("three-a", "three-b", "three-c")
                 }
             };
 
@@ -725,15 +725,15 @@ namespace System.CommandLine.Tests
             {
                 new Command("one")
                 {
-                    new Argument<string>().AcceptOnlyFromAmong("one-a", "one-b", "one-c")
+                    CreateArgumentWithAcceptOnlyFromAmong("one-a", "one-b", "one-c")
                 },
                 new Command("two")
                 {
-                    new Argument<string>().AcceptOnlyFromAmong("two-a", "two-b", "two-c")
+                    CreateArgumentWithAcceptOnlyFromAmong("two-a", "two-b", "two-c")
                 },
                 new Command("three")
                 {
-                    new Argument<string>().AcceptOnlyFromAmong("three-a", "three-b", "three-c")
+                    CreateArgumentWithAcceptOnlyFromAmong("three-a", "three-b", "three-c")
                 }
             };
 
@@ -967,6 +967,13 @@ namespace System.CommandLine.Tests
                   .Should()
                   .Be(
                       $"Cannot parse argument 'SleepyDay' for option '--day' as expected type 'System.DayOfWeek'. Did you mean one of the following?{NewLine}Friday{NewLine}Monday{NewLine}Saturday{NewLine}Sunday{NewLine}Thursday{NewLine}Tuesday{NewLine}Wednesday");
+        }
+
+        private Argument<string> CreateArgumentWithAcceptOnlyFromAmong(params string[] values)
+        {
+            Argument<string> argument = new();
+            argument.AcceptOnlyFromAmong(values);
+            return argument;
         }
     }
 }

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -441,8 +441,8 @@ namespace System.CommandLine.Tests
         {
             var parser = new RootCommand
             {
-                new Option<string>("--bread").AcceptOnlyFromAmong("wheat", "sourdough", "rye"),
-                new Option<string>("--cheese").AcceptOnlyFromAmong("provolone", "cheddar", "cream cheese")
+                CreateOptionWithAcceptOnlyFromAmong(name: "--bread", "wheat", "sourdough", "rye"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "--cheese", "provolone", "cheddar", "cream cheese")
             };
 
             var commandLine = "--bread";
@@ -546,8 +546,8 @@ namespace System.CommandLine.Tests
             var parser = new Parser(
                 new Command("outer")
                 {
-                    new Option<string>("--one").AcceptOnlyFromAmong("one-a", "one-b"),
-                    new Option<string>("--two").AcceptOnlyFromAmong("two-a", "two-b")
+                    CreateOptionWithAcceptOnlyFromAmong(name: "--one", "one-a", "one-b"),
+                    CreateOptionWithAcceptOnlyFromAmong(name: "--two", "two-a", "two-b")
                 });
 
             var commandLine = "outer --two";
@@ -648,12 +648,9 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("outer")
             {
-                new Option<string>("one")
-                    .AcceptOnlyFromAmong("one-a", "one-b", "one-c"),
-                new Option<string>("two")
-                    .AcceptOnlyFromAmong("two-a", "two-b", "two-c"),
-                new Option<string>("three")
-                    .AcceptOnlyFromAmong("three-a", "three-b", "three-c")
+                CreateOptionWithAcceptOnlyFromAmong(name: "one", "one-a", "one-b", "one-c"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "two", "two-a", "two-b", "two-c"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "three", "three-a", "three-b", "three-c")
             };
 
             var parser = new CommandLineBuilder(new RootCommand
@@ -675,12 +672,9 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("outer")
             {
-                new Option<string>("one")
-                    .AcceptOnlyFromAmong("one-a", "one-b", "one-c"),
-                new Option<string>("two")
-                    .AcceptOnlyFromAmong("two-a", "two-b", "two-c"),
-                new Option<string>("three")
-                    .AcceptOnlyFromAmong("three-a", "three-b", "three-c")
+                CreateOptionWithAcceptOnlyFromAmong(name: "one", "one-a", "one-b", "one-c"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "two", "two-a", "two-b", "two-c"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "three", "three-a", "three-b", "three-c")
             };
 
             var result = command.Parse("outer two b");
@@ -750,8 +744,8 @@ namespace System.CommandLine.Tests
         {
             var command = new RootCommand
             {
-                new Option<string>("--framework").AcceptOnlyFromAmong("net7.0"),
-                new Option<string>("--language").AcceptOnlyFromAmong("C#"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "--framework", "net7.0"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "--language", "C#"),
                 new Option<string>("--langVersion")
             };
             var parser = new CommandLineBuilder(command).Build();
@@ -767,8 +761,8 @@ namespace System.CommandLine.Tests
         {
             var command = new RootCommand
             {
-                new Option<string>("--framework").AcceptOnlyFromAmong("net7.0"),
-                new Option<string>("--language").AcceptOnlyFromAmong("C#"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "--framework", "net7.0"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "--language", "C#"),
                 new Option<string>("--langVersion")
             };
             var parser = new CommandLineBuilder(command).Build();
@@ -969,9 +963,16 @@ namespace System.CommandLine.Tests
                       $"Cannot parse argument 'SleepyDay' for option '--day' as expected type 'System.DayOfWeek'. Did you mean one of the following?{NewLine}Friday{NewLine}Monday{NewLine}Saturday{NewLine}Sunday{NewLine}Thursday{NewLine}Tuesday{NewLine}Wednesday");
         }
 
-        private Argument<string> CreateArgumentWithAcceptOnlyFromAmong(params string[] values)
+        private static Argument<string> CreateArgumentWithAcceptOnlyFromAmong(params string[] values)
         {
             Argument<string> argument = new();
+            argument.AcceptOnlyFromAmong(values);
+            return argument;
+        }
+
+        private static Option<string> CreateOptionWithAcceptOnlyFromAmong(string name, params string[] values)
+        {
+            Option<string> argument = new(name);
             argument.AcceptOnlyFromAmong(values);
             return argument;
         }

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -358,8 +358,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_of_enum_can_limit_enum_members_as_valid_values()
         {
-            var option = new Option<ConsoleColor>("--color")
-                .AcceptOnlyFromAmong(ConsoleColor.Red.ToString(), ConsoleColor.Green.ToString());
+            Option<ConsoleColor> option = new("--color");
+            option.AcceptOnlyFromAmong(ConsoleColor.Red.ToString(), ConsoleColor.Green.ToString());
 
             var result = option.Parse("--color Fuschia");
 
@@ -373,7 +373,6 @@ namespace System.CommandLine.Tests
         public void Option_of_T_fluent_APIs_return_Option_of_T()
         {
             Option<string> option = new Option<string>("--path")
-                .AcceptOnlyFromAmong("text")
                 .AcceptLegalFileNamesOnly()
                 .AcceptLegalFilePathsOnly();
 

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -373,8 +373,7 @@ namespace System.CommandLine.Tests
         public void Option_of_T_fluent_APIs_return_Option_of_T()
         {
             Option<string> option = new Option<string>("--path")
-                .AcceptLegalFileNamesOnly()
-                .AcceptLegalFilePathsOnly();
+                .AcceptLegalFileNamesOnly();
 
             option.Should().BeOfType<Option<string>>();
         }

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -368,15 +368,6 @@ namespace System.CommandLine.Tests
                 .Should()
                 .BeEquivalentTo(new[] { $"Argument 'Fuschia' not recognized. Must be one of:\n\t'Red'\n\t'Green'" });
         }
-
-        [Fact]
-        public void Option_of_T_fluent_APIs_return_Option_of_T()
-        {
-            Option<string> option = new Option<string>("--path");
-            option.AcceptLegalFileNamesOnly();
-
-            option.Should().BeOfType<Option<string>>();
-        }
         
         protected override Symbol CreateSymbol(string name) => new Option<string>(name);
     }

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -372,8 +372,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_of_T_fluent_APIs_return_Option_of_T()
         {
-            Option<string> option = new Option<string>("--path")
-                .AcceptLegalFileNamesOnly();
+            Option<string> option = new Option<string>("--path");
+            option.AcceptLegalFileNamesOnly();
 
             option.Should().BeOfType<Option<string>>();
         }

--- a/src/System.CommandLine.Tests/ParseDiagramTests.cs
+++ b/src/System.CommandLine.Tests/ParseDiagramTests.cs
@@ -32,9 +32,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_result_diagram_displays_unmatched_tokens()
         {
+            Option<string> option = new ("-x");
+            option.AcceptOnlyFromAmong("arg1", "arg2", "arg3");
+
             var command = new Command("command")
             {
-                new Option<string>("-x").AcceptOnlyFromAmong("arg1", "arg2", "arg3")
+                option
             };
 
             var result = command.Parse("command -x ar");

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -350,8 +350,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_can_be_specified_multiple_times_and_their_arguments_are_collated()
         {
-            var animalsOption = new Option<string[]>(new[] { "-a", "--animals" })
-                .AcceptOnlyFromAmong("dog", "cat", "sheep");
+            var animalsOption = new Option<string[]>(new[] { "-a", "--animals" });
+            animalsOption.AcceptOnlyFromAmong("dog", "cat", "sheep");
             var vegetablesOption = new Option<string[]>(new[] { "-v", "--vegetables" });
             var parser = new Parser(
                 new Command("the-command") {

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -71,12 +71,14 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1475
         public void When_FromAmong_is_used_then_the_ArgumentResult_ErrorMessage_is_set()
         {
-            var option = new Argument<string>().AcceptOnlyFromAmong("a", "b");
-            var command = new Command("test") { option };
+            var argument = new Argument<string>();
+            argument.AcceptOnlyFromAmong("a", "b");
+
+            var command = new Command("test") { argument };
 
             var parseResult = command.Parse("test c");
 
-            parseResult.FindResultFor(option)
+            parseResult.FindResultFor(argument)
                        .ErrorMessage
                        .Should()
                        .Be(parseResult.Errors.Single().Message)
@@ -90,8 +92,8 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("set")
             {
-                new Argument<string>("key").AcceptOnlyFromAmong("key1", "key2"),
-                new Argument<string>("value").AcceptOnlyFromAmong("value1", "value2")
+                CreateArgumentWithAcceptOnlyFromAmong(name: "key", "key1", "key2"),
+                CreateArgumentWithAcceptOnlyFromAmong(name : "value", "value1", "value2")
             };
 
             var result = command.Parse("set key1 value1");
@@ -104,8 +106,8 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("set")
             {
-                new Argument<string>("key").AcceptOnlyFromAmong("key1", "key2"),
-                new Argument<string>("value").AcceptOnlyFromAmong("value1", "value2")
+                CreateArgumentWithAcceptOnlyFromAmong(name : "key", "key1", "key2"),
+                CreateArgumentWithAcceptOnlyFromAmong(name : "value", "value1", "value2")
             };
 
             var result = command.Parse("set not-key1 value1");
@@ -152,8 +154,8 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("set")
             {
-                new Argument<string>("key").AcceptOnlyFromAmong("key1", "key2"),
-                new Argument<string>("value").AcceptOnlyFromAmong("value1", "value2")
+                CreateArgumentWithAcceptOnlyFromAmong(name : "key", "key1", "key2"),
+                CreateArgumentWithAcceptOnlyFromAmong(name : "value", "value1", "value2")
             };
 
             var result = command.Parse("set key1 not-value1");
@@ -1232,6 +1234,13 @@ namespace System.CommandLine.Tests
                        .Message
                        .Should()
                        .Be("Required argument missing for option: '-o'.");
+        }
+
+        private Argument<string> CreateArgumentWithAcceptOnlyFromAmong(string name, params string[] values)
+        {
+            Argument<string> argument = new(name);
+            argument.AcceptOnlyFromAmong(values);
+            return argument;
         }
     }
 }

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -560,9 +560,11 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFilePathsOnly_rejects_command_arguments_containing_invalid_path_characters()
             {
+                Argument<string> argument = new();
+                argument.AcceptLegalFilePathsOnly();
                 var command = new Command("the-command")
                 {
-                    new Argument<string>().AcceptLegalFilePathsOnly()
+                    argument
                 };
 
                 var invalidCharacter = Path.GetInvalidPathChars().First(c => c != '"');
@@ -600,9 +602,11 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFilePathsOnly_accepts_command_arguments_containing_valid_path_characters()
             {
+                Argument<string[]> argument = new ();
+                argument.AcceptLegalFilePathsOnly();
                 var command = new Command("the-command")
                 {
-                    new Argument<string[]>().AcceptLegalFilePathsOnly()
+                    argument
                 };
 
                 var validPathName = Directory.GetCurrentDirectory();

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -644,9 +644,12 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFileNamesOnly_rejects_command_arguments_containing_invalid_file_name_characters()
             {
+                Argument<string> argument = new();
+                argument.AcceptLegalFileNamesOnly();
+
                 var command = new Command("the-command")
                 {
-                    new Argument<string>().AcceptLegalFileNamesOnly()
+                    argument
                 };
 
                 var invalidCharacter = Path.GetInvalidFileNameChars().First(c => c != '"');
@@ -684,9 +687,12 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFileNamesOnly_accepts_command_arguments_containing_valid_file_name_characters()
             {
+                Argument<string[]> argument = new ();
+                argument.AcceptLegalFileNamesOnly();
+
                 var command = new Command("the-command")
                 {
-                    new Argument<string[]>().AcceptLegalFileNamesOnly()
+                    argument
                 };
 
                 var validFileName = Path.GetFileName(Directory.GetCurrentDirectory());

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -667,9 +667,12 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFileNamesOnly_rejects_option_arguments_containing_invalid_file_name_characters()
             {
+                Option<string> option = new("-x");
+                option.AcceptLegalFileNamesOnly();
+
                 var command = new Command("the-command")
                 {
-                    new Option<string>("-x").AcceptLegalFileNamesOnly()
+                    option
                 };
 
                 var invalidCharacter = Path.GetInvalidFileNameChars().First(c => c != '"');
@@ -706,9 +709,12 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFileNamesOnly_accepts_option_arguments_containing_valid_file_name_characters()
             {
+                Option<string[]> option = new("-x");
+                option.AcceptLegalFileNamesOnly();
+
                 var command = new Command("the-command")
                 {
-                    new Option<string[]>("-x").AcceptLegalFileNamesOnly()
+                    option
                 };
 
                 var validFileName = Path.GetFileName(Directory.GetCurrentDirectory());

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -24,8 +24,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_accepts_only_specific_arguments_but_a_wrong_one_is_supplied_then_an_informative_error_is_returned()
         {
-            var option = new Option<string>("-x")
-                .AcceptOnlyFromAmong("this", "that", "the-other-thing");
+            var option = new Option<string>("-x");
+            option.AcceptOnlyFromAmong("this", "that", "the-other-thing");
 
             var result = option.Parse("-x none-of-those");
 
@@ -40,8 +40,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_en_error_then_the_error_has_a_reference_to_the_option()
         {
-            var option = new Option<string>("-x")
-                .AcceptOnlyFromAmong("this", "that");
+            var option = new Option<string>("-x");
+            option.AcceptOnlyFromAmong("this", "that");
 
             var result = option.Parse("-x something_else");
 
@@ -54,7 +54,8 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1475
         public void When_FromAmong_is_used_then_the_OptionResult_ErrorMessage_is_set()
         {
-            var option = new Option<string>("--opt").AcceptOnlyFromAmong("a", "b");
+            var option = new Option<string>("--opt");
+            option.AcceptOnlyFromAmong("a", "b");
             var command = new Command("test") { option };
 
             var parseResult = command.Parse("test --opt c");

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -582,9 +582,11 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFilePathsOnly_rejects_option_arguments_containing_invalid_path_characters()
             {
+                Option<string> option = new ("-x");
+                option.AcceptLegalFilePathsOnly();
                 var command = new Command("the-command")
                 {
-                    new Option<string>("-x").AcceptLegalFilePathsOnly()
+                    option
                 };
 
                 var invalidCharacter = Path.GetInvalidPathChars().First(c => c != '"');
@@ -620,9 +622,12 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFilePathsOnly_accepts_option_arguments_containing_valid_path_characters()
             {
+                Option<string[]> option = new ("-x");
+                option.AcceptLegalFilePathsOnly();
+
                 var command = new Command("the-command")
                 {
-                    new Option<string[]>("-x").AcceptLegalFilePathsOnly()
+                    option
                 };
 
                 var validPathName = Directory.GetCurrentDirectory();

--- a/src/System.CommandLine.Tests/TestApps/Trimming/Program.cs
+++ b/src/System.CommandLine.Tests/TestApps/Trimming/Program.cs
@@ -1,7 +1,8 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 
-var fileArgument = new Argument<FileInfo>().AcceptLegalFileNamesOnly();
+var fileArgument = new Argument<FileInfo>();
+fileArgument.AcceptLegalFileNamesOnly();
 
 var command = new RootCommand
 {

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -204,7 +204,6 @@ namespace System.CommandLine
         /// <summary>
         /// Configures the argument to accept only values representing legal file paths.
         /// </summary>
-        /// <returns>The configured argument.</returns>
         public void AcceptLegalFilePathsOnly()
         {
             var invalidPathChars = Path.GetInvalidPathChars();
@@ -231,8 +230,7 @@ namespace System.CommandLine
         /// Configures the argument to accept only values representing legal file names.
         /// </summary>
         /// <remarks>A parse error will result, for example, if file path separators are found in the parsed value.</remarks>
-        /// <returns>The configured argument.</returns>
-        public Argument<T> AcceptLegalFileNamesOnly()
+        public void AcceptLegalFileNamesOnly()
         {
             var invalidFileNameChars = Path.GetInvalidFileNameChars();
 
@@ -249,8 +247,6 @@ namespace System.CommandLine
                     }
                 }
             });
-
-            return this;
         }
     }
 }

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -205,7 +205,7 @@ namespace System.CommandLine
         /// Configures the argument to accept only values representing legal file paths.
         /// </summary>
         /// <returns>The configured argument.</returns>
-        public Argument<T> AcceptLegalFilePathsOnly()
+        public void AcceptLegalFilePathsOnly()
         {
             var invalidPathChars = Path.GetInvalidPathChars();
 
@@ -225,8 +225,6 @@ namespace System.CommandLine
                     }
                 }
             });
-
-            return this;
         }
 
         /// <summary>

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -174,8 +174,7 @@ namespace System.CommandLine
         /// Configures the argument to accept only the specified values, and to suggest them as command line completions.
         /// </summary>
         /// <param name="values">The values that are allowed for the argument.</param>
-        /// <returns>The configured argument.</returns>
-        public Argument<T> AcceptOnlyFromAmong(params string[] values)
+        public void AcceptOnlyFromAmong(params string[] values)
         {
             if (values is not null && values.Length > 0)
             {
@@ -184,8 +183,6 @@ namespace System.CommandLine
                 CompletionSources.Clear();
                 CompletionSources.Add(values);
             }
-
-            return this;
 
             void UnrecognizedArgumentError(ArgumentResult argumentResult)
             {

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -108,18 +108,12 @@ namespace System.CommandLine
         /// <summary>
         /// Configures the option to accept only values representing legal file paths.
         /// </summary>
-        /// <returns>The configured option.</returns>
         public void AcceptLegalFilePathsOnly() => _argument.AcceptLegalFilePathsOnly();
 
         /// <summary>
         /// Configures the option to accept only values representing legal file names.
         /// </summary>
         /// <remarks>A parse error will result, for example, if file path separators are found in the parsed value.</remarks>
-        /// <returns>The configured option.</returns>
-        public Option<T> AcceptLegalFileNamesOnly()
-        {
-            _argument.AcceptLegalFileNamesOnly();
-            return this;
-        }
+        public void AcceptLegalFileNamesOnly() => _argument.AcceptLegalFileNamesOnly();
     }
 }

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -103,13 +103,7 @@ namespace System.CommandLine
         /// Configures the option to accept only the specified values, and to suggest them as command line completions.
         /// </summary>
         /// <param name="values">The values that are allowed for the option.</param>
-        /// <returns>The configured option.</returns>
-        public Option<T> AcceptOnlyFromAmong(params string[] values)
-        {
-            _argument.AcceptOnlyFromAmong(values);
-
-            return this;
-        }
+        public void AcceptOnlyFromAmong(params string[] values) => _argument.AcceptOnlyFromAmong(values);
 
         /// <summary>
         /// Configures the option to accept only values representing legal file paths.

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -109,11 +109,7 @@ namespace System.CommandLine
         /// Configures the option to accept only values representing legal file paths.
         /// </summary>
         /// <returns>The configured option.</returns>
-        public Option<T> AcceptLegalFilePathsOnly()
-        {
-            _argument.AcceptLegalFilePathsOnly();
-            return this;
-        }
+        public void AcceptLegalFilePathsOnly() => _argument.AcceptLegalFilePathsOnly();
 
         /// <summary>
         /// Configures the option to accept only values representing legal file names.


### PR DESCRIPTION
Based on the feedback from @bartonjs 