### PR TITLE
UnrecognizedArgument error should mention first invalid argument, not the last one

### DIFF
--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -178,12 +178,12 @@ namespace System.CommandLine.Tests
             option.Arity = new ArgumentArity(1, 4);
             option.AllowMultipleArgumentsPerToken = true;
 
-            var command = new Command("--list")
+            var command = new Command("list")
             {
                 option
             };
 
-            var result = command.Parse("--list --columns c1 c2");
+            var result = command.Parse("list --columns c1 c2");
 
             // Currently there is no possibility for a single validator to produce multiple errors,
             // so only the first one is checked.

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -171,6 +171,29 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void When_FromAmong_is_used_and_multiple_invalid_inputs_are_provided_the_error_mentions_first_invalid_argument()
+        {
+            Option<string[]> option = new(new[] { "--columns" });
+            option.AcceptOnlyFromAmong("author", "language", "tags", "type");
+            option.Arity = new ArgumentArity(1, 4);
+            option.AllowMultipleArgumentsPerToken = true;
+
+            var command = new Command("--list")
+            {
+                option
+            };
+
+            var result = command.Parse("--list --columns c1 c2");
+
+            // Currently there is no possibility for a single validator to produce multiple errors,
+            // so only the first one is checked.
+            result.Errors[0]
+                  .Message
+                  .Should()
+                  .Be(LocalizationResources.Instance.UnrecognizedArgument("c1", new[] { "author", "language", "tags", "type" }));
+        }
+
+        [Fact]
         public void When_a_required_argument_is_not_supplied_then_an_error_is_returned()
         {
             var option = new Option<string>("-x");

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -195,6 +195,7 @@ namespace System.CommandLine
                         if (Array.IndexOf(values, token.Value) < 0)
                         {
                             argumentResult.ErrorMessage = argumentResult.LocalizationResources.UnrecognizedArgument(token.Value, values);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
In #1959 I've introduce a bug that SDK has hit in https://github.com/dotnet/sdk/pull/29131

Previously, the method was returning error for the first mismatch:

https://github.com/dotnet/command-line-api/blob/82273cb56c83b589e8e5b63da0ac9745ffc6e105/src/System.CommandLine/Parsing/SymbolResult.cs#L132-L135

After my changes it was the last one. This fix just helps me to unblock the SDK update, it does not solve the problem of producing multiple errors by a single validator.