### PR TITLE
Added one test for DragonFruit when parsing <summary> tag

### DIFF
--- a/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/CommandLineTests.cs
@@ -94,6 +94,30 @@ namespace System.CommandLine.DragonFruit.Tests
         }
 
         [Fact]
+        public async Task When_XML_documentation_comment_contains_a_para_tag_and_some_text_then_help_skips_text_outside_para_tag()
+        {
+            int exitCode = await CommandLine.InvokeMethodAsync(
+                new[] { "--help" },
+                TestProgram.TestMainMethodInfoWithTextAndPara,
+                null,
+                _testProgram, 
+                _terminal);
+
+            exitCode.Should().Be(0);
+
+            var stdOut = _terminal.Out.ToString();
+
+            stdOut.Should()
+                .Contain("<args>  These are arguments")
+                .And.Contain("Arguments:");
+            stdOut.Should()
+                .ContainAll("--name <name>", "Specifies the name option")
+                .And.Contain("Options:");
+            stdOut.Should()
+                .Contain($"Description:{Environment.NewLine}  Help for the test program{Environment.NewLine}  More help for the test program{Environment.NewLine}");
+        }
+
+        [Fact]
         public void It_synchronously_shows_help_text_based_on_XML_documentation_comments()
         {
             int exitCode = CommandLine.InvokeMethod(

--- a/src/System.CommandLine.DragonFruit.Tests/TestProgram.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/TestProgram.cs
@@ -11,6 +11,8 @@ namespace System.CommandLine.DragonFruit.Tests
         
         public static readonly MethodInfo TestMainMethodInfoWithPara = typeof(TestProgram).GetMethod(nameof(TestMainWithPara));
 
+        public static readonly MethodInfo TestMainMethodInfoWithTextAndPara = typeof(TestProgram).GetMethod(nameof(TestMainWithTextAndPara));
+
         public static readonly MethodInfo TestMainMethodInfoWithDefault = typeof(TestProgram).GetMethod(nameof(TestMainWithDefault));
 
         /// <summary>
@@ -21,6 +23,25 @@ namespace System.CommandLine.DragonFruit.Tests
         /// <param name="console"></param>
         /// <param name="args">These are arguments</param>
         public void TestMainWithPara(string name, IConsole console, string[] args = null)
+        {
+            console.Out.Write(name);
+            if (args != null && args.Length > 0)
+            {
+                console.Out.Write($"args: { string.Join(",", args) }");
+            }
+        }
+
+        /// <summary>
+        /// Skipped help for the test program
+        /// More skipped help for the test program<para>Help for the test program</para>More skipped help for the test program
+        /// More skipped help for the test program<para>More help for the test program</para>More skipped help for the test program
+        ///
+        /// More skipped help for the test program
+        /// </summary>
+        /// <param name="name">Specifies the name option</param>
+        /// <param name="console"></param>
+        /// <param name="args">These are arguments</param>
+        public void TestMainWithTextAndPara(string name, IConsole console, string[] args = null)
         {
             console.Out.Write(name);
             if (args != null && args.Length > 0)


### PR DESCRIPTION
As for today the issue described in #415 do not exists anymore. 

When `<summary>` tag contains any `<para>` tag, only text inside `<para>` tag will be printed. Everything else will be ommited.

I have added one test to cover this scenario. 