### PR TITLE
restore SymbolResult.Symbol

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -386,6 +386,7 @@ System.CommandLine.IO
 System.CommandLine.Parsing
   public class ArgumentResult : SymbolResult
     public System.CommandLine.Argument Argument { get; }
+    public System.CommandLine.Symbol Symbol { get; }
     public System.Object GetValueOrDefault()
     public T GetValueOrDefault<T>()
     public System.Void OnlyTake(System.Int32 numberOfTokens)
@@ -395,10 +396,12 @@ System.CommandLine.Parsing
   public class CommandResult : SymbolResult
     public System.Collections.Generic.IEnumerable<SymbolResult> Children { get; }
     public System.CommandLine.Command Command { get; }
+    public System.CommandLine.Symbol Symbol { get; }
     public Token Token { get; }
   public class OptionResult : SymbolResult
     public System.Boolean IsImplicit { get; }
     public System.CommandLine.Option Option { get; }
+    public System.CommandLine.Symbol Symbol { get; }
     public Token Token { get; }
     public System.Object GetValueOrDefault()
     public T GetValueOrDefault<T>()
@@ -426,6 +429,7 @@ System.CommandLine.Parsing
     public System.String ErrorMessage { get; set; }
     public System.CommandLine.LocalizationResources LocalizationResources { get; }
     public SymbolResult Parent { get; }
+    public System.CommandLine.Symbol Symbol { get; }
     public System.Collections.Generic.IReadOnlyList<Token> Tokens { get; }
     public ArgumentResult FindResultFor(System.CommandLine.Argument argument)
     public CommandResult FindResultFor(System.CommandLine.Command command)

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -647,7 +647,7 @@ ERR:
             {
                 if (context.ParseResult.FindResultFor(versionOption) is { })
                 {
-                    if (context.ParseResult.Errors.Any(e => e.SymbolResult is OptionResult optionResult && optionResult.Option is VersionOption))
+                    if (context.ParseResult.Errors.Any(e => e.SymbolResult?.Symbol is VersionOption))
                     {
                         context.InvocationResult = static ctx => ParseErrorResult.Apply(ctx, null);
                     }
@@ -688,7 +688,7 @@ ERR:
             {
                 if (context.ParseResult.FindResultFor(versionOption) is { })
                 {
-                    if (context.ParseResult.Errors.Any(e => e.SymbolResult is OptionResult optionResult && optionResult.Option is VersionOption))
+                    if (context.ParseResult.Errors.Any(e => e.SymbolResult?.Symbol is VersionOption))
                     {
                         context.InvocationResult = static ctx => ParseErrorResult.Apply(ctx, null);
                     }

--- a/src/System.CommandLine/Help/VersionOption.cs
+++ b/src/System.CommandLine/Help/VersionOption.cs
@@ -34,7 +34,7 @@ namespace System.CommandLine.Help
             Validators.Add(static result =>
             {
                 if (result.Parent is CommandResult parent &&
-                    parent.Children.Where(r => !(r is OptionResult optionResult && optionResult.Option is VersionOption))
+                    parent.Children.Where(r => r.Symbol is not VersionOption)
                           .Any(IsNotImplicit))
                 {
                     result.ErrorMessage = result.LocalizationResources.VersionOptionCannotBeCombinedWithOtherArguments(result.Token?.Value ?? result.Option.Name);

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -209,12 +209,7 @@ namespace System.CommandLine
         {
             SymbolResult currentSymbolResult = SymbolToComplete(position);
 
-            Symbol currentSymbol = currentSymbolResult switch
-            {
-                ArgumentResult argumentResult => argumentResult.Argument,
-                OptionResult optionResult => optionResult.Option,
-                _ => ((CommandResult)currentSymbolResult).Command
-            };
+            Symbol currentSymbol = currentSymbolResult.Symbol;
 
             var context = GetCompletionContext();
 

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -22,6 +22,9 @@ namespace System.CommandLine.Parsing
             Argument = argument ?? throw new ArgumentNullException(nameof(argument));
         }
 
+        /// <inheritdoc/>
+        public override Symbol Symbol => Argument;
+
         /// <summary>
         /// The argument to which the result applies.
         /// </summary>

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -21,6 +21,9 @@ namespace System.CommandLine.Parsing
             Token = token ?? throw new ArgumentNullException(nameof(token));
         }
 
+        /// <inheritdoc/>
+        public override Symbol Symbol => Command;
+
         /// <summary>
         /// The command to which the result applies.
         /// </summary>

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -24,6 +24,9 @@ namespace System.CommandLine.Parsing
             Token = token;
         }
 
+        /// <inheritdoc/>
+        public override Symbol Symbol => Option;
+
         /// <summary>
         /// The option to which the result applies.
         /// </summary>

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -22,6 +22,11 @@ namespace System.CommandLine.Parsing
         }
 
         /// <summary>
+        /// The symbol to which the result applies.
+        /// </summary>
+        public abstract Symbol Symbol { get; }
+
+        /// <summary>
         /// An error message for this symbol result.
         /// </summary>
         /// <remarks>Setting this value to a non-<c>null</c> during parsing will cause the parser to indicate an error for the user and prevent invocation of the command line.</remarks>


### PR DESCRIPTION
Based on feedback shared offline by @jonsequitur 

FWIW I wanted to make the derived SymbolResult types return the derived Symbol type, but it's currently not possible as this C# feature is not supported by libraries targeting .NET Standard:

```cs
abstract class SymbolResult
{
   abstract Symbol Symbol { get; }
}

class CommandResult
{
   override Command Symbol => _command;
}
```

```log
Target runtime doesn't support covariant types in overrides
```