### PR TITLE
use Validator to set Handler for VersionOption

### DIFF
--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Help;
-using System.CommandLine.Invocation;
-using System.CommandLine.IO;
 
 namespace System.CommandLine.Parsing
 {
@@ -20,7 +18,6 @@ namespace System.CommandLine.Parsing
         private Dictionary<string, IReadOnlyList<string>>? _directives;
         private CommandResult _innermostCommandResult;
         private bool _isHelpRequested;
-        private bool _isVersionRequested;
 
         public ParseOperation(
             List<Token> tokens,
@@ -62,7 +59,7 @@ namespace System.CommandLine.Parsing
                 Validate();
             }
 
-            ParseResult parseResult = new (
+            return new (
                 parser,
                 _rootCommandResult,
                 _innermostCommandResult,
@@ -71,17 +68,6 @@ namespace System.CommandLine.Parsing
                 _symbolResultTree.UnmatchedTokens,
                 _symbolResultTree.Errors,
                 _rawInput);
-
-            if (_isVersionRequested)
-            {
-                // FIX: (GetResult) use the ActiveOption's handler
-                parseResult.Handler = new AnonymousCommandHandler(context =>
-                {
-                    context.Console.Out.WriteLine(RootCommand.ExecutableVersion);
-                });
-            }
-
-            return parseResult;
         }
 
         private void ParseSubcommand()
@@ -190,10 +176,6 @@ namespace System.CommandLine.Parsing
                 if (option is HelpOption)
                 {
                     _isHelpRequested = true;
-                }
-                else if (option is VersionOption)
-                {
-                    _isVersionRequested = true;
                 }
 
                 optionResult = new OptionResult(


### PR DESCRIPTION
@jonsequitur while reviewing #1969 I reminded myself about the concept of `ActiveOption` and got to conclusion that it can be implemented by using existing public APIs.

During validaiton of an OptionResult we know that it's Parent must be CommandResult. CommandResult exposes Command, which exposes Handler. So we can set it during validation.

In case of VersionOption we can validate that there are no errors and then just set the handler.

I am not sure whether Validators should have side effects like this, I just want to hear your thoughts on this.