### PR TITLE
More SymbolResult improvements

### DIFF
--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -278,7 +278,7 @@ namespace System.CommandLine.Tests
                     .Parent
                     .Parent
                     .Should()
-                    .BeAssignableTo<CommandResult>()
+                    .BeOfType<CommandResult>()
                     .Which
                     .Command
                     .Should()
@@ -340,7 +340,7 @@ namespace System.CommandLine.Tests
                 argumentResult
                     .Parent
                     .Should()
-                    .BeAssignableTo<CommandResult>()
+                    .BeOfType<CommandResult>()
                     .Which
                     .Command
                     .Should()

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -46,7 +46,7 @@ namespace System.CommandLine.Tests
                 .CommandResult
                 .Parent
                 .Should()
-                .BeAssignableTo<CommandResult>()
+                .BeOfType<CommandResult>()
                 .Which
                 .Command
                 .Name

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -668,7 +668,7 @@ namespace System.CommandLine.Tests
             result.CommandResult
                   .Parent
                   .Should()
-                  .BeAssignableTo<CommandResult>()
+                  .BeOfType<CommandResult>()
                   .Which
                   .Children
                   .Should()
@@ -697,7 +697,7 @@ namespace System.CommandLine.Tests
             result.CommandResult
                   .Parent
                   .Should()
-                  .BeAssignableTo<CommandResult>()
+                  .BeOfType<CommandResult>()
                   .Which
                   .Children
                   .Should()
@@ -1008,7 +1008,7 @@ namespace System.CommandLine.Tests
                   .CommandResult
                   .Parent
                   .Should()
-                  .BeAssignableTo<CommandResult>()
+                  .BeOfType<CommandResult>()
                   .Which
                   .Children
                   .Should()

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -113,7 +113,7 @@ namespace System.CommandLine
         /// <returns>Returns the default value for the argument, if defined. Null otherwise.</returns>
         public object? GetDefaultValue()
         {
-            return GetDefaultValue(new ArgumentResult(this, null));
+            return GetDefaultValue(new ArgumentResult(this, null!, null));
         }
 
         internal abstract object? GetDefaultValue(ArgumentResult argumentResult);

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -15,14 +15,14 @@ namespace System.CommandLine
     public class ParseResult
     {
         private readonly IReadOnlyList<ParseError> _errors;
-        private readonly RootCommandResult _rootCommandResult;
+        private readonly CommandResult _rootCommandResult;
         private readonly IReadOnlyList<Token> _unmatchedTokens;
         private Dictionary<string, IReadOnlyList<string>>? _directives;
         private CompletionContext? _completionContext;
 
         internal ParseResult(
             Parser parser,
-            RootCommandResult rootCommandResult,
+            CommandResult rootCommandResult,
             CommandResult commandResult,
             Dictionary<string, IReadOnlyList<string>>? directives,
             List<Token> tokens,

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -16,7 +16,8 @@ namespace System.CommandLine.Parsing
 
         internal ArgumentResult(
             Argument argument,
-            SymbolResult? parent) : base(parent)
+            SymbolResultTree symbolResultTree,
+            SymbolResult? parent) : base(symbolResultTree, parent)
         {
             Argument = argument ?? throw new ArgumentNullException(nameof(argument));
         }
@@ -110,7 +111,7 @@ namespace System.CommandLine.Parsing
 
             if (Parent!.UseDefaultValueFor(argument))
             {
-                var argumentResult = new ArgumentResult(argument, Parent);
+                var argumentResult = new ArgumentResult(argument, _symbolResultTree, Parent);
 
                 var defaultValue = argument.GetDefaultValue(argumentResult);
 

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -111,7 +111,7 @@ namespace System.CommandLine.Parsing
 
             if (Parent!.UseDefaultValueFor(argument))
             {
-                var argumentResult = new ArgumentResult(argument, _symbolResultTree, Parent);
+                var argumentResult = new ArgumentResult(argument, SymbolResultTree, Parent);
 
                 var defaultValue = argument.GetDefaultValue(argumentResult);
 

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -34,7 +34,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// Child symbol results in the parse tree.
         /// </summary>
-        public IEnumerable<SymbolResult> Children => _symbolResultTree.GetChildren(this);
+        public IEnumerable<SymbolResult> Children => SymbolResultTree.GetChildren(this);
 
         internal sealed override int MaximumArgumentCapacity
         {

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -8,13 +8,14 @@ namespace System.CommandLine.Parsing
     /// <summary>
     /// A result produced when parsing a <see cref="Command" />.
     /// </summary>
-    public class CommandResult : SymbolResult
+    public sealed class CommandResult : SymbolResult
     {
         internal CommandResult(
             Command command,
             Token token,
+            SymbolResultTree symbolResultTree,
             CommandResult? parent = null) :
-            base(parent)
+            base(symbolResultTree, parent)
         {
             Command = command ?? throw new ArgumentNullException(nameof(command));
             Token = token ?? throw new ArgumentNullException(nameof(token));
@@ -33,7 +34,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// Child symbol results in the parse tree.
         /// </summary>
-        public IEnumerable<SymbolResult> Children => GetChildren(this);
+        public IEnumerable<SymbolResult> Children => _symbolResultTree.GetChildren(this);
 
         internal sealed override int MaximumArgumentCapacity
         {

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -15,9 +15,10 @@ namespace System.CommandLine.Parsing
 
         internal OptionResult(
             Option option,
+            SymbolResultTree symbolResultTree,
             Token? token = null,
             CommandResult? parent = null) :
-            base(parent)
+            base(symbolResultTree, parent)
         {
             Option = option ?? throw new ArgumentNullException(nameof(option));
             Token = token;

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -102,6 +102,12 @@ namespace System.CommandLine.Parsing
 
                     if (currentArgumentCount < argument.Arity.MaximumNumberOfValues)
                     {
+                        if (CurrentToken.Symbol is null)
+                        {
+                            // update the token with missing information now, so later stages don't need to modify it
+                            CurrentToken.Symbol = argument;
+                        }
+
                         var argumentNode = new CommandArgumentNode(
                             CurrentToken,
                             argument,

--- a/src/System.CommandLine/Parsing/ParseResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/ParseResultExtensions.cs
@@ -159,7 +159,7 @@ namespace System.CommandLine.Parsing
                     builder.Append("[ ");
                     builder.Append(symbolResult.Token().Value);
 
-                    foreach (SymbolResult child in symbolResult.GetChildren(symbolResult))
+                    foreach (SymbolResult child in symbolResult.SymbolResultTree.GetChildren(symbolResult))
                     {
                         if (child is ArgumentResult arg &&
                             (arg.Argument.ValueType == typeof(bool) ||

--- a/src/System.CommandLine/Parsing/ParseResultVisitor.cs
+++ b/src/System.CommandLine/Parsing/ParseResultVisitor.cs
@@ -140,13 +140,8 @@ namespace System.CommandLine.Parsing
                 AddToResult(argumentResult);
             }
 
-            var token = argumentNode.Token.Symbol is null
-                            ? new Token(argumentNode.Token.Value, TokenType.Argument, argumentResult.Argument)
-                            : argumentNode.Token;
-
-            argumentResult.AddToken(token);
-
-            _innermostCommandResult?.AddToken(token);
+            argumentResult.AddToken(argumentNode.Token);
+            _innermostCommandResult?.AddToken(argumentNode.Token);
         }
 
         private void VisitOptionNode(OptionNode optionNode)

--- a/src/System.CommandLine/Parsing/Parser.cs
+++ b/src/System.CommandLine/Parsing/Parser.cs
@@ -56,7 +56,8 @@ namespace System.CommandLine.Parsing
                 tokens,
                 tokenizationErrors,
                 operation.UnmatchedTokens,
-                rawInput);
+                rawInput,
+                operation.RootCommandNode!);
 
             visitor.Visit(operation.RootCommandNode!);
 

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -12,12 +12,12 @@ namespace System.CommandLine.Parsing
     /// </summary>
     public abstract class SymbolResult
     {
-        private protected readonly SymbolResultTree _symbolResultTree;
+        internal readonly SymbolResultTree SymbolResultTree;
         private protected List<Token>? _tokens;
 
         private protected SymbolResult(SymbolResultTree symbolResultTree, SymbolResult? parent)
         {
-            _symbolResultTree = symbolResultTree;
+            SymbolResultTree = symbolResultTree;
             Parent = parent;
         }
 
@@ -47,7 +47,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// Localization resources used to produce messages for this symbol result.
         /// </summary>
-        public LocalizationResources LocalizationResources => _symbolResultTree.LocalizationResources;
+        public LocalizationResources LocalizationResources => SymbolResultTree.LocalizationResources;
 
         internal void AddToken(Token token) => (_tokens ??= new()).Add(token);
 
@@ -56,23 +56,21 @@ namespace System.CommandLine.Parsing
         /// </summary>
         /// <param name="argument">The argument for which to find a result.</param>
         /// <returns>An argument result if the argument was matched by the parser or has a default value; otherwise, <c>null</c>.</returns>
-        public ArgumentResult? FindResultFor(Argument argument) => _symbolResultTree.FindResultFor(argument);
+        public ArgumentResult? FindResultFor(Argument argument) => SymbolResultTree.FindResultFor(argument);
 
         /// <summary>
         /// Finds a result for the specific command anywhere in the parse tree, including parent and child symbol results.
         /// </summary>
         /// <param name="command">The command for which to find a result.</param>
         /// <returns>An command result if the command was matched by the parser; otherwise, <c>null</c>.</returns>
-        public CommandResult? FindResultFor(Command command) => _symbolResultTree.FindResultFor(command);
+        public CommandResult? FindResultFor(Command command) => SymbolResultTree.FindResultFor(command);
 
         /// <summary>
         /// Finds a result for the specific option anywhere in the parse tree, including parent and child symbol results.
         /// </summary>
         /// <param name="option">The option for which to find a result.</param>
         /// <returns>An option result if the option was matched by the parser or has a default value; otherwise, <c>null</c>.</returns>
-        public OptionResult? FindResultFor(Option option) => _symbolResultTree.FindResultFor(option);
-
-        internal IEnumerable<SymbolResult> GetChildren(SymbolResult parent) => _symbolResultTree.GetChildren(parent);
+        public OptionResult? FindResultFor(Option option) => SymbolResultTree.FindResultFor(option);
 
         /// <inheritdoc cref="ParseResult.GetValue(Argument)"/>
         public T GetValue<T>(Argument<T> argument)

--- a/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultExtensions.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine.Parsing
 
             foreach (var item in commandResult
                                  .Children
-                                 .FlattenBreadthFirst(o => o.GetChildren(o)))
+                                 .FlattenBreadthFirst(o => o.SymbolResultTree.GetChildren(o)))
             {
                 yield return item;
             }

--- a/src/System.CommandLine/Parsing/SymbolResultTree.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultTree.cs
@@ -31,11 +31,14 @@ namespace System.CommandLine.Parsing
 
         internal IEnumerable<SymbolResult> GetChildren(SymbolResult parent)
         {
-            foreach (KeyValuePair<Symbol, SymbolResult> pair in _symbolResults)
+            if (parent is not ArgumentResult)
             {
-                if (ReferenceEquals(parent, pair.Value.Parent))
+                foreach (KeyValuePair<Symbol, SymbolResult> pair in _symbolResults)
                 {
-                    yield return pair.Value;
+                    if (ReferenceEquals(parent, pair.Value.Parent))
+                    {
+                        yield return pair.Value;
+                    }
                 }
             }
         }

--- a/src/System.CommandLine/Parsing/SymbolResultTree.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultTree.cs
@@ -5,35 +5,31 @@ using System.Collections.Generic;
 
 namespace System.CommandLine.Parsing
 {
-    internal sealed class SymbolResultTree
+    internal sealed class SymbolResultTree : Dictionary<Symbol, SymbolResult>
     {
-        private readonly Dictionary<Symbol, SymbolResult> _symbolResults;
         private readonly LocalizationResources _localizationResources;
 
-        internal SymbolResultTree(
-            Dictionary<Symbol, SymbolResult> symbolResults,
-            LocalizationResources localizationResources)
+        internal SymbolResultTree(LocalizationResources localizationResources)
         {
-            _symbolResults = symbolResults;
             _localizationResources = localizationResources;
         }
 
         internal LocalizationResources LocalizationResources => _localizationResources;
 
         internal ArgumentResult? FindResultFor(Argument argument)
-            => _symbolResults.TryGetValue(argument, out SymbolResult? result) ? (ArgumentResult)result : default;
+            => TryGetValue(argument, out SymbolResult? result) ? (ArgumentResult)result : default;
 
         internal CommandResult? FindResultFor(Command command)
-            => _symbolResults.TryGetValue(command, out SymbolResult? result) ? (CommandResult)result : default;
+            => TryGetValue(command, out SymbolResult? result) ? (CommandResult)result : default;
 
         internal OptionResult? FindResultFor(Option option)
-            => _symbolResults.TryGetValue(option, out SymbolResult? result) ? (OptionResult)result : default;
+            => TryGetValue(option, out SymbolResult? result) ? (OptionResult)result : default;
 
         internal IEnumerable<SymbolResult> GetChildren(SymbolResult parent)
         {
             if (parent is not ArgumentResult)
             {
-                foreach (KeyValuePair<Symbol, SymbolResult> pair in _symbolResults)
+                foreach (KeyValuePair<Symbol, SymbolResult> pair in this)
                 {
                     if (ReferenceEquals(parent, pair.Value.Parent))
                     {

--- a/src/System.CommandLine/Parsing/SymbolResultTree.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultTree.cs
@@ -5,35 +5,33 @@ using System.Collections.Generic;
 
 namespace System.CommandLine.Parsing
 {
-    internal sealed class RootCommandResult : CommandResult
+    internal sealed class SymbolResultTree
     {
         private readonly Dictionary<Symbol, SymbolResult> _symbolResults;
         private readonly LocalizationResources _localizationResources;
 
-        public RootCommandResult(
-            Command command,
-            Token token,
+        internal SymbolResultTree(
             Dictionary<Symbol, SymbolResult> symbolResults,
-            LocalizationResources localizationResources) : base(command, token)
+            LocalizationResources localizationResources)
         {
             _symbolResults = symbolResults;
             _localizationResources = localizationResources;
         }
 
-        public override LocalizationResources LocalizationResources => _localizationResources;
+        internal LocalizationResources LocalizationResources => _localizationResources;
 
-        public override ArgumentResult? FindResultFor(Argument argument)
+        internal ArgumentResult? FindResultFor(Argument argument)
             => _symbolResults.TryGetValue(argument, out SymbolResult? result) ? (ArgumentResult)result : default;
 
-        public override CommandResult? FindResultFor(Command command)
+        internal CommandResult? FindResultFor(Command command)
             => _symbolResults.TryGetValue(command, out SymbolResult? result) ? (CommandResult)result : default;
 
-        public override OptionResult? FindResultFor(Option option)
+        internal OptionResult? FindResultFor(Option option)
             => _symbolResults.TryGetValue(option, out SymbolResult? result) ? (OptionResult)result : default;
 
-        internal override IEnumerable<SymbolResult> GetChildren(SymbolResult parent)
+        internal IEnumerable<SymbolResult> GetChildren(SymbolResult parent)
         {
-            foreach (var pair in _symbolResults)
+            foreach (KeyValuePair<Symbol, SymbolResult> pair in _symbolResults)
             {
                 if (ReferenceEquals(parent, pair.Value.Parent))
                 {

--- a/src/System.CommandLine/Parsing/Token.cs
+++ b/src/System.CommandLine/Parsing/Token.cs
@@ -46,7 +46,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The Symbol represented by the token (if any).
         /// </summary>
-        internal Symbol? Symbol { get; }
+        internal Symbol? Symbol { get; set; }
 
         /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as Token);


### PR DESCRIPTION
* remove RootCommandResult (internal), introduce SymbolResultTree (internal) and make all virtual SymbolResult methods non-virtual and delegating to SymbolResultTree
* remove internal SymbolResult.GetChildren, expose SymbolResult.SymbolResultTree as internal field, optimize SymbolResultTree.GetChildren for AgumentResult
* make SymbolResultTree derive from Dictionary<Symbol, SymbolResult
* update the token with missing information during parsing, so later stages don't need to modify it
* refactor the code so root command and inner most command are never nulls

I was not able to finish the removal of a list copy per symbol result:
https://github.com/dotnet/command-line-api/commit/d84ca2aaf8689bd719b029dcbad04fcb8e00f582
https://github.com/dotnet/command-line-api/commit/b28a616bc46ac5e55f67b709d8b6dfef0c68f238

I've run into situation where I am not sure whether this will be possible to implement, I'll finish that tomorrow.