### PR TITLE
Minor token improvements

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -374,8 +374,6 @@ System.CommandLine.Parsing
     public T GetValue<T>(Argument<T> argument)
     public T GetValue<T>(Option<T> option)
   public class Token, System.IEquatable<Token>
-    public static System.Boolean op_Equality(Token left, Token right)
-    public static System.Boolean op_Inequality(Token left, Token right)
     .ctor(System.String value, TokenType type, System.CommandLine.Symbol symbol)
     public TokenType Type { get; }
     public System.String Value { get; }

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -375,6 +375,7 @@ System.CommandLine.Parsing
     public T GetValue<T>(Option<T> option)
   public class Token, System.IEquatable<Token>
     .ctor(System.String value, TokenType type, System.CommandLine.Symbol symbol)
+    public System.CommandLine.Symbol Symbol { get; }
     public TokenType Type { get; }
     public System.String Value { get; }
     public System.Boolean Equals(System.Object obj)

--- a/src/System.CommandLine.Tests/TokenTests.cs
+++ b/src/System.CommandLine.Tests/TokenTests.cs
@@ -1,0 +1,53 @@
+﻿using FluentAssertions;
+using System.CommandLine.Parsing;
+using Xunit;
+
+namespace System.CommandLine.Tests
+{
+    public class TokenTests
+    {
+        [Fact]
+        public void Tokens_are_equal_when_they_use_same_value_type_and_symbol()
+        {
+            Option<int> count = new ("--count");
+            Token token = new (count.Name, TokenType.Option, count);
+            Token same = new (count.Name, TokenType.Option, count);
+
+            token.Equals(same).Should().BeTrue();
+            token.Equals((object)same).Should().BeTrue();
+        }
+
+        [Fact]
+        public void Tokens_are_not_equal_when_they_do_not_use_same_value_type_and_symbol()
+        {
+            Option<int> symbol = new("--count");
+            Option<int> symbolWithSameName = new("--count");
+
+            Token token = new(symbol.Name, TokenType.Option, symbol);
+            Token differentValue = new("different", TokenType.Option, symbol);
+            Token differentType = new(symbol.Name, TokenType.Argument, symbol);
+            Token differentSymbol = new(symbol.Name, TokenType.Option, symbolWithSameName);
+
+            Assert(token, differentValue);
+            Assert(token, differentType);
+            Assert(token, differentSymbol);
+            Assert(token, null);
+
+            static void Assert(Token token, Token different)
+            {
+                token.Equals(different).Should().BeFalse();
+                token.Equals((object)different).Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public void Symbol_property_returns_value_provided_in_constructor()
+        {
+            Option<int> symbol = new("--count");
+
+            Token token = new(symbol.Name, TokenType.Option, symbol);
+
+            token.Symbol.Should().Be(symbol);
+        }
+    }
+}

--- a/src/System.CommandLine/Parsing/Token.cs
+++ b/src/System.CommandLine/Parsing/Token.cs
@@ -46,7 +46,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The Symbol represented by the token (if any).
         /// </summary>
-        internal Symbol? Symbol { get; set; }
+        public Symbol? Symbol { get; internal set; }
 
         /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as Token);

--- a/src/System.CommandLine/Parsing/Token.cs
+++ b/src/System.CommandLine/Parsing/Token.cs
@@ -59,21 +59,5 @@ namespace System.CommandLine.Parsing
 
         /// <inheritdoc />
         public override string ToString() => Value;
-
-        /// <summary>
-        /// Checks if two specified <see cref="Token"/> instances have the same value.
-        /// </summary>
-        /// <param name="left">The first <see cref="Token"/>.</param>
-        /// <param name="right">The second <see cref="Token"/>.</param>
-        /// <returns><see langword="true" /> if the objects are equal.</returns>
-        public static bool operator ==(Token? left, Token? right) => left is null ? right is null : left.Equals(right);
-
-        /// <summary>
-        /// Checks if two specified <see cref="Token"/> instances have different values.
-        /// </summary>
-        /// <param name="left">The first <see cref="Token"/>.</param>
-        /// <param name="right">The second <see cref="Token"/>.</param>
-        /// <returns><see langword="true" /> if the objects are not equal.</returns>
-        public static bool operator !=(Token? left, Token? right) => left is null ? right is not null : !left.Equals(right);
     }
 }


### PR DESCRIPTION
While creating the API design proposal I've noticed that:

- public `Token` ctor accepts `Symbol`, but the property is internal. Some users already asked for exposing in the past (#1815)
- `Token` does not need to override the quality operators, I have most likely introduced them when I've made it a struct in the past