### PR TITLE
Parent search bug fix

### DIFF
--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -57,20 +57,25 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1563
         public void Command_GetCompletions_returns_available_option_aliases_for_global_options()
         {
-            var subcommand = new Command("command")
+            var subcommand2 = new Command("command2")
             {
                 new Option<string>("--one", "option one"),
                 new Option<string>("--two", "option two")
             };
 
+            var subcommand1 = new Command("command1")
+            {
+                subcommand2
+            };
+
             var rootCommand = new RootCommand
             {
-                subcommand
+                subcommand1
             };
 
             rootCommand.AddGlobalOption(new Option<string>("--three", "option three"));
 
-            var completions = subcommand.GetCompletions(CompletionContext.Empty);
+            var completions = subcommand2.GetCompletions(CompletionContext.Empty);
 
             completions
                 .Select(item => item.Label)

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -205,7 +205,7 @@ namespace System.CommandLine
                         }
                     }
 
-                    parent = parent.Next;
+                    parent = parent.Symbol.FirstParent;
                 }
             }
 

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -192,20 +192,28 @@ namespace System.CommandLine
                 ParentNode? parent = FirstParent;
                 while (parent is not null)
                 {
-                    if (parent.Symbol is Command parentCommand && parentCommand.HasOptions)
-                    {
-                        for (var i = 0; i < parentCommand.Options.Count; i++)
-                        {
-                            var option = parentCommand.Options[i];
+                    Command parentCommand = (Command)parent.Symbol;
 
-                            if (option.IsGlobal)
+                    if (context.IsEmpty || context.ParseResult.FindResultFor(parentCommand) is not null)
+                    {
+                        if (parentCommand.HasOptions)
+                        {
+                            for (var i = 0; i < parentCommand.Options.Count; i++)
                             {
-                                AddCompletionsFor(option);
+                                var option = parentCommand.Options[i];
+
+                                if (option.IsGlobal)
+                                {
+                                    AddCompletionsFor(option);
+                                }
                             }
                         }
+                        parent = parent.Symbol.FirstParent;
                     }
-
-                    parent = parent.Symbol.FirstParent;
+                    else
+                    {
+                        parent = parent.Next;
+                    }
                 }
             }
 

--- a/src/System.CommandLine/Completions/CompletionContext.cs
+++ b/src/System.CommandLine/Completions/CompletionContext.cs
@@ -31,6 +31,8 @@ namespace System.CommandLine.Completions
         /// <remarks>Can be used for testing purposes.</remarks>
         public static CompletionContext Empty => _empty ??= new TokenCompletionContext(ParseResult.Empty());
 
+        internal bool IsEmpty => ReferenceEquals(this, _empty);
+
         /// <summary>
         /// Gets the text to be matched for completion, which can be used to filter a list of completions.
         /// </summary>


### PR DESCRIPTION
Every symbol can have multiple parents. When getting the completions for commands, the global options defined by the parent commands should be included as well. The problem was that we were searching only the parents of current command (flat, one level above), rather going up in the hierarchy to reach the root command

Discovered by https://github.com/dotnet/sdk/pull/29131