### PR TITLE
Rename Option.IsGlobal to AppliesToSelfAndChildren, make it public

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -54,7 +54,6 @@ System.CommandLine
     public System.Boolean TreatUnmatchedTokensAsErrors { get; set; }
     public System.Collections.Generic.List<System.Action<System.CommandLine.Parsing.CommandResult>> Validators { get; }
     public System.Void Add(Symbol symbol)
-    public System.Void AddGlobalOption(Option option)
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
     public System.Collections.Generic.IEnumerator<Symbol> GetEnumerator()
   public static class CommandExtensions
@@ -184,6 +183,7 @@ System.CommandLine
     public System.String VersionOptionDescription()
   public abstract class Option : IdentifierSymbol, System.CommandLine.Binding.IValueDescriptor
     public System.Boolean AllowMultipleArgumentsPerToken { get; set; }
+    public System.Boolean AppliesToSelfAndChildren { get; set; }
     public System.String ArgumentHelpName { get; set; }
     public ArgumentArity Arity { get; set; }
     public System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> CompletionSources { get; }

--- a/src/System.CommandLine.Tests/CommandLineConfigurationTests.cs
+++ b/src/System.CommandLine.Tests/CommandLineConfigurationTests.cs
@@ -170,13 +170,13 @@ public class CommandLineConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_there_are_duplicate_sibling_global_option_aliases_on_the_root_command()
     {
-        var option1 = new Option<string>("--dupe");
-        var option2 = new Option<string>("-y");
+        var option1 = new Option<string>("--dupe") { AppliesToSelfAndChildren = true };
+        var option2 = new Option<string>("-y") { AppliesToSelfAndChildren = true };
         option2.AddAlias("--dupe");
 
         var command = new RootCommand();
-        command.AddGlobalOption(option1);
-        command.AddGlobalOption(option2);
+        command.Options.Add(option1);
+        command.Options.Add(option2);
 
         var config = new CommandLineConfiguration(command);
 
@@ -200,7 +200,7 @@ public class CommandLineConfigurationTests
                 new Option<string>("--dupe")
             }
         };
-        rootCommand.AddGlobalOption(new Option<string>("--dupe"));
+        rootCommand.Options.Add(new Option<string>("--dupe") { AppliesToSelfAndChildren = true });
 
         var config = new CommandLineConfiguration(rootCommand);
 
@@ -219,7 +219,7 @@ public class CommandLineConfigurationTests
                 new Command("--dupe")
             }
         };
-        rootCommand.AddGlobalOption(new Option<string>("--dupe"));
+        rootCommand.Options.Add(new Option<string>("--dupe") { AppliesToSelfAndChildren = true });
 
         var config = new CommandLineConfiguration(rootCommand);
 

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -281,9 +281,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void AddGlobalOption_updates_Options_property()
         {
-            var option = new Option<string>("-x");
+            var option = new Option<string>("-x") { AppliesToSelfAndChildren = true };
             var command = new Command("mycommand");
-            command.AddGlobalOption(option);
+            command.Options.Add(option);
 
             command.Options
                    .Should()
@@ -303,7 +303,8 @@ namespace System.CommandLine.Tests
                 .Should()
                 .BeEmpty();
 
-            command.AddGlobalOption(option);
+            option.AppliesToSelfAndChildren = true;
+            command.Options.Add(option);
 
             command.Options
                 .Should()

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -73,7 +73,7 @@ namespace System.CommandLine.Tests
                 subcommand1
             };
 
-            rootCommand.AddGlobalOption(new Option<string>("--three", "option three"));
+            rootCommand.Options.Add(new Option<string>("--three", "option three") { AppliesToSelfAndChildren = true });
 
             var completions = subcommand2.GetCompletions(CompletionContext.Empty);
 

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -13,9 +13,9 @@ namespace System.CommandLine.Tests
         {
             var root = new Command("parent");
 
-            var option = new Option<int>("--global");
+            var option = new Option<int>("--global") { AppliesToSelfAndChildren = true };
 
-            root.AddGlobalOption(option);
+            root.Options.Add(option);
 
             var child = new Command("child");
 
@@ -32,9 +32,10 @@ namespace System.CommandLine.Tests
             command.SetHandler(() => { });
             var requiredOption = new Option<bool>("--i-must-be-set")
             {
-                IsRequired = true
+                IsRequired = true,
+                AppliesToSelfAndChildren = true
             };
-            rootCommand.AddGlobalOption(requiredOption);
+            rootCommand.Options.Add(requiredOption);
 
             var result = rootCommand.Parse("child");
 
@@ -50,9 +51,10 @@ namespace System.CommandLine.Tests
             var rootCommand = new RootCommand();
             var requiredOption = new Option<bool>(new[] { "-i", "--i-must-be-set" })
             {
-                IsRequired = true
+                IsRequired = true,
+                AppliesToSelfAndChildren = true
             };
-            rootCommand.AddGlobalOption(requiredOption);
+            rootCommand.Options.Add(requiredOption);
 
             var result = rootCommand.Parse("");
 
@@ -70,9 +72,10 @@ namespace System.CommandLine.Tests
             command.SetHandler(() => { });
             var requiredOption = new Option<bool>("--i-must-be-set")
             {
-                IsRequired = true
+                IsRequired = true,
+                AppliesToSelfAndChildren = true
             };
-            rootCommand.AddGlobalOption(requiredOption);
+            rootCommand.Options.Add(requiredOption);
 
             var result = rootCommand.Parse("child --i-must-be-set");
 
@@ -84,9 +87,9 @@ namespace System.CommandLine.Tests
         {
             var root = new Command("parent");
 
-            var option = new Option<int>("--global");
+            var option = new Option<int>("--global") { AppliesToSelfAndChildren = true };
 
-            root.AddGlobalOption(option);
+            root.Options.Add(option);
 
             var child = new Command("child");
 
@@ -106,9 +109,9 @@ namespace System.CommandLine.Tests
             
             root.Subcommands.Add(firstChild);
             
-            var option = new Option<int>("--global");
+            var option = new Option<int>("--global") { AppliesToSelfAndChildren = true };
             
-            firstChild.AddGlobalOption(option);
+            firstChild.Options.Add(option);
             
             var secondChild = new Command("second");
             

--- a/src/System.CommandLine.Tests/ParseResultTests.cs
+++ b/src/System.CommandLine.Tests/ParseResultTests.cs
@@ -98,13 +98,13 @@ namespace System.CommandLine.Tests
             {
                 leafCommand
             };
-            midCommand1.AddGlobalOption(new Option<string>("--three1", "option three 1"));
+            midCommand1.Options.Add(new Option<string>("--three1", "option three 1") { AppliesToSelfAndChildren = true });
 
             var midCommand2 = new Command("midCommand2")
             {
                 leafCommand
             };
-            midCommand2.AddGlobalOption(new Option<string>("--three2", "option three 2"));
+            midCommand2.Options.Add(new Option<string>("--three2", "option three 2") { AppliesToSelfAndChildren = true });
 
             var rootCommand = new Command("root")
             {

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -458,7 +458,7 @@ namespace System.CommandLine.Tests
         [InlineData("subcommand --file \"Foo\"")]
         public void Validators_on_global_options_are_executed_when_invoking_a_subcommand(string commandLine)
         {
-            var option = new Option<FileInfo>("--file");
+            var option = new Option<FileInfo>("--file") { AppliesToSelfAndChildren = true };
             option.Validators.Add(r =>
             {
                 r.AddError("Invoked validator");
@@ -469,7 +469,7 @@ namespace System.CommandLine.Tests
             {
                 subCommand
             };
-            rootCommand.AddGlobalOption(option);
+            rootCommand.Options.Add(option);
 
             var result = rootCommand.Parse(commandLine);
 
@@ -495,7 +495,11 @@ namespace System.CommandLine.Tests
         {
             var handlerWasCalled = false;
 
-            var globalOption = new Option<int>("--value");
+            var globalOption = new Option<int>("--value")
+            { 
+                AppliesToSelfAndChildren = true
+            };
+
             globalOption.Validators.Add(r => r.AddError("oops!"));
 
             var grandchildCommand = new Command("grandchild");
@@ -509,7 +513,7 @@ namespace System.CommandLine.Tests
                 childCommand
             };
 
-            rootCommand.AddGlobalOption(globalOption);
+            rootCommand.Options.Add(globalOption);
 
             rootCommand.SetHandler((int i) => handlerWasCalled = true, globalOption);
             childCommand.SetHandler((int i) => handlerWasCalled = true, globalOption);

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -364,7 +364,7 @@ ERR:
             if (builder.HelpOption is null)
             {
                 builder.HelpOption = helpOption;
-                builder.Command.AddGlobalOption(helpOption);
+                builder.Command.Options.Add(helpOption);
                 builder.MaxHelpWidth = maxWidth;
             }
             return builder;

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -82,18 +82,6 @@ namespace System.CommandLine
         internal bool HasValidators => _validators is not null && _validators.Count > 0;
 
         /// <summary>
-        /// Adds a global <see cref="Option"/> to the command.
-        /// </summary>
-        /// <param name="option">The global option to add to the command.</param>
-        /// <remarks>Global options are applied to the command and recursively to subcommands. They do not apply to
-        /// parent commands.</remarks>
-        public void AddGlobalOption(Option option)
-        {
-            option.AppliesToSelfAndChildren = true;
-            Options.Add(option);
-        }
-
-        /// <summary>
         /// Adds a <see cref="Symbol"/> to the command.
         /// </summary>
         /// <param name="symbol">The symbol to add to the command.</param>

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -89,7 +89,7 @@ namespace System.CommandLine
         /// parent commands.</remarks>
         public void AddGlobalOption(Option option)
         {
-            option.IsGlobal = true;
+            option.AppliesToSelfAndChildren = true;
             Options.Add(option);
         }
 
@@ -202,7 +202,7 @@ namespace System.CommandLine
                             {
                                 var option = parentCommand.Options[i];
 
-                                if (option.IsGlobal)
+                                if (option.AppliesToSelfAndChildren)
                                 {
                                     AddCompletionsFor(option);
                                 }

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -226,7 +226,7 @@ public partial class HelpBuilder
                                 foreach (var option in parentCommand.Options)
                                 {
                                     // global help aliases may be duplicated, we just ignore them
-                                    if (option.IsGlobal && !option.IsHidden && uniqueOptions.Add(option))
+                                    if (option.AppliesToSelfAndChildren && !option.IsHidden && uniqueOptions.Add(option))
                                     {
                                         options.Add(ctx.HelpBuilder.GetTwoColumnRow(option, ctx));
                                     }

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -125,7 +125,7 @@ namespace System.CommandLine.Help
                 {
                     if (!displayOptionTitle)
                     {
-                        displayOptionTitle = parentCommand.HasOptions && parentCommand.Options.Any(x => x.IsGlobal && !x.IsHidden);
+                        displayOptionTitle = parentCommand.HasOptions && parentCommand.Options.Any(x => x.AppliesToSelfAndChildren && !x.IsHidden);
                     }
 
                     yield return parentCommand.Name;

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -15,6 +15,7 @@ namespace System.CommandLine.Help
             : base(aliases, null, new Argument<bool> { Arity = ArgumentArity.Zero })
         {
             _localizationResources = getLocalizationResources;
+            AppliesToSelfAndChildren = true;
         }
 
         public HelpOption(Func<LocalizationResources> getLocalizationResources) : this(new[]

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -75,7 +75,7 @@ namespace System.CommandLine
         /// Global options are applied to the command and recursively to subcommands.
         /// They do not apply to parent commands.
         /// </summary>
-        internal bool IsGlobal { get; set; }
+        internal bool AppliesToSelfAndChildren { get; set; }
 
         /// <summary>
         /// Validators that will be called when the option is matched by the parser.

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -75,7 +75,7 @@ namespace System.CommandLine
         /// Global options are applied to the command and recursively to subcommands.
         /// They do not apply to parent commands.
         /// </summary>
-        internal bool AppliesToSelfAndChildren { get; set; }
+        public bool AppliesToSelfAndChildren { get; set; }
 
         /// <summary>
         /// Validators that will be called when the option is matched by the parser.

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -72,8 +72,8 @@ namespace System.CommandLine
         }
 
         /// <summary>
-        /// Global options are applied to the command and recursively to subcommands.
-        /// They do not apply to parent commands.
+        /// When set to true, this option will be applied to the command and recursively to subcommands.
+        /// It will not apply to parent commands.
         /// </summary>
         public bool AppliesToSelfAndChildren { get; set; }
 

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -84,7 +84,7 @@ namespace System.CommandLine.Parsing
             {
                 var option = options[i];
 
-                if (!completeValidation && !(option.IsGlobal || option.Argument.HasDefaultValue || (option is HelpOption or VersionOption)))
+                if (!completeValidation && !(option.AppliesToSelfAndChildren || option.Argument.HasDefaultValue || (option is HelpOption or VersionOption)))
                 {
                     continue;
                 }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -454,7 +454,7 @@ namespace System.CommandLine.Parsing
                     Option option = options[childIndex];
                     foreach (string childAlias in option.Aliases)
                     {
-                        if (!option.IsGlobal || !tokens.ContainsKey(childAlias))
+                        if (!option.AppliesToSelfAndChildren || !tokens.ContainsKey(childAlias))
                         {
                             tokens.Add(childAlias, new Token(childAlias, TokenType.Option, option, Token.ImplicitPosition));
                         }
@@ -476,7 +476,7 @@ namespace System.CommandLine.Parsing
                             for (var i = 0; i < parentCommand.Options.Count; i++)
                             {
                                 Option option = parentCommand.Options[i];
-                                if (option.IsGlobal)
+                                if (option.AppliesToSelfAndChildren)
                                 {
                                     foreach (var childAlias in option.Aliases)
                                     {


### PR DESCRIPTION
fixes #2055

Note from #2055: "This might be not the final name, we might rename it once the API gets approved by .NET Team API Review Board (.NET 8 Preview 3-4 timeframe)"