### PR TITLE
SymbolResults improvements

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -426,7 +426,6 @@ System.CommandLine.Parsing
     public System.String ErrorMessage { get; set; }
     public System.CommandLine.LocalizationResources LocalizationResources { get; }
     public SymbolResult Parent { get; }
-    public System.CommandLine.Symbol Symbol { get; }
     public System.Collections.Generic.IReadOnlyList<Token> Tokens { get; }
     public ArgumentResult FindResultFor(System.CommandLine.Argument argument)
     public CommandResult FindResultFor(System.CommandLine.Command command)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -424,7 +424,7 @@ System.CommandLine.Parsing
   public abstract class SymbolResult
     public System.Collections.Generic.IReadOnlyList<SymbolResult> Children { get; }
     public System.String ErrorMessage { get; set; }
-    public System.CommandLine.LocalizationResources LocalizationResources { get; set; }
+    public System.CommandLine.LocalizationResources LocalizationResources { get; }
     public SymbolResult Parent { get; }
     public System.CommandLine.Symbol Symbol { get; }
     public System.Collections.Generic.IReadOnlyList<Token> Tokens { get; }

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -393,6 +393,7 @@ System.CommandLine.Parsing
   public class CommandLineStringSplitter
     public System.Collections.Generic.IEnumerable<System.String> Split(System.String commandLine)
   public class CommandResult : SymbolResult
+    public System.Collections.Generic.IEnumerable<SymbolResult> Children { get; }
     public System.CommandLine.Command Command { get; }
     public Token Token { get; }
   public class OptionResult : SymbolResult
@@ -422,7 +423,6 @@ System.CommandLine.Parsing
     public static System.Threading.Tasks.Task<System.Int32> InvokeAsync(this Parser parser, System.String[] args, System.CommandLine.IConsole console = null, System.Threading.CancellationToken cancellationToken = null)
     public static System.CommandLine.ParseResult Parse(this Parser parser, System.String commandLine)
   public abstract class SymbolResult
-    public System.Collections.Generic.IReadOnlyList<SymbolResult> Children { get; }
     public System.String ErrorMessage { get; set; }
     public System.CommandLine.LocalizationResources LocalizationResources { get; }
     public SymbolResult Parent { get; }

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -131,7 +131,7 @@ namespace System.CommandLine.Tests
                 argument.Parse("x")
                         .Errors
                         .Should()
-                        .ContainSingle(e => e.SymbolResult.Symbol == argument)
+                        .ContainSingle(e => ((ArgumentResult)e.SymbolResult).Argument == argument)
                         .Which
                         .Message
                         .Should()
@@ -150,7 +150,7 @@ namespace System.CommandLine.Tests
                 argument.Parse("")
                         .Errors
                         .Should()
-                        .ContainSingle(e => e.SymbolResult.Symbol == argument)
+                        .ContainSingle(e => ((ArgumentResult)e.SymbolResult).Argument == argument)
                         .Which
                         .Message
                         .Should()
@@ -248,7 +248,10 @@ namespace System.CommandLine.Tests
 
                 argumentResult
                     .Parent
-                    .Symbol
+                    .Should()
+                    .BeOfType<OptionResult>()
+                    .Which
+                    .Option
                     .Should()
                     .Be(command.Options.Single());
             }
@@ -274,9 +277,12 @@ namespace System.CommandLine.Tests
                 argumentResult
                     .Parent
                     .Parent
-                    .Symbol
                     .Should()
-                    .Be(command);
+                    .BeAssignableTo<CommandResult>()
+                    .Which
+                    .Command
+                    .Should()
+                    .BeSameAs(command);
             }
             
             [Theory]
@@ -333,9 +339,12 @@ namespace System.CommandLine.Tests
 
                 argumentResult
                     .Parent
-                    .Symbol
                     .Should()
-                    .Be(command);
+                    .BeAssignableTo<CommandResult>()
+                    .Which
+                    .Command
+                    .Should()
+                    .BeSameAs(command);
             }
 
             [Fact]

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -31,7 +31,7 @@ namespace System.CommandLine.Tests
 
             result
                 .RootCommandResult
-                .Symbol
+                .Command
                 .Name
                 .Should()
                 .Be("outer");
@@ -45,7 +45,10 @@ namespace System.CommandLine.Tests
             result
                 .CommandResult
                 .Parent
-                .Symbol
+                .Should()
+                .BeAssignableTo<CommandResult>()
+                .Which
+                .Command
                 .Name
                 .Should()
                 .Be("outer");
@@ -57,7 +60,10 @@ namespace System.CommandLine.Tests
             var result = _parser.Parse("outer inner --option argument1");
 
             result.CommandResult
-                  .Symbol
+                  .Should()
+                  .BeOfType<CommandResult>()
+                  .Which
+                  .Command
                   .Name
                   .Should()
                   .Be("inner");
@@ -71,7 +77,10 @@ namespace System.CommandLine.Tests
             result.CommandResult
                   .Children
                   .ElementAt(0)
-                  .Symbol
+                  .Should()
+                  .BeOfType<OptionResult>()
+                  .Which
+                  .Option
                   .Name
                   .Should()
                   .Be("option");
@@ -195,7 +204,7 @@ namespace System.CommandLine.Tests
 
             var result = outer.Parse(input);
 
-            result.CommandResult.Symbol.Name.Should().Be(expectedCommand);
+            result.CommandResult.Command.Name.Should().Be(expectedCommand);
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ParseResultTests.cs
+++ b/src/System.CommandLine.Tests/ParseResultTests.cs
@@ -75,12 +75,12 @@ namespace System.CommandLine.Tests
 
             var result = new Parser(command).Parse("outer inner-one inner-two");
 
-            result.CommandResult.Symbol.Name.Should().Be("inner-one");
+            result.CommandResult.Command.Name.Should().Be("inner-one");
             result.Errors.Count.Should().Be(1);
 
             var result2 = new Parser(command).Parse("outer inner-two inner-one");
 
-            result2.CommandResult.Symbol.Name.Should().Be("inner-two");
+            result2.CommandResult.Command.Name.Should().Be("inner-two");
             result2.Errors.Count.Should().Be(1);
         }
     }

--- a/src/System.CommandLine.Tests/ParserTests.MultiplePositions.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultiplePositions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Parsing;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
@@ -141,7 +142,15 @@ namespace System.CommandLine.Tests
                 var result = outer.Parse(commandLine);
 
                 result.Errors.Should().BeEmpty();
-                result.CommandResult.Parent.Symbol.Name.Should().Be(expectedParent);
+                result.CommandResult
+                    .Parent
+                    .Should()
+                    .BeOfType<CommandResult>()
+                    .Which
+                    .Command
+                    .Name
+                    .Should()
+                    .Be(expectedParent);
             }
 
             [Fact]

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -129,7 +129,7 @@ namespace System.CommandLine.Tests
 
             result.CommandResult
                   .Children
-                  .Select(o => o.Symbol.Name)
+                  .Select(o => ((OptionResult)o).Option.Name)
                   .Should()
                   .BeEquivalentTo("x", "y", "z");
         }
@@ -172,7 +172,7 @@ namespace System.CommandLine.Tests
 
             result.CommandResult
                   .Children
-                  .Select(o => o.Symbol.Name)
+                  .Select(o => ((OptionResult)o).Option.Name)
                   .Should()
                   .BeEquivalentTo("xyz");
         }
@@ -427,13 +427,13 @@ namespace System.CommandLine.Tests
                   .Children
                   .Should()
                   .ContainSingle(o =>
-                                     o.Symbol.Name == "inner1" &&
+                                     ((OptionResult)o).Option.Name == "inner1" &&
                                      o.Tokens.Single().Value == "argument1");
             result.CommandResult
                   .Children
                   .Should()
                   .ContainSingle(o =>
-                                     o.Symbol.Name == "inner2" &&
+                                     ((OptionResult)o).Option.Name == "inner2" &&
                                      o.Tokens.Single().Value == "argument2");
         }
 
@@ -669,11 +669,11 @@ namespace System.CommandLine.Tests
                   .Parent
                   .Children
                   .Should()
-                  .NotContain(o => o.Symbol.Name == "x");
+                  .AllBeAssignableTo<CommandResult>();
             result.CommandResult
                   .Children
                   .Should()
-                  .ContainSingle(o => o.Symbol.Name == "x");
+                  .ContainSingle(o => ((OptionResult)o).Option.Name == "x");
         }
 
         [Fact]
@@ -695,7 +695,7 @@ namespace System.CommandLine.Tests
                   .Parent
                   .Children
                   .Should()
-                  .ContainSingle(o => o.Symbol.Name == "x");
+                  .ContainSingle(o => o is OptionResult && ((OptionResult)o).Option.Name == "x");
         }
 
         [Fact]
@@ -1003,7 +1003,7 @@ namespace System.CommandLine.Tests
                   .Parent
                   .Children
                   .Should()
-                  .Contain(c => c.Symbol == option);
+                  .Contain(o => ((OptionResult)o).Option == option);
         }
 
         [Fact]
@@ -1020,12 +1020,12 @@ namespace System.CommandLine.Tests
 
             parser.Parse("-a").CommandResult
                   .Children
-                  .Select(s => s.Symbol)
+                  .Select(s => ((OptionResult)s).Option)
                   .Should()
                   .BeEquivalentTo(option1);
             parser.Parse("--a").CommandResult
                   .Children
-                  .Select(s => s.Symbol)
+                  .Select(s => ((OptionResult)s).Option)
                   .Should()
                   .BeEquivalentTo(option2);
         }

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -667,6 +667,9 @@ namespace System.CommandLine.Tests
 
             result.CommandResult
                   .Parent
+                  .Should()
+                  .BeAssignableTo<CommandResult>()
+                  .Which
                   .Children
                   .Should()
                   .AllBeAssignableTo<CommandResult>();
@@ -693,6 +696,9 @@ namespace System.CommandLine.Tests
                   .BeEmpty();
             result.CommandResult
                   .Parent
+                  .Should()
+                  .BeAssignableTo<CommandResult>()
+                  .Which
                   .Children
                   .Should()
                   .ContainSingle(o => o is OptionResult && ((OptionResult)o).Option.Name == "x");
@@ -1001,6 +1007,9 @@ namespace System.CommandLine.Tests
             parser.Parse("outer --inner inner")
                   .CommandResult
                   .Parent
+                  .Should()
+                  .BeAssignableTo<CommandResult>()
+                  .Which
                   .Children
                   .Should()
                   .Contain(o => ((OptionResult)o).Option == option);

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -48,7 +48,7 @@ namespace System.CommandLine.Tests
             result.Errors
                   .Where(e => e.SymbolResult != null)
                   .Should()
-                  .Contain(e => e.SymbolResult.Symbol.Name == option.Name);
+                  .Contain(e => ((OptionResult)e.SymbolResult).Option.Name == option.Name);
         }
 
         [Fact] // https://github.com/dotnet/command-line-api/issues/1475
@@ -201,7 +201,7 @@ namespace System.CommandLine.Tests
                   .Should()
                   .HaveCount(1)
                   .And
-                  .Contain(e => e.SymbolResult.Symbol == command)
+                  .Contain(e => ((CommandResult)e.SymbolResult).Command == command)
                   .Which
                   .Message
                   .Should()
@@ -225,7 +225,7 @@ namespace System.CommandLine.Tests
                   .Should()
                   .HaveCount(1)
                   .And
-                  .Contain(e => e.SymbolResult.Symbol == command)
+                  .Contain(e => ((CommandResult)e.SymbolResult).Command == command)
                   .Which
                   .Message
                   .Should()
@@ -308,8 +308,8 @@ namespace System.CommandLine.Tests
 
             command.Validators.Add(commandResult =>
             {
-                if (commandResult.Children.Any(sr => sr.Symbol is IdentifierSymbol id && id.HasAlias("--one")) &&
-                    commandResult.Children.Any(sr => sr.Symbol is IdentifierSymbol id && id.HasAlias("--two")))
+                if (commandResult.Children.Any(sr => ((OptionResult)sr).Option.HasAlias("--one")) &&
+                    commandResult.Children.Any(sr => ((OptionResult)sr).Option.HasAlias("--two")))
                 {
                     commandResult.ErrorMessage = "Options '--one' and '--two' cannot be used together.";
                 }
@@ -346,7 +346,7 @@ namespace System.CommandLine.Tests
                   .Should()
                   .HaveCount(1)
                   .And
-                  .Contain(e => e.SymbolResult.Symbol == option)
+                  .Contain(e => ((OptionResult)e.SymbolResult).Option == option)
                   .Which
                   .Message
                   .Should()
@@ -373,7 +373,7 @@ namespace System.CommandLine.Tests
                   .Should()
                   .HaveCount(1)
                   .And
-                  .Contain(e => e.SymbolResult.Symbol == argument)
+                  .Contain(e => ((ArgumentResult)e.SymbolResult).Argument == argument)
                   .Which
                   .Message
                   .Should()
@@ -442,7 +442,7 @@ namespace System.CommandLine.Tests
                   .Should()
                   .HaveCount(1)
                   .And
-                  .Contain(e => e.SymbolResult.Symbol == option)
+                  .Contain(e => ((OptionResult)e.SymbolResult).Option == option)
                   .Which
                   .Message
                   .Should()
@@ -575,7 +575,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol == command.Arguments.First() &&
+                      .Contain(e => ((ArgumentResult)e.SymbolResult).Argument == command.Arguments.First() &&
                                     e.Message == $"Character not allowed in a path: '{invalidCharacter}'.");
             }   
             
@@ -597,7 +597,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "x" &&
+                      .Contain(e => ((OptionResult)e.SymbolResult).Option.Name == "x" &&
                                     e.Message == $"Character not allowed in a path: '{invalidCharacter}'.");
             }
 
@@ -660,7 +660,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol == command.Arguments.First() &&
+                      .Contain(e => ((ArgumentResult)e.SymbolResult).Argument == command.Arguments.First() &&
                                     e.Message == $"Character not allowed in a file name: '{invalidCharacter}'.");
             }
 
@@ -683,7 +683,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "x" &&
+                      .Contain(e => ((OptionResult)e.SymbolResult).Option.Name == "x" &&
                                     e.Message == $"Character not allowed in a file name: '{invalidCharacter}'.");
             }
 
@@ -743,7 +743,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .Contain(e => ((ArgumentResult)e.SymbolResult).Argument.Name == "to" &&
                                     e.Message == $"File does not exist: '{path}'.");
             }
 
@@ -762,7 +762,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .Contain(e => ((OptionResult)e.SymbolResult).Option.Name == "to" &&
                                     e.Message == $"File does not exist: '{path}'.");
             }
 
@@ -781,7 +781,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .Contain(e => ((ArgumentResult)e.SymbolResult).Argument.Name == "to" &&
                                     e.Message == $"Directory does not exist: '{path}'.");
             }
 
@@ -800,7 +800,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .Contain(e => ((OptionResult)e.SymbolResult).Option.Name == "to" &&
                                     e.Message == $"Directory does not exist: '{path}'.");
             }
 
@@ -819,7 +819,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol == command.Arguments.First() &&
+                      .Contain(e => ((ArgumentResult)e.SymbolResult).Argument == command.Arguments.First() &&
                                     e.Message == $"File or directory does not exist: '{path}'.");
             }
 
@@ -838,7 +838,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .Contain(e => ((OptionResult)e.SymbolResult).Option.Name == "to" &&
                                     e.Message == $"File or directory does not exist: '{path}'.");
             }
 
@@ -857,7 +857,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "to" && 
+                      .Contain(e => ((ArgumentResult)e.SymbolResult).Argument.Name == "to" && 
                                     e.Message == $"File does not exist: '{path}'.");
             }
             
@@ -876,7 +876,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .Contain(e => e.SymbolResult.Symbol.Name == "to" && 
+                      .Contain(e => ((OptionResult)e.SymbolResult).Option.Name == "to" && 
                                     e.Message == $"File does not exist: '{path}'.");
             }
 
@@ -895,7 +895,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .ContainSingle(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .ContainSingle(e => ((ArgumentResult)e.SymbolResult).Argument.Name == "to" &&
                                           e.Message == $"Directory does not exist: '{path}'.");
             }
 
@@ -914,7 +914,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .ContainSingle(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .ContainSingle(e => ((OptionResult)e.SymbolResult).Option.Name == "to" &&
                                           e.Message == $"Directory does not exist: '{path}'.");
             }
 
@@ -935,7 +935,7 @@ namespace System.CommandLine.Tests
 
                 result.Errors
                       .Should()
-                      .ContainSingle(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .ContainSingle(e => ((ArgumentResult)e.SymbolResult).Argument.Name == "to" &&
                                           e.Message == $"File or directory does not exist: '{path}'.");
             }
 
@@ -954,7 +954,7 @@ namespace System.CommandLine.Tests
 
                 result.Errors
                       .Should()
-                      .ContainSingle(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .ContainSingle(e => ((OptionResult)e.SymbolResult).Option.Name == "to" &&
                                           e.Message == $"File or directory does not exist: '{path}'.");
             }
 
@@ -973,7 +973,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .ContainSingle(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .ContainSingle(e => ((ArgumentResult)e.SymbolResult).Argument.Name == "to" &&
                                           e.Message == $"File or directory does not exist: '{path}'.");
             }
 
@@ -992,7 +992,7 @@ namespace System.CommandLine.Tests
                       .Should()
                       .HaveCount(1)
                       .And
-                      .ContainSingle(e => e.SymbolResult.Symbol.Name == "to" &&
+                      .ContainSingle(e => ((OptionResult)e.SymbolResult).Option.Name == "to" &&
                                           e.Message == $"File or directory does not exist: '{path}'.");
             }
 
@@ -1083,7 +1083,7 @@ namespace System.CommandLine.Tests
                   .Should()
                   .ContainSingle(
                       e => e.Message.Equals(LocalizationResources.Instance.RequiredCommandWasNotProvided()) &&
-                           e.SymbolResult.Symbol.Name.Equals("inner"));
+                           ((CommandResult)e.SymbolResult).Command.Name.Equals("inner"));
         }
 
         [Fact]
@@ -1099,7 +1099,7 @@ namespace System.CommandLine.Tests
                   .Should()
                   .ContainSingle(
                       e => e.Message.Equals(LocalizationResources.Instance.RequiredCommandWasNotProvided()) &&
-                           e.SymbolResult.Symbol == rootCommand);
+                           ((CommandResult)e.SymbolResult).Command == rootCommand);
         }
 
         [Fact]

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -647,7 +647,7 @@ ERR:
             {
                 if (context.ParseResult.FindResultFor(versionOption) is { })
                 {
-                    if (context.ParseResult.Errors.Any(e => e.SymbolResult?.Symbol is VersionOption))
+                    if (context.ParseResult.Errors.Any(e => e.SymbolResult is OptionResult optionResult && optionResult.Option is VersionOption))
                     {
                         context.InvocationResult = static ctx => ParseErrorResult.Apply(ctx, null);
                     }
@@ -688,7 +688,7 @@ ERR:
             {
                 if (context.ParseResult.FindResultFor(versionOption) is { })
                 {
-                    if (context.ParseResult.Errors.Any(e => e.SymbolResult?.Symbol is VersionOption))
+                    if (context.ParseResult.Errors.Any(e => e.SymbolResult is OptionResult optionResult && optionResult.Option is VersionOption))
                     {
                         context.InvocationResult = static ctx => ParseErrorResult.Apply(ctx, null);
                     }

--- a/src/System.CommandLine/Help/VersionOption.cs
+++ b/src/System.CommandLine/Help/VersionOption.cs
@@ -37,7 +37,7 @@ namespace System.CommandLine.Help
                     parent.Children.Where(r => !(r is OptionResult optionResult && optionResult.Option is VersionOption))
                           .Any(IsNotImplicit))
                 {
-                    result.ErrorMessage =  result.LocalizationResources.VersionOptionCannotBeCombinedWithOtherArguments(result.Token?.Value);
+                    result.ErrorMessage = result.LocalizationResources.VersionOptionCannotBeCombinedWithOtherArguments(result.Token?.Value ?? result.Option.Name);
                 }
             });
         }

--- a/src/System.CommandLine/Help/VersionOption.cs
+++ b/src/System.CommandLine/Help/VersionOption.cs
@@ -31,13 +31,13 @@ namespace System.CommandLine.Help
 
         private void AddValidators()
         {
-            Validators.Add(result =>
+            Validators.Add(static result =>
             {
                 if (result.Parent is { } parent &&
-                    parent.Children.Where(r => r.Symbol is not VersionOption)
+                    parent.Children.Where(r => !(r is OptionResult optionResult && optionResult.Option is VersionOption))
                           .Any(IsNotImplicit))
                 {
-                    result.ErrorMessage =  result.LocalizationResources.VersionOptionCannotBeCombinedWithOtherArguments(result.Token?.Value ?? result.Symbol.Name);
+                    result.ErrorMessage =  result.LocalizationResources.VersionOptionCannotBeCombinedWithOtherArguments(result.Token?.Value);
                 }
             });
         }

--- a/src/System.CommandLine/Help/VersionOption.cs
+++ b/src/System.CommandLine/Help/VersionOption.cs
@@ -33,7 +33,7 @@ namespace System.CommandLine.Help
         {
             Validators.Add(static result =>
             {
-                if (result.Parent is { } parent &&
+                if (result.Parent is CommandResult parent &&
                     parent.Children.Where(r => !(r is OptionResult optionResult && optionResult.Option is VersionOption))
                           .Any(IsNotImplicit))
                 {

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -207,9 +207,14 @@ namespace System.CommandLine
         public IEnumerable<CompletionItem> GetCompletions(
             int? position = null)
         {
-            var currentSymbolResult = SymbolToComplete(position);
+            SymbolResult currentSymbolResult = SymbolToComplete(position);
 
-            var currentSymbol = currentSymbolResult.Symbol;
+            Symbol currentSymbol = currentSymbolResult switch
+            {
+                ArgumentResult argumentResult => argumentResult.Argument,
+                OptionResult optionResult => optionResult.Option,
+                _ => ((CommandResult)currentSymbolResult).Command
+            };
 
             var context = GetCompletionContext();
 

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -16,15 +16,17 @@ namespace System.CommandLine.Parsing
 
         internal ArgumentResult(
             Argument argument,
-            SymbolResult? parent) : base(argument, parent)
+            SymbolResult? parent) : base(parent)
         {
-            Argument = argument;
+            Argument = argument ?? throw new ArgumentNullException(nameof(argument));
         }
 
         /// <summary>
         /// The argument to which the result applies.
         /// </summary>
         public Argument Argument { get; }
+
+        internal override int MaximumArgumentCapacity => Argument.Arity.MaximumNumberOfValues;
 
         internal bool IsImplicit => Argument.HasDefaultValue && Tokens.Count == 0;
 

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -16,10 +16,9 @@ namespace System.CommandLine.Parsing
             Command command,
             Token token,
             CommandResult? parent = null) :
-            base(command ?? throw new ArgumentNullException(nameof(command)),
-                 parent)
+            base(parent)
         {
-            Command = command;
+            Command = command ?? throw new ArgumentNullException(nameof(command));
             Token = token ?? throw new ArgumentNullException(nameof(token));
         }
 
@@ -32,6 +31,26 @@ namespace System.CommandLine.Parsing
         /// The token that was parsed to specify the command.
         /// </summary>
         public Token Token { get; }
+
+        internal sealed override int MaximumArgumentCapacity
+        {
+            get
+            {
+                var value = 0;
+
+                if (Command.HasArguments)
+                {
+                    var arguments = Command.Arguments;
+
+                    for (var i = 0; i < arguments.Count; i++)
+                    {
+                        value += arguments[i].Arity.MaximumNumberOfValues;
+                    }
+                }
+
+                return value;
+            }
+        }
 
         internal override bool UseDefaultValueFor(Argument argument) =>
             FindResultFor(argument) switch

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -11,6 +11,7 @@ namespace System.CommandLine.Parsing
     public class CommandResult : SymbolResult
     {
         private Dictionary<Argument, ArgumentResult>? _defaultArgumentValues;
+        private List<SymbolResult>? _children;
 
         internal CommandResult(
             Command command,
@@ -32,6 +33,11 @@ namespace System.CommandLine.Parsing
         /// </summary>
         public Token Token { get; }
 
+        /// <summary>
+        /// Child symbol results in the parse tree.
+        /// </summary>
+        public IReadOnlyList<SymbolResult> Children => _children is not null ? _children : Array.Empty<SymbolResult>();
+
         internal sealed override int MaximumArgumentCapacity
         {
             get
@@ -51,6 +57,8 @@ namespace System.CommandLine.Parsing
                 return value;
             }
         }
+
+        internal void AddChild(SymbolResult symbolResult) => (_children ??= new()).Add(symbolResult);
 
         internal override bool UseDefaultValueFor(Argument argument) =>
             FindResultFor(argument) switch

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -10,9 +10,6 @@ namespace System.CommandLine.Parsing
     /// </summary>
     public class CommandResult : SymbolResult
     {
-        private Dictionary<Argument, ArgumentResult>? _defaultArgumentValues;
-        private List<SymbolResult>? _children;
-
         internal CommandResult(
             Command command,
             Token token,
@@ -36,7 +33,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// Child symbol results in the parse tree.
         /// </summary>
-        public IReadOnlyList<SymbolResult> Children => _children is not null ? _children : Array.Empty<SymbolResult>();
+        public IEnumerable<SymbolResult> Children => GetChildren(this);
 
         internal sealed override int MaximumArgumentCapacity
         {
@@ -58,8 +55,6 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        internal void AddChild(SymbolResult symbolResult) => (_children ??= new()).Add(symbolResult);
-
         internal override bool UseDefaultValueFor(Argument argument) =>
             FindResultFor(argument) switch
             {
@@ -67,10 +62,5 @@ namespace System.CommandLine.Parsing
                                       arg.Tokens.Count == 0,
                 _ => false
             };
-
-        internal ArgumentResult GetOrCreateDefaultArgumentResult(Argument argument) =>
-            (_defaultArgumentValues ??= new()).GetOrAdd(
-                argument,
-                arg => new ArgumentResult(arg, this));
     }
 }

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.CommandLine.Binding;
 using System.Diagnostics.CodeAnalysis;
 
@@ -12,9 +11,7 @@ namespace System.CommandLine.Parsing
     /// </summary>
     public sealed class OptionResult : SymbolResult
     {
-        private List<ArgumentResult>? _children;
         private ArgumentConversionResult? _argumentConversionResult;
-        private Dictionary<Argument, ArgumentResult>? _defaultArgumentValues;
 
         internal OptionResult(
             Option option,
@@ -80,9 +77,9 @@ namespace System.CommandLine.Parsing
             {
                 if (_argumentConversionResult is null)
                 {
-                    if (_children is not null)
+                    if (FindResultFor(Option.Argument) is ArgumentResult firstChild)
                     {
-                        return _argumentConversionResult = _children[0].GetArgumentConversionResult();
+                        return _argumentConversionResult = firstChild.GetArgumentConversionResult();
                     }
 
                     return _argumentConversionResult = ArgumentConversionResult.None(Option.Argument);
@@ -92,13 +89,6 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        internal void AddChild(ArgumentResult argumentResult) => (_children ??= new()).Add(argumentResult);
-
         internal override bool UseDefaultValueFor(Argument argument) => IsImplicit;
-
-        internal ArgumentResult GetOrCreateDefaultArgumentResult(Argument argument) =>
-            (_defaultArgumentValues ??= new()).GetOrAdd(
-                argument,
-                arg => new ArgumentResult(arg, this));
     }
 }

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -19,10 +19,9 @@ namespace System.CommandLine.Parsing
             Option option,
             Token? token = null,
             CommandResult? parent = null) :
-            base(option ?? throw new ArgumentNullException(nameof(option)),
-                 parent)
+            base(parent)
         {
-            Option = option;
+            Option = option ?? throw new ArgumentNullException(nameof(option));
             Token = token;
         }
 
@@ -41,6 +40,8 @@ namespace System.CommandLine.Parsing
         /// The token that was parsed to specify the option.
         /// </summary>
         public Token? Token { get; }
+
+        internal override int MaximumArgumentCapacity => Option.Argument.Arity.MaximumNumberOfValues;
 
         /// <inheritdoc cref="GetValueOrDefault{T}"/>
         public object? GetValueOrDefault() =>

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -12,6 +12,7 @@ namespace System.CommandLine.Parsing
     /// </summary>
     public sealed class OptionResult : SymbolResult
     {
+        private List<ArgumentResult>? _children;
         private ArgumentConversionResult? _argumentConversionResult;
         private Dictionary<Argument, ArgumentResult>? _defaultArgumentValues;
 
@@ -79,14 +80,9 @@ namespace System.CommandLine.Parsing
             {
                 if (_argumentConversionResult is null)
                 {
-                    for (var i = 0; i < Children.Count; i++)
+                    if (_children is not null)
                     {
-                        var child = Children[i];
-
-                        if (child is ArgumentResult argumentResult)
-                        {
-                            return _argumentConversionResult = argumentResult.GetArgumentConversionResult();
-                        }
+                        return _argumentConversionResult = _children[0].GetArgumentConversionResult();
                     }
 
                     return _argumentConversionResult = ArgumentConversionResult.None(Option.Argument);
@@ -95,7 +91,9 @@ namespace System.CommandLine.Parsing
                 return _argumentConversionResult;
             }
         }
-        
+
+        internal void AddChild(ArgumentResult argumentResult) => (_children ??= new()).Add(argumentResult);
+
         internal override bool UseDefaultValueFor(Argument argument) => IsImplicit;
 
         internal ArgumentResult GetOrCreateDefaultArgumentResult(Argument argument) =>

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -159,10 +159,8 @@ namespace System.CommandLine.Parsing
                     builder.Append("[ ");
                     builder.Append(symbolResult.Token().Value);
 
-                    for (var i = 0; i < symbolResult.Children.Count; i++)
+                    foreach (SymbolResult child in symbolResult.GetChildren(symbolResult))
                     {
-                        var child = symbolResult.Children[i];
-
                         if (child is ArgumentResult arg &&
                             (arg.Argument.ValueType == typeof(bool) ||
                              arg.Argument.Arity.MaximumNumberOfValues == 0))

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -121,9 +121,8 @@ namespace System.CommandLine.Parsing
             _rootCommandResult = new RootCommandResult(
                 rootCommandNode.Command,
                 rootCommandNode.Token,
-                _symbolResults);
-
-            _rootCommandResult.LocalizationResources = _parser.Configuration.LocalizationResources;
+                _symbolResults,
+                _parser.Configuration.LocalizationResources ?? LocalizationResources.Instance);
 
             _innermostCommandResult = _rootCommandResult;
         }

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -185,11 +185,8 @@ namespace System.CommandLine.Parsing
         private void VisitOptionArgumentNode(
             OptionArgumentNode argumentNode)
         {
-            _symbolResults.TryGetValue(
-                argumentNode.ParentOptionNode.Option,
-                out var optionResult);
-
-            if (optionResult is not OptionResult)
+            if (!(_symbolResults.TryGetValue(argumentNode.ParentOptionNode.Option, out SymbolResult? symbolResult)
+                    && symbolResult is OptionResult optionResult))
             {
                 return;
             }

--- a/src/System.CommandLine/Parsing/RootCommandResult.cs
+++ b/src/System.CommandLine/Parsing/RootCommandResult.cs
@@ -8,14 +8,19 @@ namespace System.CommandLine.Parsing
     internal sealed class RootCommandResult : CommandResult
     {
         private readonly Dictionary<Symbol, SymbolResult> _symbolResults;
+        private readonly LocalizationResources _localizationResources;
 
         public RootCommandResult(
             Command command,
             Token token,
-            Dictionary<Symbol, SymbolResult> symbolResults) : base(command, token)
+            Dictionary<Symbol, SymbolResult> symbolResults,
+            LocalizationResources localizationResources) : base(command, token)
         {
             _symbolResults = symbolResults;
+            _localizationResources = localizationResources;
         }
+
+        public override LocalizationResources LocalizationResources => _localizationResources;
 
         public override ArgumentResult? FindResultFor(Argument argument)
             => _symbolResults.TryGetValue(argument, out SymbolResult? result) ? (ArgumentResult)result : default;

--- a/src/System.CommandLine/Parsing/RootCommandResult.cs
+++ b/src/System.CommandLine/Parsing/RootCommandResult.cs
@@ -30,5 +30,16 @@ namespace System.CommandLine.Parsing
 
         public override OptionResult? FindResultFor(Option option)
             => _symbolResults.TryGetValue(option, out SymbolResult? result) ? (OptionResult)result : default;
+
+        internal override IEnumerable<SymbolResult> GetChildren(SymbolResult parent)
+        {
+            foreach (var pair in _symbolResults)
+            {
+                if (ReferenceEquals(parent, pair.Value.Parent))
+                {
+                    yield return pair.Value;
+                }
+            }
+        }
     }
 }

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -16,12 +16,8 @@ namespace System.CommandLine.Parsing
         private List<SymbolResult>? _children;
         private protected List<Token>? _tokens;
 
-        private protected SymbolResult(
-            Symbol symbol, 
-            SymbolResult? parent)
+        private protected SymbolResult(SymbolResult? parent)
         {
-            Symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
-
             Parent = parent;
         }
 
@@ -44,11 +40,6 @@ namespace System.CommandLine.Parsing
         public SymbolResult? Parent { get; }
 
         /// <summary>
-        /// The symbol to which the result applies.
-        /// </summary>
-        public Symbol Symbol { get; }
-
-        /// <summary>
         /// The list of tokens associated with this symbol result during parsing.
         /// </summary>
         public IReadOnlyList<Token> Tokens => _tokens is not null ? _tokens : Array.Empty<Token>();
@@ -58,38 +49,7 @@ namespace System.CommandLine.Parsing
         private protected virtual int RemainingArgumentCapacity =>
             MaximumArgumentCapacity - Tokens.Count;
 
-        internal int MaximumArgumentCapacity
-        {
-            get
-            {
-                switch (Symbol)
-                {
-                    case Option option:
-                        return option.Argument.Arity.MaximumNumberOfValues;
-
-                    case Argument argument:
-                        return argument.Arity.MaximumNumberOfValues;
-
-                    case Command command:
-                        var value = 0;
-
-                        if (command.HasArguments)
-                        {
-                            var arguments = command.Arguments;
-
-                            for (var i = 0; i < arguments.Count; i++)
-                            {
-                                value += arguments[i].Arity.MaximumNumberOfValues;
-                            }
-                        }
-
-                        return value;
-
-                    default:
-                        throw new NotSupportedException();
-                }
-            }
-        }
+        internal abstract int MaximumArgumentCapacity { get; }
 
         /// <summary>
         /// Localization resources used to produce messages for this symbol result.

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -15,7 +15,6 @@ namespace System.CommandLine.Parsing
     {
         private List<SymbolResult>? _children;
         private protected List<Token>? _tokens;
-        private LocalizationResources? _resources;
 
         private protected SymbolResult(
             Symbol symbol, 
@@ -95,11 +94,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// Localization resources used to produce messages for this symbol result.
         /// </summary>
-        public LocalizationResources LocalizationResources
-        {
-            get => _resources ??= Parent?.LocalizationResources ?? LocalizationResources.Instance;
-            set => _resources = value;
-        }
+        public virtual LocalizationResources LocalizationResources => GetRoot().LocalizationResources;
 
         internal void AddToken(Token token) => (_tokens ??= new()).Add(token);
 

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -13,7 +13,6 @@ namespace System.CommandLine.Parsing
     /// </summary>
     public abstract class SymbolResult
     {
-        private List<SymbolResult>? _children;
         private protected List<Token>? _tokens;
 
         private protected SymbolResult(SymbolResult? parent)
@@ -26,13 +25,6 @@ namespace System.CommandLine.Parsing
         /// </summary>
         /// <remarks>Setting this value to a non-<c>null</c> during parsing will cause the parser to indicate an error for the user and prevent invocation of the command line.</remarks>
         public string? ErrorMessage { get; set; }
-
-        /// <summary>
-        /// Child symbol results in the parse tree.
-        /// </summary>
-        public IReadOnlyList<SymbolResult> Children => _children is not null ? _children : Array.Empty<SymbolResult>();
-
-        internal void AddChild(SymbolResult symbolResult) => (_children ??= new()).Add(symbolResult);
 
         /// <summary>
         /// The parent symbol result in the parse tree.

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -71,6 +71,8 @@ namespace System.CommandLine.Parsing
         /// <returns>An option result if the option was matched by the parser or has a default value; otherwise, <c>null</c>.</returns>
         public virtual OptionResult? FindResultFor(Option option) => GetRoot().FindResultFor(option);
 
+        internal virtual IEnumerable<SymbolResult> GetChildren(SymbolResult parent) => GetRoot().GetChildren(parent);
+
         private SymbolResult GetRoot()
         {
             SymbolResult result = this;

--- a/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
@@ -7,13 +7,13 @@ namespace System.CommandLine.Parsing
 {
     internal static class SymbolResultExtensions
     {
-        internal static IEnumerable<SymbolResult> AllSymbolResults(this SymbolResult symbolResult)
+        internal static IEnumerable<SymbolResult> AllSymbolResults(this CommandResult commandResult)
         {
-            yield return symbolResult;
+            yield return commandResult;
 
-            foreach (var item in symbolResult
+            foreach (var item in commandResult
                                  .Children
-                                 .FlattenBreadthFirst(o => o.Children))
+                                 .FlattenBreadthFirst(o => o.GetChildren(o)))
             {
                 yield return item;
             }
@@ -28,7 +28,7 @@ namespace System.CommandLine.Parsing
                 _ => throw new ArgumentOutOfRangeException(nameof(symbolResult))
             };
 
-            Token CreateImplicitToken(Option option)
+            static Token CreateImplicitToken(Option option)
             {
                 return new Token(option.GetLongestAlias(removePrefix: false), TokenType.Option, option, Parsing.Token.ImplicitPosition);
             }


### PR DESCRIPTION
SymbolResults improvements based on feedback from our last meeting ([notes](https://gist.github.com/adamsitnik/b7531299c37753c3ccc3bb37e832036f)):

- single, readonly LocalizationResources for entire symbol tree
- removed Symbol from SymbolResult, as each derived type defines a more specific property (OptionResult.Option etc)
- moved SymbolResult.Children to Command.Children, as it's the only type that officially has them (the fact that Option has them is an implementation detail)
- removed a lot of allocations by not storing a list of children per symbol/command and re-using the information present in symbol dictionary (we just search for instances with Parent equal to given symbol result)

I still need to implement a copy-free approach for `Symbol.Tokens` and I don't like the fact that many of the SymbolResults properties/methods are virtual and just calling `Root.MethodAbc`. I'll send another PR tomorrow or just update this one.