### PR TITLE
CLI actions prototype

### DIFF
--- a/src/System.CommandLine.NamingConventionBinder.Tests/System.CommandLine.NamingConventionBinder.Tests.csproj
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/System.CommandLine.NamingConventionBinder.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net7.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net462</TargetFrameworks>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>

--- a/src/System.CommandLine.NamingConventionBinder/System.CommandLine.NamingConventionBinder.csproj
+++ b/src/System.CommandLine.NamingConventionBinder/System.CommandLine.NamingConventionBinder.csproj
@@ -4,7 +4,7 @@
     <IsPackable>true</IsPackable>
     <PackageId>System.CommandLine.NamingConventionBinder</PackageId>
     <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Description>This package provides command handler support for System.CommandLine performs parameter and model binding by matching option and argument names to parameter and property names.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -9,7 +9,6 @@ using FluentAssertions;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using System.CommandLine.Completions;
 
 namespace System.CommandLine.Tests
 {

--- a/src/System.CommandLine.Tests/Invocation/InvocableTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocableTests.cs
@@ -61,16 +61,18 @@ public class InvocableTests
 
         await parseResult.Action.RunAsync(_console);
 
-
-
-        // TODO (help_option_base_case) write test
-        throw new NotImplementedException();
+        _console.Out.ToString().Should().Match($"*Usage:*{RootCommand.ExecutableName}*");
     }
 
     [Fact]
-    public void subcommand_help_option_base_case()
+    public async Task subcommand_help_option_base_case()
     {
-        // TODO (help_option_base_case) write test
-        throw new NotImplementedException();
+        var root = CreateRootCommand();
+
+        var parseResult = root.Parse("one -h");
+
+        await parseResult.Action.RunAsync(_console);
+
+        _console.Out.ToString().Should().Match("*Usage:*one*");
     }
 }

--- a/src/System.CommandLine.Tests/Invocation/InvocableTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocableTests.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace System.CommandLine.Tests.Invocation;
+
+public class InvocableTests
+{
+    private readonly TestConsole _console = new();
+
+    private static RootCommand CreateRootCommand()
+    {
+        var subcommandOne = new Command("one");
+
+        var root = new RootCommand
+        {
+            subcommandOne
+        };
+
+        subcommandOne.SetHandler(CliAction.Create(ctx => ctx.Console.Write("hello from one")));
+        root.SetHandler(CliAction.Create(ctx => ctx.Console.Write("hello from root")));
+
+        return root;
+    }
+
+    [Fact]
+    public async Task root_command_handler_base_case()
+    {
+        var root = CreateRootCommand();
+
+        var parseResult = root.Parse("");
+
+        await parseResult.Action.RunAsync(_console);
+
+        _console.Out.ToString().Should().Be("hello from root");
+    }
+
+    [Fact]
+    public async Task subcommand_handler_base_case()
+    {
+        var root = CreateRootCommand();
+
+        var parseResult = root.Parse("one");
+
+        await parseResult.Action.RunAsync(_console);
+
+        _console.Out.ToString().Should().Be("hello from one");
+    }
+
+    [Fact]
+    public async Task root_command_help_option_base_case()
+    {
+        var root = CreateRootCommand();
+
+        var parseResult = root.Parse("-h");
+
+        await parseResult.Action.RunAsync(_console);
+
+
+
+        // TODO (help_option_base_case) write test
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void subcommand_help_option_base_case()
+    {
+        // TODO (help_option_base_case) write test
+        throw new NotImplementedException();
+    }
+}

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.CommandLine.Completions;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.ComponentModel;
 using System.Linq;

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -6,15 +6,15 @@ using System.CommandLine.IO;
 
 namespace System.CommandLine.Help
 {
-    internal class HelpOption : Option<bool>
+    public class HelpOption : Option<bool>
     {
-        internal HelpOption(string[] aliases)
+        public HelpOption(string[] aliases)
             : base(aliases, LocalizationResources.HelpOptionDescription(), new Argument<bool> { Arity = ArgumentArity.Zero })
         {
             AppliesToSelfAndChildren = true;
         }
 
-        internal HelpOption() : this(new[]
+        public HelpOption() : this(new[]
         {
             "-h",
             "/h",
@@ -48,7 +48,7 @@ namespace System.CommandLine.Help
 
     public class HelpAction : CliAction
     {
-        internal HelpAction(HelpOption helpOption) : base(new AnonymousCommandHandler(helpOption.Handler))
+        public HelpAction(HelpOption helpOption) : base(new AnonymousCommandHandler(helpOption.Handler))
         {
         }
     }

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -42,5 +42,15 @@ namespace System.CommandLine.Help
 
             context.HelpBuilder.Write(helpContext);
         }
+
+        internal HelpAction Action => new HelpAction(this);
+    }
+
+    internal class HelpAction : CliAction
+    {
+        public HelpAction(HelpOption helpOption) : base(new AnonymousCommandHandler(HelpOption.Handler))
+        {
+            
+        }
     }
 }

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -31,7 +31,7 @@ namespace System.CommandLine.Help
 
         public override int GetHashCode() => typeof(HelpOption).GetHashCode();
 
-        internal static void Handler(InvocationContext context)
+        internal void Handler(InvocationContext context)
         {
             var output = context.Console.Out.CreateTextWriter();
 
@@ -43,14 +43,13 @@ namespace System.CommandLine.Help
             context.HelpBuilder.Write(helpContext);
         }
 
-        internal HelpAction Action => new HelpAction(this);
+        internal HelpAction Action => new(this);
     }
 
-    internal class HelpAction : CliAction
+    public class HelpAction : CliAction
     {
-        public HelpAction(HelpOption helpOption) : base(new AnonymousCommandHandler(HelpOption.Handler))
+        internal HelpAction(HelpOption helpOption) : base(new AnonymousCommandHandler(helpOption.Handler))
         {
-            
         }
     }
 }

--- a/src/System.CommandLine/Invocation/InvocationHandler.cs
+++ b/src/System.CommandLine/Invocation/InvocationHandler.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.CommandLine.Invocation;
+
+public class CliAction : ICommandHandler
+{
+    private readonly ICommandHandler _innerHandler;
+    private ParseResult? _parseResult;
+
+    public CliAction(ICommandHandler innerHandler)
+    {
+        _innerHandler = innerHandler;
+    }
+
+    int ICommandHandler.Invoke(InvocationContext context) =>
+        _innerHandler.Invoke(context);
+
+    Task<int> ICommandHandler.InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default) =>
+        _innerHandler.InvokeAsync(context, cancellationToken);
+
+    public static ICommandHandler Create(Action<InvocationContext> invoke)
+    {
+        return new CliAction(new AnonymousCommandHandler(invoke));
+    }
+
+    public async Task<int> RunAsync(IConsole? console = null, CancellationToken? cancellationToken = null)
+    {
+        var invocationContext = new InvocationContext(
+            ParseResult,
+            console ?? new SystemConsole());
+
+        return await _innerHandler.InvokeAsync(invocationContext);
+    }
+
+    internal ParseResult ParseResult
+    {
+        get => _parseResult ?? ParseResult.Empty();
+        set => _parseResult = value;
+    }
+}
+
+public static class CommandExtensions
+{
+    public static void SetHandler(this Command command, ICommandHandler handler)
+    {
+        command.Handler = handler;
+    }
+}

--- a/src/System.CommandLine/Invocation/InvocationHandler.cs
+++ b/src/System.CommandLine/Invocation/InvocationHandler.cs
@@ -5,14 +5,20 @@ using System.CommandLine.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
+#pragma warning disable CS1591
+
 namespace System.CommandLine.Invocation;
 
-public class CliAction : ICommandHandler
+public abstract class CliAction : ICommandHandler
 {
     private readonly ICommandHandler _innerHandler;
     private ParseResult? _parseResult;
 
-    public CliAction(ICommandHandler innerHandler)
+    protected CliAction()
+    {
+    }
+
+    internal CliAction(ICommandHandler innerHandler)
     {
         _innerHandler = innerHandler;
     }
@@ -20,21 +26,20 @@ public class CliAction : ICommandHandler
     int ICommandHandler.Invoke(InvocationContext context) =>
         _innerHandler.Invoke(context);
 
-    Task<int> ICommandHandler.InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default) =>
+    Task<int> ICommandHandler.InvokeAsync(InvocationContext context, CancellationToken cancellationToken) =>
         _innerHandler.InvokeAsync(context, cancellationToken);
 
-    public static ICommandHandler Create(Action<InvocationContext> invoke)
-    {
-        return new CliAction(new AnonymousCommandHandler(invoke));
-    }
-
-    public async Task<int> RunAsync(IConsole? console = null, CancellationToken? cancellationToken = null)
+    public async Task<int> RunAsync(
+        IConsole? console = null,
+        CancellationToken? cancellationToken = null)
     {
         var invocationContext = new InvocationContext(
             ParseResult,
             console ?? new SystemConsole());
 
-        return await _innerHandler.InvokeAsync(invocationContext);
+        return await _innerHandler.InvokeAsync(
+                   invocationContext,
+                   cancellationToken ?? CancellationToken.None);
     }
 
     internal ParseResult ParseResult
@@ -44,10 +49,33 @@ public class CliAction : ICommandHandler
     }
 }
 
+internal class AnonymousCommandAction : CommandAction
+{
+    public AnonymousCommandAction(Action<InvocationContext> invoke) : base(new AnonymousCommandHandler(invoke))
+    {
+    }
+}
+
+public abstract class CommandAction : CliAction
+{
+    protected CommandAction()
+    {
+    }
+
+    protected CommandAction(ICommandHandler innerHandler) : base(innerHandler)
+    {
+    }
+}
+
 public static class CommandExtensions
 {
-    public static void SetHandler(this Command command, ICommandHandler handler)
+    public static void SetAction(this Command command, CommandAction handler)
     {
         command.Handler = handler;
+    }
+
+    public static void SetAction(this Command command, Action<InvocationContext> invoke)
+    {
+        command.SetAction(new AnonymousCommandAction(invoke));
     }
 }

--- a/src/System.CommandLine/Invocation/InvocationHandler.cs
+++ b/src/System.CommandLine/Invocation/InvocationHandler.cs
@@ -9,6 +9,9 @@ using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation;
 
+/// <summary>
+/// An action that will be taken based on command line input.
+/// </summary>
 public abstract class CliAction : ICommandHandler
 {
     private readonly ICommandHandler _innerHandler;
@@ -49,13 +52,6 @@ public abstract class CliAction : ICommandHandler
     }
 }
 
-internal class AnonymousCommandAction : CommandAction
-{
-    public AnonymousCommandAction(Action<InvocationContext> invoke) : base(new AnonymousCommandHandler(invoke))
-    {
-    }
-}
-
 public abstract class CommandAction : CliAction
 {
     protected CommandAction()
@@ -63,6 +59,13 @@ public abstract class CommandAction : CliAction
     }
 
     protected CommandAction(ICommandHandler innerHandler) : base(innerHandler)
+    {
+    }
+}
+
+internal class AnonymousCommandAction : CommandAction
+{
+    public AnonymousCommandAction(Action<InvocationContext> invoke) : base(new AnonymousCommandHandler(invoke))
     {
     }
 }

--- a/src/System.CommandLine/Invocation/ParseErrorResult.cs
+++ b/src/System.CommandLine/Invocation/ParseErrorResult.cs
@@ -24,7 +24,7 @@ namespace System.CommandLine.Invocation
 
             context.Console.ResetTerminalForegroundColor();
 
-            HelpOption.Handler(context);
+            new HelpOption().Handler(context);
         }
     }
 }

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -23,6 +23,7 @@ namespace System.CommandLine
         private Dictionary<string, IReadOnlyList<string>>? _directives;
         private CompletionContext? _completionContext;
         private ICommandHandler? _handler;
+        private CliAction? _action;
 
         internal ParseResult(
             CommandLineConfiguration configuration,
@@ -255,21 +256,34 @@ namespace System.CommandLine
 
                 if (CommandResult.Command is { } command)
                 {
-                    return _handler ??=command.Handler;
+                    return _handler ??= command.Handler;
                 }
 
                 return null;
             }
-            set => _handler = value;
         }
 
         public CliAction Action
         {
             get
             {
-                var plan = new CliAction(Handler);
-                plan.ParseResult = this;
-                return plan;
+                if (_action is null)
+                {
+                    var handler = Handler;
+
+                    if (handler is null)
+                    {
+                        return null;
+                    }
+
+                    if (handler is CliAction action)
+                    {
+                        _action = action;
+                        _action.ParseResult = this;
+                    }
+                }
+
+                return _action;
             }
         }
 

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -255,12 +255,22 @@ namespace System.CommandLine
 
                 if (CommandResult.Command is { } command)
                 {
-                    return command.Handler;
+                    return _handler ??=command.Handler;
                 }
 
                 return null;
             }
             set => _handler = value;
+        }
+
+        public CliAction Action
+        {
+            get
+            {
+                var plan = new CliAction(Handler);
+                plan.ParseResult = this;
+                return plan;
+            }
         }
 
         private SymbolResult SymbolToComplete(int? position = null)

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -192,11 +192,11 @@ namespace System.CommandLine.Parsing
                 // parse directive has a precedence over --help and --version
                 if (!_isParseRequested)
                 {
-                    if (option is HelpOption)
+                    if (option is HelpOption helpOption)
                     {
                         _isHelpRequested = true;
 
-                        _handler = new AnonymousCommandHandler(HelpOption.Handler);
+                        _handler = helpOption.Action;
                     }
                     else if (option is VersionOption)
                     {

--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -6,7 +6,7 @@
     <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Description>This package includes a powerful command line parser and other tools for building command line applications, including:
     
     * Shell-agnostic support for command line completions


### PR DESCRIPTION
These changes are a prototype for #2071.

As a next step, custom actions types should be able to be either generated or bound to command line values using source generators. More investigation is needed there.

Feedback and suggestions are welcome.

