### PR TITLE
Build System.CommandLine.NamingConventionBinder during source-build

### DIFF
--- a/sourcebuild.slnf
+++ b/sourcebuild.slnf
@@ -4,6 +4,7 @@
     "projects": [
       "src\\System.CommandLine\\System.CommandLine.csproj",
       "src\\System.CommandLine.DragonFruit\\System.CommandLine.DragonFruit.csproj",
+      "src\\System.CommandLine.NamingConventionBinder\\System.CommandLine.NamingConventionBinder.csproj",
       "src\\System.CommandLine.Rendering\\System.CommandLine.Rendering.csproj"
     ]
   }


### PR DESCRIPTION
Fixes #2025 