### PR TITLE
Introduce CliAction, make it possible for every Symbol to define one

### DIFF
--- a/samples/HostingPlayground/Program.cs
+++ b/samples/HostingPlayground/Program.cs
@@ -32,7 +32,7 @@ namespace HostingPlayground
                     IsRequired = true
                 }
             };
-            root.Handler = CommandHandler.Create<GreeterOptions, IHost>(Run);
+            root.Action = CommandHandler.Create<GreeterOptions, IHost>(Run);
             return new CommandLineBuilder(root);
         }
 

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_NamingConventionBinder_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_NamingConventionBinder_api_is_not_changed.approved.txt
@@ -17,10 +17,8 @@ System.CommandLine.NamingConventionBinder
     public static System.Void AddModelBinder(this System.CommandLine.Binding.BindingContext bindingContext, ModelBinder binder)
     public static System.CommandLine.Binding.BindingContext GetBindingContext(this System.CommandLine.Invocation.InvocationContext ctx)
     public static ModelBinder GetOrCreateModelBinder(this System.CommandLine.Binding.BindingContext bindingContext, System.CommandLine.Binding.IValueDescriptor valueDescriptor)
-  public abstract class BindingHandler, System.CommandLine.ICommandHandler
+  public abstract class BindingHandler : System.CommandLine.CliAction
     public System.CommandLine.Binding.BindingContext GetBindingContext(System.CommandLine.Invocation.InvocationContext invocationContext)
-    public System.Int32 Invoke(System.CommandLine.Invocation.InvocationContext context)
-    public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.CommandLine.Invocation.InvocationContext context, System.Threading.CancellationToken cancellationToken = null)
     public System.CommandLine.Binding.BindingContext SetBindingContext(System.CommandLine.Binding.BindingContext bindingContext)
   public static class CommandHandler
     public static BindingHandler Create(System.Delegate delegate)
@@ -115,7 +113,7 @@ System.CommandLine.NamingConventionBinder
     .ctor()
     public System.Void BindMemberFromValue<TValue>(Expression<Func<TModel,TValue>> property, System.CommandLine.Binding.IValueDescriptor valueDescriptor)
     public System.Void BindMemberFromValue<TValue>(Expression<Func<TModel,TValue>> property, Func<System.CommandLine.Binding.BindingContext,TValue> getValue)
-  public class ModelBindingCommandHandler : BindingHandler, System.CommandLine.ICommandHandler
+  public class ModelBindingCommandHandler : BindingHandler
     public System.Void BindParameter(System.Reflection.ParameterInfo param, System.CommandLine.Argument argument)
     public System.Void BindParameter(System.Reflection.ParameterInfo param, System.CommandLine.Option option)
     public System.Int32 Invoke(System.CommandLine.Invocation.InvocationContext context)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -35,12 +35,15 @@ System.CommandLine
     public static Argument<System.IO.DirectoryInfo> AcceptExistingOnly(this Argument<System.IO.DirectoryInfo> argument)
     public static Argument<System.IO.FileSystemInfo> AcceptExistingOnly(this Argument<System.IO.FileSystemInfo> argument)
     public static Argument<T> AcceptExistingOnly<T>(this Argument<T> argument)
+  public abstract class CliAction
+    public System.Int32 Invoke(System.CommandLine.Invocation.InvocationContext context)
+    public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.CommandLine.Invocation.InvocationContext context, System.Threading.CancellationToken cancellationToken = null)
   public class Command : Symbol, System.Collections.Generic.IEnumerable<Symbol>, System.Collections.IEnumerable
     .ctor(System.String name, System.String description = null)
     public System.Collections.Generic.ICollection<System.String> Aliases { get; }
     public System.Collections.Generic.IList<Argument> Arguments { get; }
     public System.Collections.Generic.IEnumerable<Symbol> Children { get; }
-    public ICommandHandler Handler { get; set; }
+    public CliAction Handler { get; set; }
     public System.Collections.Generic.IList<Option> Options { get; }
     public System.Collections.Generic.IList<Command> Subcommands { get; }
     public System.Boolean TreatUnmatchedTokensAsErrors { get; set; }
@@ -110,9 +113,6 @@ System.CommandLine
     public System.Void SetSynchronousHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Int32> handler)
   public class EnvironmentVariablesDirective : Directive
     .ctor()
-  public interface ICommandHandler
-    public System.Int32 Invoke(System.CommandLine.Invocation.InvocationContext context)
-    public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.CommandLine.Invocation.InvocationContext context, System.Threading.CancellationToken cancellationToken = null)
   public interface IConsole : System.CommandLine.IO.IStandardError, System.CommandLine.IO.IStandardIn, System.CommandLine.IO.IStandardOut
   public abstract class Option : Symbol, System.CommandLine.Binding.IValueDescriptor
     public System.Collections.Generic.ICollection<System.String> Aliases { get; }

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -138,6 +138,7 @@ System.CommandLine
     public System.CommandLine.Parsing.CommandResult CommandResult { get; }
     public CommandLineConfiguration Configuration { get; }
     public System.Collections.Generic.IReadOnlyList<System.CommandLine.Parsing.ParseError> Errors { get; }
+    public CliAction Handler { get; }
     public System.CommandLine.Parsing.CommandResult RootCommandResult { get; }
     public System.Collections.Generic.IReadOnlyList<System.CommandLine.Parsing.Token> Tokens { get; }
     public System.Collections.Generic.IReadOnlyList<System.String> UnmatchedTokens { get; }

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -43,7 +43,6 @@ System.CommandLine
     public System.Collections.Generic.ICollection<System.String> Aliases { get; }
     public System.Collections.Generic.IList<Argument> Arguments { get; }
     public System.Collections.Generic.IEnumerable<Symbol> Children { get; }
-    public CliAction Handler { get; set; }
     public System.Collections.Generic.IList<Option> Options { get; }
     public System.Collections.Generic.IList<Command> Subcommands { get; }
     public System.Boolean TreatUnmatchedTokensAsErrors { get; set; }
@@ -53,8 +52,6 @@ System.CommandLine
     public System.Collections.Generic.IEnumerator<Symbol> GetEnumerator()
     public ParseResult Parse(System.Collections.Generic.IReadOnlyList<System.String> args, CommandLineConfiguration configuration = null)
     public ParseResult Parse(System.String commandLine, CommandLineConfiguration configuration = null)
-    public System.Void SetHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Int32> handler)
-    public System.Void SetHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Int32>> handler)
   public static class CommandExtensions
     public static System.Int32 Invoke(this Command command, System.String[] args, IConsole console = null)
     public static System.Int32 Invoke(this Command command, System.String commandLine, IConsole console = null)
@@ -109,8 +106,6 @@ System.CommandLine
   public class Directive : Symbol
     .ctor(System.String name, System.Func<System.CommandLine.Invocation.InvocationContext,System.Int32> syncHandler = null, System.Func<System.CommandLine.Invocation.InvocationContext,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Int32>> asyncHandler = null)
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
-    public System.Void SetAsynchronousHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Int32>> handler)
-    public System.Void SetSynchronousHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Int32> handler)
   public class EnvironmentVariablesDirective : Directive
     .ctor()
   public interface IConsole : System.CommandLine.IO.IStandardError, System.CommandLine.IO.IStandardIn, System.CommandLine.IO.IStandardOut
@@ -166,10 +161,13 @@ System.CommandLine
     .ctor()
   public abstract class Symbol
     public System.String Description { get; set; }
+    public CliAction Handler { get; set; }
     public System.Boolean IsHidden { get; set; }
     public System.String Name { get; }
     public System.Collections.Generic.IEnumerable<Symbol> Parents { get; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
+    public System.Void SetHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Int32> handler)
+    public System.Void SetHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Int32>> handler)
     public System.String ToString()
 System.CommandLine.Binding
   public interface IValueDescriptor

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -40,6 +40,7 @@ System.CommandLine
     public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.CommandLine.Invocation.InvocationContext context, System.Threading.CancellationToken cancellationToken = null)
   public class Command : Symbol, System.Collections.Generic.IEnumerable<Symbol>, System.Collections.IEnumerable
     .ctor(System.String name, System.String description = null)
+    public CliAction Action { get; set; }
     public System.Collections.Generic.ICollection<System.String> Aliases { get; }
     public System.Collections.Generic.IList<Argument> Arguments { get; }
     public System.Collections.Generic.IEnumerable<Symbol> Children { get; }
@@ -52,6 +53,8 @@ System.CommandLine
     public System.Collections.Generic.IEnumerator<Symbol> GetEnumerator()
     public ParseResult Parse(System.Collections.Generic.IReadOnlyList<System.String> args, CommandLineConfiguration configuration = null)
     public ParseResult Parse(System.String commandLine, CommandLineConfiguration configuration = null)
+    public System.Void SetAction(System.Action<System.CommandLine.Invocation.InvocationContext> action)
+    public System.Void SetAction(System.Func<System.CommandLine.Invocation.InvocationContext,System.Threading.CancellationToken,System.Threading.Tasks.Task> action)
   public static class CommandExtensions
     public static System.Int32 Invoke(this Command command, System.String[] args, IConsole console = null)
     public static System.Int32 Invoke(this Command command, System.String commandLine, IConsole console = null)
@@ -104,12 +107,14 @@ System.CommandLine
     public static System.Void Write(this IConsole console, System.String value)
     public static System.Void WriteLine(this IConsole console, System.String value)
   public class Directive : Symbol
-    .ctor(System.String name, System.Func<System.CommandLine.Invocation.InvocationContext,System.Int32> syncHandler = null, System.Func<System.CommandLine.Invocation.InvocationContext,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Int32>> asyncHandler = null)
+    .ctor(System.String name)
+    public CliAction Action { get; set; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
   public class EnvironmentVariablesDirective : Directive
     .ctor()
   public interface IConsole : System.CommandLine.IO.IStandardError, System.CommandLine.IO.IStandardIn, System.CommandLine.IO.IStandardOut
   public abstract class Option : Symbol, System.CommandLine.Binding.IValueDescriptor
+    public CliAction Action { get; set; }
     public System.Collections.Generic.ICollection<System.String> Aliases { get; }
     public System.Boolean AllowMultipleArgumentsPerToken { get; set; }
     public System.Boolean AppliesToSelfAndChildren { get; set; }
@@ -135,10 +140,10 @@ System.CommandLine
   public class ParseDirective : Directive
     .ctor(System.Int32 errorExitCode = 1)
   public class ParseResult
+    public CliAction Action { get; }
     public System.CommandLine.Parsing.CommandResult CommandResult { get; }
     public CommandLineConfiguration Configuration { get; }
     public System.Collections.Generic.IReadOnlyList<System.CommandLine.Parsing.ParseError> Errors { get; }
-    public CliAction Handler { get; }
     public System.CommandLine.Parsing.CommandResult RootCommandResult { get; }
     public System.Collections.Generic.IReadOnlyList<System.CommandLine.Parsing.Token> Tokens { get; }
     public System.Collections.Generic.IReadOnlyList<System.String> UnmatchedTokens { get; }
@@ -162,13 +167,10 @@ System.CommandLine
     .ctor()
   public abstract class Symbol
     public System.String Description { get; set; }
-    public CliAction Handler { get; set; }
     public System.Boolean IsHidden { get; set; }
     public System.String Name { get; }
     public System.Collections.Generic.IEnumerable<Symbol> Parents { get; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
-    public System.Void SetHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Int32> handler)
-    public System.Void SetHandler(System.Func<System.CommandLine.Invocation.InvocationContext,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Int32>> handler)
     public System.String ToString()
 System.CommandLine.Binding
   public interface IValueDescriptor

--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Simple.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_Simple.cs
@@ -33,12 +33,10 @@ namespace System.CommandLine.Benchmarks.CommandLine
                 stringOption
             };
 
-            command.SetHandler(ctx => 
+            command.SetAction(ctx => 
             {
                 bool boolean = ctx.ParseResult.GetValue(boolOption);
                 string text = ctx.ParseResult.GetValue(stringOption);
-
-                return 0;
             });
 
             return command;

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -168,7 +168,7 @@ namespace System.CommandLine.DragonFruit
                 command.Arguments.Add(ArgumentBuilder.CreateArgument(argsParam));
             }
 
-            command.Handler = CommandHandler.Create(method, target);
+            command.Action = CommandHandler.Create(method, target);
         }
 
         public static CommandLineBuilder ConfigureHelpFromXmlComments(

--- a/src/System.CommandLine.Generator/CommandHandlerSourceGenerator.cs
+++ b/src/System.CommandLine.Generator/CommandHandlerSourceGenerator.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Generator
     [Generator]
     public class CommandHandlerSourceGenerator : ISourceGenerator
     {
-        private const string ICommandHandlerType = "System.CommandLine.ICommandHandler";
+        private const string CliActionType = "System.CommandLine.CliAction";
 
         public void Execute(GeneratorExecutionContext context)
         {
@@ -74,7 +74,7 @@ namespace System.CommandLine
             int handlerCount)
         {
             builder.Append($@"
-        private class GeneratedHandler_{handlerCount} : {ICommandHandlerType}
+        private class GeneratedHandler_{handlerCount} : {CliActionType}
         {{
             public GeneratedHandler_{handlerCount}(
                 {invocation.DelegateType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)} method");
@@ -115,10 +115,10 @@ namespace System.CommandLine
             }
 
             builder.Append($@"
-            public int Invoke(global::System.CommandLine.Invocation.InvocationContext context) => InvokeAsync(context, global::System.Threading.CancellationToken.None).GetAwaiter().GetResult();");
+            public override int Invoke(global::System.CommandLine.Invocation.InvocationContext context) => InvokeAsync(context, global::System.Threading.CancellationToken.None).GetAwaiter().GetResult();");
 
             builder.Append($@"
-            public async global::System.Threading.Tasks.Task<int> InvokeAsync(global::System.CommandLine.Invocation.InvocationContext context, global::System.Threading.CancellationToken cancellationToken)
+            public override async global::System.Threading.Tasks.Task<int> InvokeAsync(global::System.CommandLine.Invocation.InvocationContext context, global::System.Threading.CancellationToken cancellationToken)
             {{");
             builder.Append($@"
                 {invocation.InvokeContents()}");

--- a/src/System.CommandLine.Generator/CommandHandlerSourceGenerator.cs
+++ b/src/System.CommandLine.Generator/CommandHandlerSourceGenerator.cs
@@ -170,7 +170,7 @@ namespace System.CommandLine
             builder.Append(@"
         {");
             builder.Append($@"
-            command.Handler = new GeneratedHandler_{handlerCount}(method");
+            command.Action = new GeneratedHandler_{handlerCount}(method");
 
             if (methodParameters.Length > 0)
             {

--- a/src/System.CommandLine.Hosting.Tests/HostingHandlerTest.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingHandlerTest.cs
@@ -134,17 +134,17 @@ namespace System.CommandLine.Hosting.Tests
             service.StringValue.Should().Be("TEST");
         }
 
-        public abstract class MyBaseHandler : ICommandHandler
+        public abstract class MyBaseHandler : CliAction
         {
             public int IntOption { get; set; } // bound from option
             public IConsole Console { get; set; } // bound from DI
 
-            public int Invoke(InvocationContext context)
+            public override int Invoke(InvocationContext context)
             {
                 return Act();
             }
 
-            public Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
+            public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
             {
                 return Task.FromResult(Act());
             }
@@ -159,7 +159,7 @@ namespace System.CommandLine.Hosting.Tests
                 Options.Add(new Option<int>("--int-option")); // or nameof(Handler.IntOption).ToKebabCase() if you don't like the string literal
             }
 
-            public class MyHandler : ICommandHandler
+            public class MyHandler : CliAction
             {
                 private readonly MyService service;
 
@@ -171,13 +171,13 @@ namespace System.CommandLine.Hosting.Tests
                 public int IntOption { get; set; } // bound from option
                 public IConsole Console { get; set; } // bound from DI
 
-                public int Invoke(InvocationContext context)
+                public override int Invoke(InvocationContext context)
                 {
                     service.Value = IntOption;
                     return IntOption;
                 }
 
-                public Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
+                public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
                 {
                     service.Value = IntOption;
                     return Task.FromResult(IntOption);
@@ -209,7 +209,7 @@ namespace System.CommandLine.Hosting.Tests
                 Arguments.Add(new Argument<string>("One"));
             }
 
-            public class MyHandler : ICommandHandler
+            public class MyHandler : CliAction
             {
                 private readonly MyService service;
 
@@ -223,9 +223,9 @@ namespace System.CommandLine.Hosting.Tests
 
                 public string One { get; set; }
 
-                public int Invoke(InvocationContext context) => InvokeAsync(context, CancellationToken.None).GetAwaiter().GetResult();
+                public override int Invoke(InvocationContext context) => InvokeAsync(context, CancellationToken.None).GetAwaiter().GetResult();
 
-                public Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
+                public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
                 {
                     service.Value = IntOption;
                     service.StringValue = One;

--- a/src/System.CommandLine.Hosting.Tests/HostingTests.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingTests.cs
@@ -28,7 +28,7 @@ namespace System.CommandLine.Hosting.Tests
             }
 
             var config = new CommandLineBuilder(
-                new RootCommand { Handler = CommandHandler.Create<IHost>(Execute) }
+                new RootCommand { Action = CommandHandler.Create<IHost>(Execute) }
                 )
                 .UseHost()
                 .Build();
@@ -76,7 +76,7 @@ namespace System.CommandLine.Hosting.Tests
             }
 
             var config = new CommandLineBuilder(
-                new RootCommand { Handler = CommandHandler.Create<IHost>(Execute) }
+                new RootCommand { Action = CommandHandler.Create<IHost>(Execute) }
                 )
                 .UseHost()
                 .Build();
@@ -108,7 +108,7 @@ namespace System.CommandLine.Hosting.Tests
             var config = new CommandLineBuilder(
                 new RootCommand
                 {
-                    Handler = CommandHandler.Create<IHost>(Execute),
+                    Action = CommandHandler.Create<IHost>(Execute),
                 })
                 .UseHost(host =>
                 {
@@ -145,7 +145,7 @@ namespace System.CommandLine.Hosting.Tests
             var config = new CommandLineBuilder(
                 new RootCommand
                 {
-                    Handler = CommandHandler.Create<IHost>(Execute),
+                    Action = CommandHandler.Create<IHost>(Execute),
                 })
                 .UseHost(args =>
                 {
@@ -184,7 +184,7 @@ namespace System.CommandLine.Hosting.Tests
             var config = new CommandLineBuilder(
                 new RootCommand
                 {
-                    Handler = CommandHandler.Create<IHost>(Execute)
+                    Action = CommandHandler.Create<IHost>(Execute)
                 })
                 .UseHost()
                 .Build();
@@ -203,7 +203,7 @@ namespace System.CommandLine.Hosting.Tests
 
             var rootCmd = new RootCommand();
             rootCmd.Options.Add(new Option<int>($"-{nameof(MyOptions.MyArgument)}"));
-            rootCmd.Handler = CommandHandler.Create((IHost host) =>
+            rootCmd.Action = CommandHandler.Create((IHost host) =>
             {
                 options = host.Services
                     .GetRequiredService<IOptions<MyOptions>>()

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -116,8 +116,8 @@ namespace System.CommandLine.Hosting
 
                 BindingHandler bindingHandler = CommandHandler.Create(handlerType.GetMethod(nameof(CliAction.InvokeAsync)));
                 // NullBindingHandler that accumulated services registered so far, before handler creation
-                bindingHandler.SetBindingContext(command.Handler is BindingHandler pre ? pre.GetBindingContext(invocation) : null);
-                command.Handler = bindingHandler;
+                bindingHandler.SetBindingContext(command.Action is BindingHandler pre ? pre.GetBindingContext(invocation) : null);
+                command.Action = bindingHandler;
                 bindingHandler.GetBindingContext(invocation).AddService(handlerType, c => c.GetService<IHost>().Services.GetService(handlerType));
             }
 

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -88,7 +88,7 @@ namespace System.CommandLine.Hosting
 
         public static IHostBuilder UseCommandHandler<TCommand, THandler>(this IHostBuilder builder)
             where TCommand : Command
-            where THandler : ICommandHandler
+            where THandler : CliAction
         {
             return builder.UseCommandHandler(typeof(TCommand), typeof(THandler));
         }
@@ -100,9 +100,9 @@ namespace System.CommandLine.Hosting
                 throw new ArgumentException($"{nameof(commandType)} must be a type of {nameof(Command)}", nameof(handlerType));
             }
 
-            if (!typeof(ICommandHandler).IsAssignableFrom(handlerType))
+            if (!typeof(CliAction).IsAssignableFrom(handlerType))
             {
-                throw new ArgumentException($"{nameof(handlerType)} must implement {nameof(ICommandHandler)}", nameof(handlerType));
+                throw new ArgumentException($"{nameof(handlerType)} must implement {nameof(CliAction)}", nameof(handlerType));
             }
 
             if (builder.Properties[typeof(InvocationContext)] is InvocationContext invocation 
@@ -114,7 +114,7 @@ namespace System.CommandLine.Hosting
                     services.AddTransient(handlerType);
                 });
 
-                BindingHandler bindingHandler = CommandHandler.Create(handlerType.GetMethod(nameof(ICommandHandler.InvokeAsync)));
+                BindingHandler bindingHandler = CommandHandler.Create(handlerType.GetMethod(nameof(CliAction.InvokeAsync)));
                 // NullBindingHandler that accumulated services registered so far, before handler creation
                 bindingHandler.SetBindingContext(command.Handler is BindingHandler pre ? pre.GetBindingContext(invocation) : null);
                 command.Handler = bindingHandler;

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ModelBinderTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ModelBinderTests.cs
@@ -528,7 +528,7 @@ public class ModelBinderTests
         {
             new Argument<string[]>("names")
         };
-        rootCommand.Handler = CommandHandler.Create<string[]>(Handler);
+        rootCommand.Action = CommandHandler.Create<string[]>(Handler);
         string[] passedNames = null;
         await rootCommand.InvokeAsync("");
 
@@ -548,7 +548,7 @@ public class ModelBinderTests
         {
             new Argument<IEnumerable<string>>("names")
         };
-        rootCommand.Handler = CommandHandler.Create<IEnumerable<string>>(Handler);
+        rootCommand.Action = CommandHandler.Create<IEnumerable<string>>(Handler);
         IEnumerable<string> passedNames = null;
         await rootCommand.InvokeAsync("");
 
@@ -568,7 +568,7 @@ public class ModelBinderTests
         {
             new Option<string[]>("--names")
         };
-        rootCommand.Handler = CommandHandler.Create<string[]>(Handler);
+        rootCommand.Action = CommandHandler.Create<string[]>(Handler);
         string[] passedNames = null;
         await rootCommand.InvokeAsync("");
 
@@ -588,7 +588,7 @@ public class ModelBinderTests
         {
             new Option<IEnumerable<string>>("--names"),
         };
-        rootCommand.Handler = CommandHandler.Create<IEnumerable<string>>(Handler);
+        rootCommand.Action = CommandHandler.Create<IEnumerable<string>>(Handler);
         IEnumerable<string> passedNames = null;
         await rootCommand.InvokeAsync("");
 
@@ -611,7 +611,7 @@ public class ModelBinderTests
             new Option<int>("one") { DefaultValueFactory = (_) => 1 },
             new Option<int>("two") { DefaultValueFactory = (_) => 2 }
         };
-        rootCommand.Handler = CommandHandler.Create<int, int>((one, two) =>
+        rootCommand.Action = CommandHandler.Create<int, int>((one, two) =>
         {
             first = one;
             second = two;
@@ -636,7 +636,7 @@ public class ModelBinderTests
 
         ClassWithOnePropertyNameThatIsSubstringOfAnother boundValue = default;
 
-        command.Handler = CommandHandler.Create(
+        command.Action = CommandHandler.Create(
             (ClassWithOnePropertyNameThatIsSubstringOfAnother s) => { boundValue = s; }
         );
 
@@ -657,7 +657,7 @@ public class ModelBinderTests
 
         var cmd = new RootCommand
         {
-            Handler = CommandHandler.Create((ClassWithListTypePropertiesAndDefaultCtor value) => { boundInstance = value; })
+            Action = CommandHandler.Create((ClassWithListTypePropertiesAndDefaultCtor value) => { boundInstance = value; })
         };
 
         var result = cmd.Parse(string.Empty);
@@ -676,7 +676,7 @@ public class ModelBinderTests
         {
             new Option<decimal>("--opt-decimal")
         };
-        rootCommand.Handler = CommandHandler.Create((ComplexType options) => { receivedValue = options.OptDecimal; });
+        rootCommand.Action = CommandHandler.Create((ComplexType options) => { receivedValue = options.OptDecimal; });
 
         await rootCommand.InvokeAsync("");
 
@@ -705,7 +705,7 @@ public class ModelBinderTests
 
         DeployOptions boundOptions = null;
 
-        rootCommand.Handler = CommandHandler.Create<DeployOptions>(options =>
+        rootCommand.Action = CommandHandler.Create<DeployOptions>(options =>
         {
             boundOptions = options;
             return 0;
@@ -770,7 +770,7 @@ public class ModelBinderTests
 
         var handlerWasCalled = false;
 
-        root.Handler = CommandHandler.Create<ClassWithSpanConstructor, int>((spanCtor, intValue) =>
+        root.Action = CommandHandler.Create<ClassWithSpanConstructor, int>((spanCtor, intValue) =>
         {
             handlerWasCalled = true;
         });

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.BindingByName.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.BindingByName.cs
@@ -151,7 +151,7 @@ public partial class ModelBindingCommandHandlerTests
             {
                 new Option<DirectoryInfo>("-f")
             };
-            root.Handler = CommandHandler.Create<FileSystemInfo>(f => received = f);
+            root.Action = CommandHandler.Create<FileSystemInfo>(f => received = f);
             var path = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}";
 
             root.Invoke($"-f {path}");

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.cs
@@ -91,7 +91,7 @@ public partial class ModelBindingCommandHandlerTests
     {
         var testCase = BindingCases[(type, variation)];
 
-        ICommandHandler handler;
+        CliAction handler;
         if (!useDelegate)
         {
             var captureMethod = GetType()

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.cs
@@ -39,7 +39,7 @@ public partial class ModelBindingCommandHandlerTests
             OptionBuilder.CreateOption("-x", parameterType)
         };
 
-        command.Handler = handler;
+        command.Action = handler;
 
         var parseResult = command.Parse("");
 
@@ -115,7 +115,7 @@ public partial class ModelBindingCommandHandlerTests
         {
             OptionBuilder.CreateOption("--value", testCase.ParameterType)
         };
-        command.Handler = handler;
+        command.Action = handler;
 
         var commandLine = string.Join(" ", testCase.CommandLineTokens.Select(t => $"--value {t}"));
         var parseResult = command.Parse(commandLine);
@@ -139,7 +139,7 @@ public partial class ModelBindingCommandHandlerTests
         var o = new Option<string[]>("-i") { Description = "Path to an image or directory of supported images" };
 
         var command = new Command("command") { o };
-        command.Handler = CommandHandler.Create<string[], InvocationContext>((nameDoesNotMatch, c) => received = nameDoesNotMatch);
+        command.Action = CommandHandler.Create<string[], InvocationContext>((nameDoesNotMatch, c) => received = nameDoesNotMatch);
 
         var testConsole = new TestConsole();
         var commandLine = "command -i 1 -i 2 -i 3 ";
@@ -176,7 +176,7 @@ public partial class ModelBindingCommandHandlerTests
         {
             ArgumentBuilder.CreateArgument(type)
         };
-        command.Handler = handler;
+        command.Action = handler;
 
         var commandLine = string.Join(" ", testCase.CommandLineTokens);
         var parseResult = command.Parse(commandLine);
@@ -228,7 +228,7 @@ public partial class ModelBindingCommandHandlerTests
             throw new InvalidOperationException("Cannot bind to this type of handler");
         }
         bindingHandler.BindParameter(parameter, argument);
-        command.Handler = handler;
+        command.Action = handler;
 
         var commandLine = string.Join(" ", testCase.CommandLineTokens);
         var parseResult = command.Parse(commandLine);
@@ -281,7 +281,7 @@ public partial class ModelBindingCommandHandlerTests
             throw new InvalidOperationException("Cannot bind to this type of handler");
         }
         bindingHandler.BindParameter(parameter, option);
-        command.Handler = handler;
+        command.Action = handler;
 
         var commandLine = string.Join(" ", testCase.CommandLineTokens.Select(t => $"--value {t}"));
         var parseResult = command.Parse(commandLine);
@@ -310,7 +310,7 @@ public partial class ModelBindingCommandHandlerTests
 
         var command = new Command("wat")
         {
-            Handler = CommandHandler.Create(@delegate)
+            Action = CommandHandler.Create(@delegate)
         };
 
         var exitCode = await command.InvokeAsync("");

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ParameterBindingTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ParameterBindingTests.cs
@@ -435,20 +435,20 @@ public class ParameterBindingTests
     public async Task Method_invoked_is_matching_to_the_interface_implementation(Type type, int expectedResult)
     {
         var command = new Command("command");
-        command.Handler = CommandHandler.Create(type.GetMethod(nameof(ICommandHandler.InvokeAsync)));
+        command.Handler = CommandHandler.Create(type.GetMethod(nameof(CliAction.InvokeAsync)));
 
         int result = await command.InvokeAsync("command", _console);
 
         result.Should().Be(expectedResult);
     }
 
-    public abstract class AbstractTestCommandHandler : ICommandHandler
+    public abstract class AbstractTestCommandHandler : CliAction
     {
         public abstract Task<int> DoJobAsync();
 
-        public int Invoke(InvocationContext context) => InvokeAsync(context, CancellationToken.None).GetAwaiter().GetResult();
+        public override int Invoke(InvocationContext context) => InvokeAsync(context, CancellationToken.None).GetAwaiter().GetResult();
 
-        public Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
+        public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
             => DoJobAsync();
     }
 
@@ -458,11 +458,11 @@ public class ParameterBindingTests
             => Task.FromResult(42);
     }
 
-    public class VirtualTestCommandHandler : ICommandHandler
+    public class VirtualTestCommandHandler : CliAction
     {
-        public int Invoke(InvocationContext context) => 42;
+        public override int Invoke(InvocationContext context) => 42;
 
-        public virtual Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
+        public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
             => Task.FromResult(42);
     }
 

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ParameterBindingTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ParameterBindingTests.cs
@@ -33,7 +33,7 @@ public class ParameterBindingTests
         var command = new Command("command");
         command.Options.Add(new Option<string>("--name"));
         command.Options.Add(new Option<int>("--age"));
-        command.Handler = CommandHandler.Create<string, int>(Execute);
+        command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.InvokeAsync("command --age 425 --name Gandalf", _console);
 
@@ -55,7 +55,7 @@ public class ParameterBindingTests
         {
             new Option<string>("--first-name")
         };
-        command.Handler = CommandHandler.Create<string>(Execute);
+        command.Action = CommandHandler.Create<string>(Execute);
 
         await command.InvokeAsync("command --first-name Gandalf", _console);
 
@@ -77,7 +77,7 @@ public class ParameterBindingTests
         var command = new Command("command");
         command.Options.Add(new Option<string>("--NAME"));
         command.Options.Add(new Option<int>("--age"));
-        command.Handler = CommandHandler.Create<string, int>(Execute);
+        command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.InvokeAsync("command --age 425 --NAME Gandalf", _console);
 
@@ -102,7 +102,7 @@ public class ParameterBindingTests
             new Option<string>("--name"),
             new Option<int>("--age")
         };
-        command.Handler = CommandHandler.Create<string, int>(Execute);
+        command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.InvokeAsync("command", _console);
 
@@ -127,7 +127,7 @@ public class ParameterBindingTests
             new Option<string>("--NAME", "-n"),
             new Option<int>("--age", "-a")
         };
-        command.Handler = CommandHandler.Create<string, int>(Execute);
+        command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.InvokeAsync("command -a 425 -n Gandalf", _console);
 
@@ -146,7 +146,7 @@ public class ParameterBindingTests
             new Option<string>("--name"),
             new Option<int>("--age")
         };
-        command.Handler = CommandHandler.Create<string, int>((name, age) =>
+        command.Action = CommandHandler.Create<string, int>((name, age) =>
         {
             boundName = name;
             boundAge = age;
@@ -167,7 +167,7 @@ public class ParameterBindingTests
         {
             new Option<int?>("--age")
         };
-        command.Handler = CommandHandler.Create<int?>(age =>
+        command.Action = CommandHandler.Create<int?>(age =>
         {
             boundAge = age;
         });
@@ -187,7 +187,7 @@ public class ParameterBindingTests
         {
             new Option<int?>("--age")
         };
-        command.Handler = CommandHandler.Create<int?>(age =>
+        command.Action = CommandHandler.Create<int?>(age =>
         {
             wasCalled = true;
             boundAge = age;
@@ -209,7 +209,7 @@ public class ParameterBindingTests
         {
             new Option<DirectoryInfo>("--dir")
         };
-        command.Handler = CommandHandler.Create<DirectoryInfo>(dir =>
+        command.Action = CommandHandler.Create<DirectoryInfo>(dir =>
         {
             boundDirectoryInfo = dir;
         });
@@ -230,7 +230,7 @@ public class ParameterBindingTests
         {
             option
         };
-        command.Handler = CommandHandler.Create<ParseResult>(result => { boundParseResult = result; });
+        command.Action = CommandHandler.Create<ParseResult>(result => { boundParseResult = result; });
 
         await command.InvokeAsync("command -x 123", _console);
 
@@ -247,7 +247,7 @@ public class ParameterBindingTests
         {
             option
         };
-        command.Handler = CommandHandler.Create<BindingContext>(context => { boundContext = context; });
+        command.Action = CommandHandler.Create<BindingContext>(context => { boundContext = context; });
 
         await command.InvokeAsync("command -x 123", _console);
 
@@ -261,7 +261,7 @@ public class ParameterBindingTests
         {
             new Option<int>("-x")
         };
-        command.Handler = CommandHandler.Create<IConsole>(console => { console.Out.Write("Hello!"); });
+        command.Action = CommandHandler.Create<IConsole>(console => { console.Out.Write("Hello!"); });
 
         await command.InvokeAsync("command", _console);
 
@@ -279,7 +279,7 @@ public class ParameterBindingTests
         {
             option
         };
-        command.Handler = CommandHandler.Create<InvocationContext>(context => { boundContext = context; });
+        command.Action = CommandHandler.Create<InvocationContext>(context => { boundContext = context; });
 
         await command.InvokeAsync("command -x 123", _console);
 
@@ -310,7 +310,7 @@ public class ParameterBindingTests
             new Option<string>("--name"),
             new Option<int>("--age")
         };
-        command.Handler = CommandHandler.Create((ExecuteTestDelegate)testClass.Execute);
+        command.Action = CommandHandler.Create((ExecuteTestDelegate)testClass.Execute);
 
         await command.InvokeAsync("command --age 425 --name Gandalf", _console);
 
@@ -328,7 +328,7 @@ public class ParameterBindingTests
             new Option<string>("--name"),
             new Option<int>("--age")
         };
-        command.Handler = CommandHandler.Create(
+        command.Action = CommandHandler.Create(
             testClass.GetType().GetMethod(nameof(ExecuteTestClass.Execute)),
             testClass);
 
@@ -353,7 +353,7 @@ public class ParameterBindingTests
         var command = new Command("command");
         command.Arguments.Add(new Argument<int>("age"));
         command.Arguments.Add(new Argument<string>("name"));
-        command.Handler = CommandHandler.Create<string, int>(Execute);
+        command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.InvokeAsync("command 425 Gandalf", _console);
 
@@ -375,7 +375,7 @@ public class ParameterBindingTests
         {
             new Argument<string>("first-name")
         };
-        command.Handler = CommandHandler.Create<string>(Execute);
+        command.Action = CommandHandler.Create<string>(Execute);
 
         await command.InvokeAsync("command Gandalf", _console);
 
@@ -397,7 +397,7 @@ public class ParameterBindingTests
         var command = new Command("command");
         command.Arguments.Add(new Argument<int>("AGE"));
         command.Arguments.Add(new Argument<string>("Name"));
-        command.Handler = CommandHandler.Create<string, int>(Execute);
+        command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.InvokeAsync("command 425 Gandalf", _console);
 
@@ -420,7 +420,7 @@ public class ParameterBindingTests
         var command = new Command("command");
         command.Arguments.Add(new Argument<int>("age"));
         command.Arguments.Add(new Argument<string>("fullname|nickname"));
-        command.Handler = CommandHandler.Create<string, int>(Execute);
+        command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.InvokeAsync("command 425 Gandalf", _console);
 
@@ -435,7 +435,7 @@ public class ParameterBindingTests
     public async Task Method_invoked_is_matching_to_the_interface_implementation(Type type, int expectedResult)
     {
         var command = new Command("command");
-        command.Handler = CommandHandler.Create(type.GetMethod(nameof(CliAction.InvokeAsync)));
+        command.Action = CommandHandler.Create(type.GetMethod(nameof(CliAction.InvokeAsync)));
 
         int result = await command.InvokeAsync("command", _console);
 

--- a/src/System.CommandLine.NamingConventionBinder/BindingContextExtensions.cs
+++ b/src/System.CommandLine.NamingConventionBinder/BindingContextExtensions.cs
@@ -23,12 +23,12 @@ public static class BindingContextExtensions
     public static BindingContext GetBindingContext(this InvocationContext ctx)
     {
         // parsing resulted with no handler or it was not created yet, we fake it to just store the BindingContext between the calls
-        if (ctx.ParseResult.CommandResult.Command.Handler is null)
+        if (ctx.ParseResult.CommandResult.Command.Action is null)
         {
-            ctx.ParseResult.CommandResult.Command.Handler = new DummyStateHoldingHandler();
+            ctx.ParseResult.CommandResult.Command.Action = new DummyStateHoldingHandler();
         }
 
-        return ((BindingHandler)ctx.ParseResult.CommandResult.Command.Handler).GetBindingContext(ctx);
+        return ((BindingHandler)ctx.ParseResult.CommandResult.Command.Action).GetBindingContext(ctx);
     }
 
     /// <summary>

--- a/src/System.CommandLine.NamingConventionBinder/BindingHandler.cs
+++ b/src/System.CommandLine.NamingConventionBinder/BindingHandler.cs
@@ -1,11 +1,9 @@
 ﻿using System.CommandLine.Binding;
 using System.CommandLine.Invocation;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.CommandLine.NamingConventionBinder
 {
-    public abstract class BindingHandler : ICommandHandler
+    public abstract class BindingHandler : CliAction
     {
         private BindingContext? _bindingContext;
 
@@ -15,9 +13,5 @@ namespace System.CommandLine.NamingConventionBinder
         public BindingContext GetBindingContext(InvocationContext invocationContext) => _bindingContext ??= new BindingContext(invocationContext);
 
         public BindingContext SetBindingContext(BindingContext bindingContext) => _bindingContext = bindingContext;
-
-        public abstract int Invoke(InvocationContext context);
-
-        public abstract Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/System.CommandLine.Rendering.Tests/TerminalModeTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/TerminalModeTests.cs
@@ -42,7 +42,7 @@ namespace System.CommandLine.Rendering.Tests
             OutputMode detectedOutputMode = OutputMode.Auto;
 
             var command = new Command("hello");
-            command.SetHandler((ctx, cancellationToken) =>
+            command.SetAction((ctx, cancellationToken) =>
             {
                 detectedOutputMode = ctx.Console.DetectOutputMode();
                 return Task.FromResult(0);

--- a/src/System.CommandLine.Rendering.Tests/ViewRenderingTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/ViewRenderingTests.cs
@@ -20,11 +20,10 @@ namespace System.CommandLine.Rendering.Tests
             ParseResult parseResult = null;
 
             var command = new RootCommand();
-            command.SetHandler(ctx =>
+            command.SetAction(ctx =>
             {
                 parseResult = ctx.ParseResult;
                 ctx.Console.Append(new ParseResultView(parseResult));
-                return 0;
             });
 
             var config = new CommandLineBuilder(command).Build();

--- a/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/Program.cs
+++ b/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/Program.cs
@@ -23,14 +23,14 @@ namespace EndToEndTestApp
                 durianOption,          
             };
 
-            rootCommand.SetHandler((InvocationContext ctx, CancellationToken cancellationToken) =>
+            rootCommand.SetAction((InvocationContext ctx, CancellationToken cancellationToken) =>
             {
                 string apple = ctx.ParseResult.GetValue(appleOption);
                 string banana = ctx.ParseResult.GetValue(bananaOption);
                 string cherry = ctx.ParseResult.GetValue(cherryOption);
                 string durian = ctx.ParseResult.GetValue(durianOption);
 
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
 
             var commandLine = new CommandLineBuilder(rootCommand)

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -29,20 +29,19 @@ namespace System.CommandLine.Suggest
             {
                 shellTypeArgument
             };
-            CompleteScriptCommand.SetHandler(context =>
+            CompleteScriptCommand.SetAction(context =>
             {
                 SuggestionShellScriptHandler.Handle(context.Console, context.ParseResult.GetValue(shellTypeArgument));
-                return 0;
             });
 
             ListCommand = new Command("list")
             {
                 Description = "Lists apps registered for suggestions",
             };
-            ListCommand.SetHandler((ctx, cancellationToken) =>
+            ListCommand.SetAction((ctx, cancellationToken) =>
             {
                 ctx.Console.Out.WriteLine(ShellPrefixesToMatch(_suggestionRegistration));
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
 
             GetCommand = new Command("get", "Gets suggestions from the specified executable")
@@ -50,7 +49,7 @@ namespace System.CommandLine.Suggest
                 ExecutableOption,
                 PositionOption
             };
-            GetCommand.SetHandler(Get);
+            GetCommand.SetAction(Get);
 
             var commandPathOption = new Option<string>("--command-path") { Description = "The path to the command for which to register suggestions" };
 
@@ -60,10 +59,10 @@ namespace System.CommandLine.Suggest
                 new Option<string>("--suggestion-command") { Description = "The command to invoke to retrieve suggestions" }
             };
 
-            RegisterCommand.SetHandler((context, cancellationToken) =>
+            RegisterCommand.SetAction((context, cancellationToken) =>
             {
                 Register(context.ParseResult.GetValue(commandPathOption), context.Console);
-                return Task.FromResult(0);
+                return Task.CompletedTask;
             });
 
             var root = new RootCommand

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -378,7 +378,7 @@ namespace System.CommandLine.Tests
                 };
 
                 var command = new RootCommand();
-                command.SetHandler((ctx) => { handlerWasCalled = true; return 0; });
+                command.SetAction((ctx) => handlerWasCalled = true);
                 command.Options.Add(option);
 
                 await command.InvokeAsync("--value 42");

--- a/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
@@ -19,11 +19,10 @@ namespace System.CommandLine.Tests
             string variable = test_variable;
             const string value = "This is a test";
             var rootCommand = new RootCommand();
-            rootCommand.SetHandler((_) =>
+            rootCommand.SetAction((_) =>
             {
                 asserted = true;
                 Environment.GetEnvironmentVariable(variable).Should().Be(value);
-                return 0;
             });
 
             var config = new CommandLineBuilder(rootCommand)
@@ -42,11 +41,10 @@ namespace System.CommandLine.Tests
             string variable = test_variable;
             const string value = "This is a test";
             var rootCommand = new RootCommand();
-            rootCommand.SetHandler((_) =>
+            rootCommand.SetAction((_) =>
             {
                 asserted = true;
                 Environment.GetEnvironmentVariable(variable).Should().Be(value);
-                return 0;
             });
 
             var config = new CommandLineBuilder(rootCommand)
@@ -65,11 +63,10 @@ namespace System.CommandLine.Tests
             string variable = test_variable;
             const string value = "This is a test";
             var rootCommand = new RootCommand();
-            rootCommand.SetHandler((_) =>
+            rootCommand.SetAction((_) =>
             {
                 asserted = true;
                 Environment.GetEnvironmentVariable(variable).Should().Be(value);
-                return 0;
             });
 
             var config = new CommandLineBuilder(rootCommand)
@@ -88,11 +85,10 @@ namespace System.CommandLine.Tests
             string variable = test_variable;
             const string value = "This is = a test containing equals";
             var rootCommand = new RootCommand();
-            rootCommand.SetHandler((_) =>
+            rootCommand.SetAction((_) =>
             {
                 asserted = true;
                 Environment.GetEnvironmentVariable(variable).Should().Be(value);
-                return 0;
             });
 
             var config = new CommandLineBuilder(rootCommand)
@@ -110,11 +106,10 @@ namespace System.CommandLine.Tests
             bool asserted = false;
             string variable = test_variable;
             var rootCommand = new RootCommand();
-            rootCommand.SetHandler((_) =>
+            rootCommand.SetAction((_) =>
             {
                 asserted = true;
                 Environment.GetEnvironmentVariable(variable).Should().BeNull();
-                return 0;
             });
 
             var config = new CommandLineBuilder(rootCommand)
@@ -132,12 +127,11 @@ namespace System.CommandLine.Tests
             bool asserted = false;
             string value = $"This is a test, random: {randomizer.Next()}";
             var rootCommand = new RootCommand();
-            rootCommand.SetHandler((_) =>
+            rootCommand.SetAction((_) =>
             {
                 asserted = true;
                 var env = Environment.GetEnvironmentVariables();
                 env.Values.Cast<string>().Should().NotContain(value);
-                return 0;
             });
 
             var config = new CommandLineBuilder(rootCommand)
@@ -155,12 +149,11 @@ namespace System.CommandLine.Tests
             bool asserted = false;
             string value = $"This is a test, random: {randomizer.Next()}";
             var rootCommand = new RootCommand();
-            rootCommand.SetHandler((_) =>
+            rootCommand.SetAction((_) =>
             {
                 asserted = true;
                 var env = Environment.GetEnvironmentVariables();
                 env.Values.Cast<string>().Should().NotContain(value);
-                return 0;
             });
 
             var config = new CommandLineBuilder(rootCommand)

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -29,7 +29,7 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("child");
             var rootCommand = new RootCommand { command };
-            command.SetHandler((_) => 0);
+            command.SetAction((_) => { });
             var requiredOption = new Option<bool>("--i-must-be-set")
             {
                 IsRequired = true,
@@ -69,7 +69,7 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("child");
             var rootCommand = new RootCommand { command };
-            command.SetHandler((_) => 0);
+            command.SetAction((_) => { });
             var requiredOption = new Option<bool>("--i-must-be-set")
             {
                 IsRequired = true,

--- a/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationPipelineTests.cs
@@ -39,10 +39,10 @@ namespace System.CommandLine.Tests.Invocation
             var secondWasCalled = false;
 
             var first = new Command("first");
-            first.SetHandler((_) => { firstWasCalled = true; return 0; });
+            first.SetAction((_) => firstWasCalled = true);
 
             var second = new Command("second");
-            second.SetHandler((_) => { secondWasCalled = true; return 0; });
+            second.SetAction((_) => secondWasCalled = true);
 
             var config = new CommandLineBuilder(new RootCommand
                          {
@@ -64,10 +64,10 @@ namespace System.CommandLine.Tests.Invocation
             var secondWasCalled = false;
 
             var first = new Command("first");
-            first.SetHandler((_) => { firstWasCalled = true; return 0; });
+            first.SetAction((_) => firstWasCalled = true);
 
             var second = new Command("second");
-            second.SetHandler((_) => { secondWasCalled = true; return 0; });
+            second.SetAction((_) => secondWasCalled = true);
 
             var config = new CommandLineBuilder(new RootCommand
                          {
@@ -120,7 +120,7 @@ namespace System.CommandLine.Tests.Invocation
         public void When_command_handler_throws_then_InvokeAsync_does_not_handle_the_exception()
         {
             var command = new Command("the-command");
-            command.SetHandler((_, __) =>
+            command.SetAction((_, __) =>
             {
                 throw new Exception("oops!");
                 // Help the compiler pick a CommandHandler.Create overload.
@@ -149,7 +149,7 @@ namespace System.CommandLine.Tests.Invocation
         public void When_command_handler_throws_then_Invoke_does_not_handle_the_exception()
         {
             var command = new Command("the-command");
-            command.SetHandler((_, __) =>
+            command.SetAction((_, __) =>
             {
                 throw new Exception("oops!");
                 // Help the compiler pick a CommandHandler.Create overload.
@@ -181,7 +181,7 @@ namespace System.CommandLine.Tests.Invocation
             var command = new Command("the-command");
             var implicitInnerCommand = new Command("implicit-inner-command");
             command.Subcommands.Add(implicitInnerCommand);
-            implicitInnerCommand.SetHandler((context, cancellationToken) =>
+            implicitInnerCommand.SetAction((context, cancellationToken) =>
             {
                 wasCalled = true;
                 context.ParseResult.Errors.Should().BeEmpty();
@@ -217,7 +217,7 @@ namespace System.CommandLine.Tests.Invocation
             var handlerWasCalled = false;
 
             var command = new Command("the-command");
-            command.SetHandler((context, cancellationToken) =>
+            command.SetAction((context, cancellationToken) =>
             {
                 handlerWasCalled = true;
                 context.ParseResult.Errors.Should().BeEmpty();
@@ -248,7 +248,7 @@ namespace System.CommandLine.Tests.Invocation
             var handlerWasCalled = false;
 
             var command = new Command("the-command");
-            command.SetHandler((context, cancellationToken) =>
+            command.SetAction((context, cancellationToken) =>
             {
                 handlerWasCalled = true;
                 context.ParseResult.Errors.Should().BeEmpty();
@@ -278,7 +278,7 @@ namespace System.CommandLine.Tests.Invocation
             bool handlerWasCalled = false;
 
             var command = new Command("help-command");
-            command.SetHandler((context, cancellationToken) =>
+            command.SetAction((context, cancellationToken) =>
             {
                 handlerWasCalled = true;
                 context.HelpBuilder.Should().NotBeNull();
@@ -305,7 +305,7 @@ namespace System.CommandLine.Tests.Invocation
             HelpBuilder createdHelpBuilder = null;
 
             var command = new Command("help-command");
-            command.SetHandler((context, cancellationToken) =>
+            command.SetAction((context, cancellationToken) =>
             {
                 handlerWasCalled = true;
                 context.HelpBuilder.Should().Be(createdHelpBuilder);
@@ -336,7 +336,7 @@ namespace System.CommandLine.Tests.Invocation
             var handlerWasCalled = false;
 
             var command = new Command("the-command");
-            command.SetHandler((InvocationContext context, CancellationToken cancellationToken) =>
+            command.SetAction((InvocationContext context, CancellationToken cancellationToken) =>
             {
                 handlerWasCalled = true;
                 return Task.FromResult(0);

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -346,5 +346,38 @@ namespace System.CommandLine.Tests
                 .Should()
                 .BeEquivalentTo(new[] { $"Argument 'Fuschia' not recognized. Must be one of:\n\t'Red'\n\t'Green'" });
         }
+
+        [Fact]
+        public void Every_option_can_provide_a_handler_and_it_takes_precedence_over_command_handler()
+        {
+            bool optionHandlerWasCalled = false;
+            bool commandHandlerWasCalled = false;
+
+            Option<bool> option = new("--test");
+            option.SetHandler((_) =>
+            {
+                optionHandlerWasCalled = true;
+                return 100;
+            });
+            Command command = new Command("cmd")
+            {
+                option
+            };
+            command.SetHandler((_) =>
+            {
+                commandHandlerWasCalled = true;
+                return 200;
+            });
+
+            ParseResult parseResult = command.Parse("cmd --test true");
+
+            parseResult.Handler.Should().NotBeNull();
+            optionHandlerWasCalled.Should().BeFalse();
+            commandHandlerWasCalled.Should().BeFalse();
+
+            parseResult.Invoke().Should().Be(100);
+            optionHandlerWasCalled.Should().BeTrue();
+            commandHandlerWasCalled.Should().BeFalse();
+        }
     }
 }

--- a/src/System.CommandLine.Tests/ParseResultTests.cs
+++ b/src/System.CommandLine.Tests/ParseResultTests.cs
@@ -121,5 +121,30 @@ namespace System.CommandLine.Tests
                 .Should()
                 .BeEquivalentTo("--one", "--two", "--three2");
         }
+
+        [Fact]
+        public void Handler_is_null_when_parsed_command_did_not_specify_handler()
+            => new RootCommand().Parse("").Handler.Should().BeNull();
+
+        [Fact]
+        public void Handler_is_not_null_when_parsed_command_specified_handler()
+        {
+            bool handlerWasCalled = false;
+
+            RootCommand command = new();
+            command.SetHandler((_) =>
+            {
+                handlerWasCalled = true;
+                return 123;
+            });
+
+            ParseResult parseResult = command.Parse("");
+
+            parseResult.Handler.Should().NotBeNull();
+            handlerWasCalled.Should().BeFalse();
+
+            parseResult.Handler.Invoke(null!).Should().Be(123);
+            handlerWasCalled.Should().BeTrue();
+        }
     }
 }

--- a/src/System.CommandLine.Tests/ParseResultTests.cs
+++ b/src/System.CommandLine.Tests/ParseResultTests.cs
@@ -124,7 +124,7 @@ namespace System.CommandLine.Tests
 
         [Fact]
         public void Handler_is_null_when_parsed_command_did_not_specify_handler()
-            => new RootCommand().Parse("").Handler.Should().BeNull();
+            => new RootCommand().Parse("").Action.Should().BeNull();
 
         [Fact]
         public void Handler_is_not_null_when_parsed_command_specified_handler()
@@ -132,18 +132,14 @@ namespace System.CommandLine.Tests
             bool handlerWasCalled = false;
 
             RootCommand command = new();
-            command.SetHandler((_) =>
-            {
-                handlerWasCalled = true;
-                return 123;
-            });
+            command.SetAction((_) => handlerWasCalled = true);
 
             ParseResult parseResult = command.Parse("");
 
-            parseResult.Handler.Should().NotBeNull();
+            parseResult.Action.Should().NotBeNull();
             handlerWasCalled.Should().BeFalse();
 
-            parseResult.Handler.Invoke(null!).Should().Be(123);
+            parseResult.Action.Invoke(null!).Should().Be(0);
             handlerWasCalled.Should().BeTrue();
         }
     }

--- a/src/System.CommandLine.Tests/ParserTests.MultiplePositions.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultiplePositions.cs
@@ -118,7 +118,7 @@ namespace System.CommandLine.Tests
                 string expectedParent)
             {
                 var reusedCommand = new Command("reused");
-                reusedCommand.SetHandler((_) => 0);
+                reusedCommand.SetAction((_) => { });
                 reusedCommand.Add(new Option<string>("--the-option"));
 
                 var outer = new Command("outer")

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -514,9 +514,9 @@ namespace System.CommandLine.Tests
 
             rootCommand.Options.Add(globalOption);
 
-            rootCommand.SetHandler((ctx) => { handlerWasCalled = true; return 0; });
-            childCommand.SetHandler((ctx) => { handlerWasCalled = true; return 0; });
-            grandchildCommand.SetHandler((ctx) => { handlerWasCalled = true; return 0; });
+            rootCommand.SetAction((ctx) => handlerWasCalled = true);
+            childCommand.SetAction((ctx) => handlerWasCalled = true);
+            grandchildCommand.SetAction((ctx) => handlerWasCalled = true);
 
             var result = await rootCommand.InvokeAsync(commandLine);
 
@@ -1145,7 +1145,7 @@ namespace System.CommandLine.Tests
         {
             var outer = new Command("outer");
             var inner = new Command("inner");
-            inner.SetHandler((_) => 0);
+            inner.SetAction((_) => { });
             var innerer = new Command("inner-er");
             outer.Subcommands.Add(inner);
             inner.Subcommands.Add(innerer);

--- a/src/System.CommandLine.Tests/TestApps/NativeAOT/Program.cs
+++ b/src/System.CommandLine.Tests/TestApps/NativeAOT/Program.cs
@@ -16,16 +16,14 @@ public class Program
             stringOption
         };
 
-        command.SetHandler(Run);
+        command.SetAction(Run);
 
         return new CommandLineBuilder(command).Build().Invoke(args);
 
-        int Run(InvocationContext context)
+        void Run(InvocationContext context)
         {
             context.Console.WriteLine($"Bool option: {context.ParseResult.GetValue(boolOption)}");
             context.Console.WriteLine($"String option: {context.ParseResult.GetValue(stringOption)}");
-
-            return 0;
         }
     }
 }

--- a/src/System.CommandLine.Tests/TestApps/Trimming/Program.cs
+++ b/src/System.CommandLine.Tests/TestApps/Trimming/Program.cs
@@ -9,11 +9,9 @@ var command = new RootCommand
     fileArgument
 };
 
-command.SetHandler(context =>
+command.SetAction(context =>
 {
     context.Console.Write($"The file you chose was: {context.ParseResult.GetValue(fileArgument)}");
-
-    return 0;
 });
 
 command.Invoke(args);

--- a/src/System.CommandLine.Tests/UseExceptionHandlerTests.cs
+++ b/src/System.CommandLine.Tests/UseExceptionHandlerTests.cs
@@ -53,7 +53,7 @@ namespace System.CommandLine.Tests
         public async Task UseExceptionHandler_catches_command_handler_exceptions_and_sets_result_code_to_1()
         {
             var command = new Command("the-command");
-            command.SetHandler((_, __) => Task.FromException<int>(new Exception("oops!")));
+            command.SetAction((_, __) => Task.FromException<int>(new Exception("oops!")));
 
             var config = new CommandLineBuilder(new RootCommand
                          {
@@ -71,7 +71,7 @@ namespace System.CommandLine.Tests
         public async Task UseExceptionHandler_catches_command_handler_exceptions_and_writes_details_to_standard_error()
         {
             var command = new Command("the-command");
-            command.SetHandler((_, __) => Task.FromException<int>(new Exception("oops!")));
+            command.SetAction((_, __) => Task.FromException<int>(new Exception("oops!")));
 
             var config = new CommandLineBuilder(new RootCommand
                          {

--- a/src/System.CommandLine.Tests/UseHelpTests.cs
+++ b/src/System.CommandLine.Tests/UseHelpTests.cs
@@ -46,7 +46,7 @@ namespace System.CommandLine.Tests
             var wasCalled = false;
             var command = new Command("command");
             var subcommand = new Command("subcommand");
-            subcommand.SetHandler((_) => { wasCalled = true; return 0; });
+            subcommand.SetAction((_) => wasCalled = true);
             command.Subcommands.Add(subcommand);
 
             var config =

--- a/src/System.CommandLine.Tests/VersionOptionTests.cs
+++ b/src/System.CommandLine.Tests/VersionOptionTests.cs
@@ -37,7 +37,7 @@ namespace System.CommandLine.Tests
         {
             var wasCalled = false;
             var rootCommand = new RootCommand();
-            rootCommand.SetHandler((_) => { wasCalled = true; return 0; });
+            rootCommand.SetAction((_) => wasCalled = true);
 
             var config = new CommandLineBuilder(rootCommand)
                          .UseVersionOption()
@@ -78,7 +78,7 @@ namespace System.CommandLine.Tests
                     DefaultValueFactory = (_) => true
                 }
             };
-            rootCommand.SetHandler((_) => 0);
+            rootCommand.SetAction((_) => { });
 
             var configuration = new CommandLineBuilder(rootCommand)
                 .UseVersionOption()
@@ -98,7 +98,7 @@ namespace System.CommandLine.Tests
             {
                 new Argument<bool>("x") { DefaultValueFactory =(_) => true }
             };
-            rootCommand.SetHandler((_) => 0);
+            rootCommand.SetAction((_) => { });
 
             var configuration = new CommandLineBuilder(rootCommand)
                 .UseVersionOption()
@@ -117,13 +117,13 @@ namespace System.CommandLine.Tests
         public void Version_is_not_valid_with_other_tokens(string commandLine)
         {
             var subcommand = new Command("subcommand");
-            subcommand.SetHandler((_) => 0);
+            subcommand.SetAction((_) => { });
             var rootCommand = new RootCommand
             {
                 subcommand,
                 new Option<bool>("-x")
             };
-            rootCommand.SetHandler((_) => 0);
+            rootCommand.SetAction((_) => { });
 
             var configuration = new CommandLineBuilder(rootCommand)
                 .UseVersionOption()
@@ -138,13 +138,13 @@ namespace System.CommandLine.Tests
         public void Version_option_is_not_added_to_subcommands()
         {
             var childCommand = new Command("subcommand");
-            childCommand.SetHandler((_) => 0);
+            childCommand.SetAction((_) => { });
 
             var rootCommand = new RootCommand
             {
                 childCommand,
             };
-            rootCommand.SetHandler((_) => 0);
+            rootCommand.SetAction((_) => { });
 
             var configuration = new CommandLineBuilder(rootCommand)
                          .UseVersionOption()
@@ -198,12 +198,12 @@ namespace System.CommandLine.Tests
         public void Version_is_not_valid_with_other_tokens_uses_custom_alias()
         {
             var childCommand = new Command("subcommand");
-            childCommand.SetHandler((_) => 0);
+            childCommand.SetAction((_) => { });
             var rootCommand = new RootCommand
             {
                 childCommand
             };
-            rootCommand.SetHandler((_) => 0);
+            rootCommand.SetAction((_) => { });
 
             var configuration = new CommandLineBuilder(rootCommand)
                          .UseVersionOption("-v")

--- a/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
+++ b/src/System.CommandLine/Builder/CommandLineBuilderExtensions.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine
     public partial class CommandLineBuilder
     {
         /// <summary>
-        /// Enables signaling and handling of process termination via a <see cref="CancellationToken"/> that can be passed to a <see cref="ICommandHandler"/> during invocation.
+        /// Enables signaling and handling of process termination via a <see cref="CancellationToken"/> that can be passed to a <see cref="CliAction"/> during invocation.
         /// </summary>
         /// <param name="timeout">
         /// Optional timeout for the command to process the exit cancellation.

--- a/src/System.CommandLine/CliAction.cs
+++ b/src/System.CommandLine/CliAction.cs
@@ -8,23 +8,23 @@ using System.Threading.Tasks;
 namespace System.CommandLine
 {
     /// <summary>
-    /// Defines the behavior of a command.
+    /// Defines the behavior of a symbol.
     /// </summary>
-    public interface ICommandHandler
+    public abstract class CliAction
     {
         /// <summary>
-        /// Performs an action when the associated command is invoked on the command line.
+        /// Performs an action when the associated symbol is invoked on the command line.
         /// </summary>
         /// <param name="context">Provides context for the invocation, including parse results and binding support.</param>
         /// <returns>A value that can be used as the exit code for the process.</returns>
-        int Invoke(InvocationContext context);
+        public abstract int Invoke(InvocationContext context);
 
         /// <summary>
-        /// Performs an action when the associated command is invoked on the command line.
+        /// Performs an action when the associated symbol is invoked on the command line.
         /// </summary>
         /// <param name="context">Provides context for the invocation, including parse results and binding support.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A value that can be used as the exit code for the process.</returns>
-        Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default);
+        public abstract Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -122,14 +122,14 @@ namespace System.CommandLine
         public bool TreatUnmatchedTokensAsErrors { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the <see cref="ICommandHandler"/> for the command. The handler represents the action
+        /// Gets or sets the <see cref="CliAction"/> for the command. The handler represents the action
         /// that will be performed when the command is invoked.
         /// </summary>
         /// <remarks>
         /// <para>Use one of the <see cref="SetHandler(Func{InvocationContext, Int32})" /> overloads to construct a handler.</para>
         /// <para>If the handler is not specified, parser errors will be generated for command line input that
         /// invokes this command.</para></remarks>
-        public ICommandHandler? Handler { get; set; }
+        public CliAction? Handler { get; set; }
 
         /// <summary>
         /// Represents all of the symbols for the command.
@@ -258,13 +258,13 @@ namespace System.CommandLine
         /// Sets a synchronous command handler. The handler should return an exit code.
         /// </summary>
         public void SetHandler(Func<InvocationContext, int> handler)
-            => Handler = new AnonymousCommandHandler(handler);
+            => Handler = new AnonymousCliAction(handler);
 
         /// <summary>
         /// Sets an asynchronous command handler. The handler should return an exit code.
         /// </summary>
         public void SetHandler(Func<InvocationContext, CancellationToken, Task<int>> handler)
-            => Handler = new AnonymousCommandHandler(handler);
+            => Handler = new AnonymousCliAction(handler);
 
         internal bool EqualsNameOrAlias(string name)
             => Name.Equals(name, StringComparison.Ordinal) || (_aliases is not null && _aliases.Contains(name));

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -91,6 +91,28 @@ namespace System.CommandLine
         public ICollection<string> Aliases => _aliases ??= new();
 
         /// <summary>
+        /// Gets or sets the <see cref="CliAction"/> for the Command. The handler represents the action
+        /// that will be performed when the Command is invoked.
+        /// </summary>
+        /// <remarks>
+        /// <para>Use one of the <see cref="SetAction(Action{InvocationContext})" /> overloads to construct a handler.</para>
+        /// <para>If the handler is not specified, parser errors will be generated for command line input that
+        /// invokes this Command.</para></remarks>
+        public CliAction? Action { get; set; }
+
+        /// <summary>
+        /// Sets a synchronous action.
+        /// </summary>
+        public void SetAction(Action<InvocationContext> action)
+            => Action = new AnonymousCliAction(action);
+
+        /// <summary>
+        /// Sets an asynchronous action.
+        /// </summary>
+        public void SetAction(Func<InvocationContext, CancellationToken, Task> action)
+            => Action = new AnonymousCliAction(action);
+
+        /// <summary>
         /// Adds a <see cref="Symbol"/> to the command.
         /// </summary>
         /// <param name="symbol">The symbol to add to the command.</param>

--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -122,16 +122,6 @@ namespace System.CommandLine
         public bool TreatUnmatchedTokensAsErrors { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets the <see cref="CliAction"/> for the command. The handler represents the action
-        /// that will be performed when the command is invoked.
-        /// </summary>
-        /// <remarks>
-        /// <para>Use one of the <see cref="SetHandler(Func{InvocationContext, Int32})" /> overloads to construct a handler.</para>
-        /// <para>If the handler is not specified, parser errors will be generated for command line input that
-        /// invokes this command.</para></remarks>
-        public CliAction? Handler { get; set; }
-
-        /// <summary>
         /// Represents all of the symbols for the command.
         /// </summary>
         public IEnumerator<Symbol> GetEnumerator() => Children.GetEnumerator();
@@ -253,18 +243,6 @@ namespace System.CommandLine
                 }
             }
         }
-
-        /// <summary>
-        /// Sets a synchronous command handler. The handler should return an exit code.
-        /// </summary>
-        public void SetHandler(Func<InvocationContext, int> handler)
-            => Handler = new AnonymousCliAction(handler);
-
-        /// <summary>
-        /// Sets an asynchronous command handler. The handler should return an exit code.
-        /// </summary>
-        public void SetHandler(Func<InvocationContext, CancellationToken, Task<int>> handler)
-            => Handler = new AnonymousCliAction(handler);
 
         internal bool EqualsNameOrAlias(string name)
             => Name.Equals(name, StringComparison.Ordinal) || (_aliases is not null && _aliases.Contains(name));

--- a/src/System.CommandLine/Directive.cs
+++ b/src/System.CommandLine/Directive.cs
@@ -30,35 +30,13 @@ namespace System.CommandLine
         {
             if (syncHandler is not null)
             {
-                SetSynchronousHandler(syncHandler);
+                SetHandler(syncHandler);
             }
             else if (asyncHandler is not null)
             {
-                SetAsynchronousHandler(asyncHandler);
+                SetHandler(asyncHandler);
             }
         }
-
-        public void SetAsynchronousHandler(Func<InvocationContext, CancellationToken, Task<int>> handler)
-        {
-            if (handler is null)
-            {
-                throw new ArgumentNullException(nameof(handler));
-            }
-
-            Handler = new AnonymousCliAction(handler);
-        }
-
-        public void SetSynchronousHandler(Func<InvocationContext, int> handler)
-        {
-            if (handler is null)
-            {
-                throw new ArgumentNullException(nameof(handler));
-            }
-
-            Handler = new AnonymousCliAction(handler);
-        }
-
-        internal CliAction? Handler { get; private set; }
 
         public override IEnumerable<CompletionItem> GetCompletions(CompletionContext context)
             => Array.Empty<CompletionItem>();

--- a/src/System.CommandLine/Directive.cs
+++ b/src/System.CommandLine/Directive.cs
@@ -45,7 +45,7 @@ namespace System.CommandLine
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            Handler = new AnonymousCommandHandler(handler);
+            Handler = new AnonymousCliAction(handler);
         }
 
         public void SetSynchronousHandler(Func<InvocationContext, int> handler)
@@ -55,10 +55,10 @@ namespace System.CommandLine
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            Handler = new AnonymousCommandHandler(handler);
+            Handler = new AnonymousCliAction(handler);
         }
 
-        internal ICommandHandler? Handler { get; private set; }
+        internal CliAction? Handler { get; private set; }
 
         public override IEnumerable<CompletionItem> GetCompletions(CompletionContext context)
             => Array.Empty<CompletionItem>();

--- a/src/System.CommandLine/Directive.cs
+++ b/src/System.CommandLine/Directive.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.CommandLine.Completions;
-using System.CommandLine.Invocation;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace System.CommandLine
 {
@@ -21,22 +18,16 @@ namespace System.CommandLine
         /// Initializes a new instance of the Directive class.
         /// </summary>
         /// <param name="name">The name of the directive. It can't contain whitespaces.</param>
-        /// <param name="syncHandler">The synchronous action that is invoked when directive is parsed.</param>
-        /// <param name="asyncHandler">The asynchronous action that is invoked when directive is parsed.</param>
-        public Directive(string name, 
-            Func<InvocationContext, int>? syncHandler = null,
-            Func<InvocationContext, CancellationToken, Task<int>>? asyncHandler = null)
+        public Directive(string name)
             : base(name)
         {
-            if (syncHandler is not null)
-            {
-                SetHandler(syncHandler);
-            }
-            else if (asyncHandler is not null)
-            {
-                SetHandler(asyncHandler);
-            }
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="CliAction"/> for the Directive. The handler represents the action
+        /// that will be performed when the Directive is invoked.
+        /// </summary>
+        public CliAction? Action { get; set; }
 
         public override IEnumerable<CompletionItem> GetCompletions(CompletionContext context)
             => Array.Empty<CompletionItem>();

--- a/src/System.CommandLine/EnvironmentVariablesDirective.cs
+++ b/src/System.CommandLine/EnvironmentVariablesDirective.cs
@@ -11,21 +11,19 @@ namespace System.CommandLine
     public sealed class EnvironmentVariablesDirective : Directive
     {
         public EnvironmentVariablesDirective() : base("env")
-        {
-            Handler = new SetEnvVarsAction(this);
-        }
+            => Action = new EnvironmentVariablesDirectiveAction(this);
 
-        private sealed class SetEnvVarsAction : CliAction
+        private sealed class EnvironmentVariablesDirectiveAction : CliAction
         {
             private readonly EnvironmentVariablesDirective _directive;
 
-            internal SetEnvVarsAction(EnvironmentVariablesDirective directive) => _directive = directive;
+            internal EnvironmentVariablesDirectiveAction(EnvironmentVariablesDirective directive) => _directive = directive;
 
             public override int Invoke(InvocationContext context)
             {
                 SetEnvVars(context);
 
-                return context.ParseResult.CommandResult.Command.Handler?.Invoke(context) ?? 0;
+                return context.ParseResult.CommandResult.Command.Action?.Invoke(context) ?? 0;
             }
 
             public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default)
@@ -37,8 +35,8 @@ namespace System.CommandLine
 
                 SetEnvVars(context);
 
-                return context.ParseResult.CommandResult.Command.Handler is not null
-                    ? context.ParseResult.CommandResult.Command.Handler.InvokeAsync(context, cancellationToken)
+                return context.ParseResult.CommandResult.Command.Action is not null
+                    ? context.ParseResult.CommandResult.Command.Action.InvokeAsync(context, cancellationToken)
                     : Task.FromResult(0);
             }
 

--- a/src/System.CommandLine/EnvironmentVariablesDirective.cs
+++ b/src/System.CommandLine/EnvironmentVariablesDirective.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine
     {
         public EnvironmentVariablesDirective() : base("env")
         {
-            SetSynchronousHandler(SyncHandler);
+            SetHandler(SyncHandler);
         }
 
         private int SyncHandler(InvocationContext context)

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -13,6 +13,7 @@ namespace System.CommandLine.Help
         {
             AppliesToSelfAndChildren = true;
             Description = LocalizationResources.HelpOptionDescription();
+            SetHandler(Display);
         }
 
         internal HelpOption() : this("--help", new[] { "-h", "/h", "-?", "/?" })
@@ -25,7 +26,7 @@ namespace System.CommandLine.Help
 
         public override int GetHashCode() => typeof(HelpOption).GetHashCode();
 
-        internal static int Handler(InvocationContext context)
+        internal static int Display(InvocationContext context)
         {
             var output = context.Console.Out.CreateTextWriter();
 

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -3,6 +3,8 @@
 
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.CommandLine.Help
 {
@@ -13,7 +15,7 @@ namespace System.CommandLine.Help
         {
             AppliesToSelfAndChildren = true;
             Description = LocalizationResources.HelpOptionDescription();
-            SetHandler(Display);
+            Action = new HelpOptionAction();
         }
 
         internal HelpOption() : this("--help", new[] { "-h", "/h", "-?", "/?" })
@@ -26,18 +28,33 @@ namespace System.CommandLine.Help
 
         public override int GetHashCode() => typeof(HelpOption).GetHashCode();
 
-        internal static int Display(InvocationContext context)
+        private sealed class HelpOptionAction : CliAction
         {
-            var output = context.Console.Out.CreateTextWriter();
+            private static void Display(InvocationContext context)
+            {
+                var output = context.Console.Out.CreateTextWriter();
 
-            var helpContext = new HelpContext(context.HelpBuilder,
-                                              context.ParseResult.CommandResult.Command,
-                                              output,
-                                              context.ParseResult);
+                var helpContext = new HelpContext(context.HelpBuilder,
+                                                  context.ParseResult.CommandResult.Command,
+                                                  output,
+                                                  context.ParseResult);
 
-            context.HelpBuilder.Write(helpContext);
+                context.HelpBuilder.Write(helpContext);
+            }
 
-            return 0;
+            public override int Invoke(InvocationContext context)
+            {
+                Display(context);
+
+                return 0;
+            }
+
+            public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default)
+                => cancellationToken.IsCancellationRequested 
+                    ? Task.FromCanceled<int>(cancellationToken)
+                    : Task.FromResult(Invoke(context));
         }
+
+        
     }
 }

--- a/src/System.CommandLine/Help/VersionOption.cs
+++ b/src/System.CommandLine/Help/VersionOption.cs
@@ -15,6 +15,7 @@ namespace System.CommandLine.Help
         {
             Description = LocalizationResources.VersionOptionDescription();
             AddValidators();
+            SetHandler(Display);
         }
 
         internal VersionOption(string name, string[] aliases)
@@ -22,6 +23,7 @@ namespace System.CommandLine.Help
         {
             Description = LocalizationResources.VersionOptionDescription();
             AddValidators();
+            SetHandler(Display);
         }
 
         private void AddValidators()
@@ -53,7 +55,7 @@ namespace System.CommandLine.Help
 
         public override int GetHashCode() => typeof(VersionOption).GetHashCode();
 
-        internal static int Handler(InvocationContext context)
+        private static int Display(InvocationContext context)
         {
             context.Console.Out.WriteLine(RootCommand.ExecutableVersion);
             return 0;

--- a/src/System.CommandLine/Invocation/AnonymousCliAction.cs
+++ b/src/System.CommandLine/Invocation/AnonymousCliAction.cs
@@ -11,11 +11,11 @@ namespace System.CommandLine.Invocation
         private readonly Func<InvocationContext, CancellationToken, Task<int>>? _asyncHandle;
         private readonly Func<InvocationContext, int>? _syncHandle;
 
-        internal AnonymousCliAction(Func<InvocationContext, CancellationToken, Task<int>> handle)
-            => _asyncHandle = handle ?? throw new ArgumentNullException(nameof(handle));
+        internal AnonymousCliAction(Func<InvocationContext, CancellationToken, Task<int>> handler)
+            => _asyncHandle = handler ?? throw new ArgumentNullException(nameof(handler));
 
-        internal AnonymousCliAction(Func<InvocationContext, int> handle)
-            => _syncHandle = handle ?? throw new ArgumentNullException(nameof(handle));
+        internal AnonymousCliAction(Func<InvocationContext, int> handler)
+            => _syncHandle = handler ?? throw new ArgumentNullException(nameof(handler));
 
         public override int Invoke(InvocationContext context)
         {

--- a/src/System.CommandLine/Invocation/AnonymousCliAction.cs
+++ b/src/System.CommandLine/Invocation/AnonymousCliAction.cs
@@ -6,18 +6,18 @@ using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation
 {
-    internal sealed class AnonymousCommandHandler : ICommandHandler
+    internal sealed class AnonymousCliAction : CliAction
     {
         private readonly Func<InvocationContext, CancellationToken, Task<int>>? _asyncHandle;
         private readonly Func<InvocationContext, int>? _syncHandle;
 
-        internal AnonymousCommandHandler(Func<InvocationContext, CancellationToken, Task<int>> handle)
+        internal AnonymousCliAction(Func<InvocationContext, CancellationToken, Task<int>> handle)
             => _asyncHandle = handle ?? throw new ArgumentNullException(nameof(handle));
 
-        internal AnonymousCommandHandler(Func<InvocationContext, int> handle)
+        internal AnonymousCliAction(Func<InvocationContext, int> handle)
             => _syncHandle = handle ?? throw new ArgumentNullException(nameof(handle));
 
-        public int Invoke(InvocationContext context)
+        public override int Invoke(InvocationContext context)
         {
             if (_syncHandle is not null)
             {
@@ -30,7 +30,7 @@ namespace System.CommandLine.Invocation
                 => InvokeAsync(context, CancellationToken.None).GetAwaiter().GetResult();
         }
 
-        public Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
+        public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken)
             => _asyncHandle is not null
                 ? _asyncHandle(context, cancellationToken)
                 : Task.FromResult(Invoke(context));

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Invocation
     {
         internal static async Task<int> InvokeAsync(ParseResult parseResult, IConsole? console, CancellationToken cancellationToken)
         {
-            if (parseResult.Handler is null && parseResult.Configuration.Middleware.Count == 0)
+            if (parseResult.Action is null && parseResult.Configuration.Middleware.Count == 0)
             {
                 return 0;
             }
@@ -22,8 +22,8 @@ namespace System.CommandLine.Invocation
 
             try
             {
-                Task<int> startedInvocation = parseResult.Handler is not null && parseResult.Configuration.Middleware.Count == 0
-                    ? parseResult.Handler.InvokeAsync(context, cts.Token)
+                Task<int> startedInvocation = parseResult.Action is not null && parseResult.Configuration.Middleware.Count == 0
+                    ? parseResult.Action.InvokeAsync(context, cts.Token)
                     : InvokeHandlerWithMiddleware(context, cts.Token);
 
                 if (parseResult.Configuration.ProcessTerminationTimeout.HasValue)
@@ -57,7 +57,7 @@ namespace System.CommandLine.Invocation
                 InvocationMiddleware invocationChain = BuildInvocationChain(context);
                 await invocationChain(context, token, async (ctx, token) =>
                 {
-                    if (ctx.ParseResult.Handler is { } handler)
+                    if (ctx.ParseResult.Action is { } handler)
                     {
                         exitCode = await handler.InvokeAsync(ctx, token);
                     }
@@ -69,7 +69,7 @@ namespace System.CommandLine.Invocation
 
         internal static int Invoke(ParseResult parseResult, IConsole? console = null)
         {
-            if (parseResult.Handler is null && parseResult.Configuration.Middleware.Count == 0)
+            if (parseResult.Action is null && parseResult.Configuration.Middleware.Count == 0)
             {
                 return 0;
             }
@@ -78,9 +78,9 @@ namespace System.CommandLine.Invocation
 
             try
             {
-                if (parseResult.Configuration.Middleware.Count == 0 && parseResult.Handler is not null)
+                if (parseResult.Configuration.Middleware.Count == 0 && parseResult.Action is not null)
                 {
-                    return parseResult.Handler.Invoke(context);
+                    return parseResult.Action.Invoke(context);
                 }
 
                 return InvokeHandlerWithMiddleware(context); // kept in a separate method to avoid JITting
@@ -96,7 +96,7 @@ namespace System.CommandLine.Invocation
                 InvocationMiddleware invocationChain = BuildInvocationChain(context);
                 invocationChain(context, CancellationToken.None, (ctx, token) =>
                 {
-                    if (ctx.ParseResult.Handler is { } handler)
+                    if (ctx.ParseResult.Action is { } handler)
                     {
                         exitCode = handler.Invoke(ctx);
                     }

--- a/src/System.CommandLine/Invocation/ParseErrorResult.cs
+++ b/src/System.CommandLine/Invocation/ParseErrorResult.cs
@@ -11,14 +11,6 @@ namespace System.CommandLine.Invocation
     internal sealed class ParseErrorResult : CliAction
     {
         public override int Invoke(InvocationContext context)
-            => Apply(context);
-
-        public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default)
-            => cancellationToken.IsCancellationRequested
-                ? Task.FromCanceled<int>(cancellationToken)
-                : Task.FromResult(Apply(context));
-
-        internal static int Apply(InvocationContext context)
         {
             context.Console.ResetTerminalForegroundColor();
             context.Console.SetTerminalForegroundRed();
@@ -32,9 +24,14 @@ namespace System.CommandLine.Invocation
 
             context.Console.ResetTerminalForegroundColor();
 
-            HelpOption.Display(context);
+            new HelpOption().Action!.Invoke(context);
 
             return context.ParseResult.Configuration.ParseErrorReportingExitCode!.Value;
         }
+
+        public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default)
+            => cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled<int>(cancellationToken)
+                : Task.FromResult(Invoke(context));
     }
 }

--- a/src/System.CommandLine/Invocation/ParseErrorResult.cs
+++ b/src/System.CommandLine/Invocation/ParseErrorResult.cs
@@ -3,11 +3,21 @@
 
 using System.CommandLine.Help;
 using System.CommandLine.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation
 {
-    internal static class ParseErrorResult
+    internal sealed class ParseErrorResult : CliAction
     {
+        public override int Invoke(InvocationContext context)
+            => Apply(context);
+
+        public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default)
+            => cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled<int>(cancellationToken)
+                : Task.FromResult(Apply(context));
+
         internal static int Apply(InvocationContext context)
         {
             context.Console.ResetTerminalForegroundColor();

--- a/src/System.CommandLine/Invocation/ParseErrorResult.cs
+++ b/src/System.CommandLine/Invocation/ParseErrorResult.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation
 {
-    internal sealed class ParseErrorResult : CliAction
+    internal sealed class ParseErrorResultAction : CliAction
     {
         public override int Invoke(InvocationContext context)
         {

--- a/src/System.CommandLine/Invocation/ParseErrorResult.cs
+++ b/src/System.CommandLine/Invocation/ParseErrorResult.cs
@@ -22,7 +22,7 @@ namespace System.CommandLine.Invocation
 
             context.Console.ResetTerminalForegroundColor();
 
-            HelpOption.Handler(context);
+            HelpOption.Display(context);
 
             return context.ParseResult.Configuration.ParseErrorReportingExitCode!.Value;
         }

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -4,12 +4,22 @@
 using System.Collections.Generic;
 using System.CommandLine.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation
 {
-    internal static class TypoCorrection
+    internal sealed class TypoCorrection : CliAction
     {
-        internal static int ProvideSuggestions(InvocationContext context)
+        public override int Invoke(InvocationContext context)
+            => ProvideSuggestions(context);
+
+        public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default)
+            => cancellationToken.IsCancellationRequested
+                ? Task.FromCanceled<int>(cancellationToken)
+                : Task.FromResult(ProvideSuggestions(context));
+
+        private static int ProvideSuggestions(InvocationContext context)
         {
             ParseResult result = context.ParseResult;
             IConsole console = context.Console;

--- a/src/System.CommandLine/Invocation/TypoCorrection.cs
+++ b/src/System.CommandLine/Invocation/TypoCorrection.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation
 {
-    internal sealed class TypoCorrection : CliAction
+    internal sealed class TypoCorrectionAction : CliAction
     {
         public override int Invoke(InvocationContext context)
             => ProvideSuggestions(context);

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -104,6 +104,12 @@ namespace System.CommandLine
         /// <remarks>The collection does not contain the <see cref="Symbol.Name"/> of the Option.</remarks>
         public ICollection<string> Aliases => _aliases ??= new();
 
+        /// <summary>
+        /// Gets or sets the <see cref="CliAction"/> for the Option. The handler represents the action
+        /// that will be performed when the Option is invoked.
+        /// </summary>
+        public CliAction? Action { get; set; }
+
         string IValueDescriptor.ValueName => Name;
 
         /// <summary>

--- a/src/System.CommandLine/ParseDirective.cs
+++ b/src/System.CommandLine/ParseDirective.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine
         /// <param name="errorExitCode">If the parse result contains errors, this exit code will be used when the process exits.</param>
         public ParseDirective(int errorExitCode = 1) : base("parse")
         {
-            SetSynchronousHandler(SyncHandler);
+            SetHandler(SyncHandler);
             ErrorExitCode = errorExitCode;
         }
 

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -229,24 +229,11 @@ namespace System.CommandLine
         /// <returns>A value that can be used as a process exit code.</returns>
         public int Invoke(IConsole? console = null) => InvocationPipeline.Invoke(this, console);
 
-        internal CliAction? Handler
-        {
-            get
-            {
-                if (_handler is not null)
-                {
-                    return _handler;
-                }
-
-                if (CommandResult.Command is { } command)
-                {
-                    return command.Handler;
-                }
-
-                return null;
-            }
-            set => _handler = value;
-        }
+        /// <summary>
+        /// Gets the <see cref="CliAction"/> for parsed result. The handler represents the action
+        /// that will be performed when the parse result is invoked.
+        /// </summary>
+        public CliAction? Handler => _handler ?? CommandResult.Command.Handler;
 
         private SymbolResult SymbolToComplete(int? position = null)
         {

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -21,7 +21,7 @@ namespace System.CommandLine
         private readonly CommandResult _rootCommandResult;
         private readonly IReadOnlyList<Token> _unmatchedTokens;
         private CompletionContext? _completionContext;
-        private ICommandHandler? _handler;
+        private CliAction? _handler;
 
         internal ParseResult(
             CommandLineConfiguration configuration,
@@ -31,7 +31,7 @@ namespace System.CommandLine
             IReadOnlyList<Token>? unmatchedTokens,
             List<ParseError>? errors,
             string? commandLineText = null,
-            ICommandHandler? handler = null)
+            CliAction? handler = null)
         {
             Configuration = configuration;
             _rootCommandResult = rootCommandResult;
@@ -229,7 +229,7 @@ namespace System.CommandLine
         /// <returns>A value that can be used as a process exit code.</returns>
         public int Invoke(IConsole? console = null) => InvocationPipeline.Invoke(this, console);
 
-        internal ICommandHandler? Handler
+        internal CliAction? Handler
         {
             get
             {

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -21,7 +21,7 @@ namespace System.CommandLine
         private readonly CommandResult _rootCommandResult;
         private readonly IReadOnlyList<Token> _unmatchedTokens;
         private CompletionContext? _completionContext;
-        private CliAction? _handler;
+        private CliAction? _action;
 
         internal ParseResult(
             CommandLineConfiguration configuration,
@@ -36,7 +36,7 @@ namespace System.CommandLine
             Configuration = configuration;
             _rootCommandResult = rootCommandResult;
             CommandResult = commandResult;
-            _handler = handler;
+            _action = handler;
 
             // skip the root command when populating Tokens property
             if (tokens.Count > 1)
@@ -233,7 +233,7 @@ namespace System.CommandLine
         /// Gets the <see cref="CliAction"/> for parsed result. The handler represents the action
         /// that will be performed when the parse result is invoked.
         /// </summary>
-        public CliAction? Handler => _handler ?? CommandResult.Command.Handler;
+        public CliAction? Action => _action ?? CommandResult.Command.Action;
 
         private SymbolResult SymbolToComplete(int? position = null)
         {

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -31,12 +31,12 @@ namespace System.CommandLine
             IReadOnlyList<Token>? unmatchedTokens,
             List<ParseError>? errors,
             string? commandLineText = null,
-            CliAction? handler = null)
+            CliAction? action = null)
         {
             Configuration = configuration;
             _rootCommandResult = rootCommandResult;
             CommandResult = commandResult;
-            _action = handler;
+            _action = action;
 
             // skip the root command when populating Tokens property
             if (tokens.Count > 1)

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -49,7 +49,7 @@ namespace System.CommandLine.Parsing
         {
             if (completeValidation)
             {
-                if (Command.Handler is null && Command.HasSubcommands)
+                if (Command.Action is null && Command.HasSubcommands)
                 {
                     SymbolResultTree.InsertFirstError(
                         new ParseError(LocalizationResources.RequiredCommandWasNotProvided(), this));

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine.Parsing
         private int _index;
         private CommandResult _innermostCommandResult;
         private bool _isHelpRequested, _isParseRequested;
-        private CliAction? _handler;
+        private CliAction? _action;
 
         public ParseOperation(
             List<Token> tokens,
@@ -60,16 +60,16 @@ namespace System.CommandLine.Parsing
                 Validate();
             }
 
-            if (_handler is null)
+            if (_action is null)
             {
                 if (_configuration.ParseErrorReportingExitCode.HasValue && _symbolResultTree.ErrorCount > 0)
                 {
-                    _handler = new ParseErrorResult();
+                    _action = new ParseErrorResult();
                 }
                 else if (_configuration.MaxLevenshteinDistance > 0 && _rootCommandResult.Command.TreatUnmatchedTokensAsErrors
                     && _symbolResultTree.UnmatchedTokens is not null)
                 {
-                    _handler = new TypoCorrection();
+                    _action = new TypoCorrection();
                 }
             }
 
@@ -81,7 +81,7 @@ namespace System.CommandLine.Parsing
                 _symbolResultTree.UnmatchedTokens,
                 _symbolResultTree.Errors,
                 _rawInput,
-                _handler);
+                _action);
         }
 
         private void ParseSubcommand()
@@ -190,14 +190,14 @@ namespace System.CommandLine.Parsing
                 // parse directive has a precedence over --help and --version
                 if (!_isParseRequested)
                 {
-                    if (option.Handler is not null)
+                    if (option.Action is not null)
                     {
                         if (option is HelpOption)
                         {
                             _isHelpRequested = true;
                         }
 
-                        _handler = option.Handler;
+                        _action = option.Action;
                     }
                 }
 
@@ -319,7 +319,7 @@ namespace System.CommandLine.Parsing
                     result.AddValue(withoutBrackets.Slice(indexOfColon + 1).ToString());
                 }
 
-                _handler = directive.Handler;
+                _action = directive.Action;
 
                 if (directive is ParseDirective)
                 {

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -190,15 +190,14 @@ namespace System.CommandLine.Parsing
                 // parse directive has a precedence over --help and --version
                 if (!_isParseRequested)
                 {
-                    if (option is HelpOption)
+                    if (option.Handler is not null)
                     {
-                        _isHelpRequested = true;
+                        if (option is HelpOption)
+                        {
+                            _isHelpRequested = true;
+                        }
 
-                        _handler = new AnonymousCliAction(HelpOption.Handler);
-                    }
-                    else if (option is VersionOption)
-                    {
-                        _handler = new AnonymousCliAction(VersionOption.Handler);
+                        _handler = option.Handler;
                     }
                 }
 

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -64,12 +64,12 @@ namespace System.CommandLine.Parsing
             {
                 if (_configuration.ParseErrorReportingExitCode.HasValue && _symbolResultTree.ErrorCount > 0)
                 {
-                    _action = new ParseErrorResult();
+                    _action = new ParseErrorResultAction();
                 }
                 else if (_configuration.MaxLevenshteinDistance > 0 && _rootCommandResult.Command.TreatUnmatchedTokensAsErrors
                     && _symbolResultTree.UnmatchedTokens is not null)
                 {
-                    _action = new TypoCorrection();
+                    _action = new TypoCorrectionAction();
                 }
             }
 

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -64,12 +64,12 @@ namespace System.CommandLine.Parsing
             {
                 if (_configuration.ParseErrorReportingExitCode.HasValue && _symbolResultTree.ErrorCount > 0)
                 {
-                    _handler = new AnonymousCliAction(ParseErrorResult.Apply);
+                    _handler = new ParseErrorResult();
                 }
                 else if (_configuration.MaxLevenshteinDistance > 0 && _rootCommandResult.Command.TreatUnmatchedTokensAsErrors
                     && _symbolResultTree.UnmatchedTokens is not null)
                 {
-                    _handler = new AnonymousCliAction(TypoCorrection.ProvideSuggestions);
+                    _handler = new TypoCorrection();
                 }
             }
 

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine.Parsing
         private int _index;
         private CommandResult _innermostCommandResult;
         private bool _isHelpRequested, _isParseRequested;
-        private ICommandHandler? _handler;
+        private CliAction? _handler;
 
         public ParseOperation(
             List<Token> tokens,
@@ -64,12 +64,12 @@ namespace System.CommandLine.Parsing
             {
                 if (_configuration.ParseErrorReportingExitCode.HasValue && _symbolResultTree.ErrorCount > 0)
                 {
-                    _handler = new AnonymousCommandHandler(ParseErrorResult.Apply);
+                    _handler = new AnonymousCliAction(ParseErrorResult.Apply);
                 }
                 else if (_configuration.MaxLevenshteinDistance > 0 && _rootCommandResult.Command.TreatUnmatchedTokensAsErrors
                     && _symbolResultTree.UnmatchedTokens is not null)
                 {
-                    _handler = new AnonymousCommandHandler(TypoCorrection.ProvideSuggestions);
+                    _handler = new AnonymousCliAction(TypoCorrection.ProvideSuggestions);
                 }
             }
 
@@ -194,11 +194,11 @@ namespace System.CommandLine.Parsing
                     {
                         _isHelpRequested = true;
 
-                        _handler = new AnonymousCommandHandler(HelpOption.Handler);
+                        _handler = new AnonymousCliAction(HelpOption.Handler);
                     }
                     else if (option is VersionOption)
                     {
-                        _handler = new AnonymousCommandHandler(VersionOption.Handler);
+                        _handler = new AnonymousCliAction(VersionOption.Handler);
                     }
                 }
 

--- a/src/System.CommandLine/SuggestDirective.cs
+++ b/src/System.CommandLine/SuggestDirective.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace System.CommandLine
 {
@@ -12,30 +14,40 @@ namespace System.CommandLine
     public sealed class SuggestDirective : Directive
     {
         public SuggestDirective() : base("suggest")
+            => Action = new SuggestDirectiveAction(this);
+
+        private sealed class SuggestDirectiveAction : CliAction
         {
-            SetHandler(SyncHandler);
-        }
+            private readonly SuggestDirective _directive;
 
-        private int SyncHandler(InvocationContext context)
-        {
-            ParseResult parseResult = context.ParseResult;
-            string? parsedValues = parseResult.FindResultFor(this)!.Values.SingleOrDefault();
-            string? rawInput = parseResult.CommandLineText;
+            internal SuggestDirectiveAction(SuggestDirective suggestDirective) => _directive = suggestDirective;
 
-            int position = !string.IsNullOrEmpty(parsedValues) ? int.Parse(parsedValues) : rawInput?.Length ?? 0;
+            public override int Invoke(InvocationContext context)
+            {
+                ParseResult parseResult = context.ParseResult;
+                string? parsedValues = parseResult.FindResultFor(_directive)!.Values.SingleOrDefault();
+                string? rawInput = parseResult.CommandLineText;
 
-            var commandLineToComplete = parseResult.Tokens.LastOrDefault(t => t.Type != TokenType.Directive)?.Value ?? "";
+                int position = !string.IsNullOrEmpty(parsedValues) ? int.Parse(parsedValues) : rawInput?.Length ?? 0;
 
-            var completionParseResult = parseResult.RootCommandResult.Command.Parse(commandLineToComplete, parseResult.Configuration);
+                var commandLineToComplete = parseResult.Tokens.LastOrDefault(t => t.Type != TokenType.Directive)?.Value ?? "";
 
-            var completions = completionParseResult.GetCompletions(position);
+                var completionParseResult = parseResult.RootCommandResult.Command.Parse(commandLineToComplete, parseResult.Configuration);
 
-            context.Console.Out.WriteLine(
-                string.Join(
-                    Environment.NewLine,
-                    completions));
+                var completions = completionParseResult.GetCompletions(position);
 
-            return 0;
+                context.Console.Out.WriteLine(
+                    string.Join(
+                        Environment.NewLine,
+                        completions));
+
+                return 0;
+            }
+
+            public override Task<int> InvokeAsync(InvocationContext context, CancellationToken cancellationToken = default)
+                => cancellationToken.IsCancellationRequested
+                    ? Task.FromCanceled<int>(cancellationToken)
+                    : Task.FromResult(Invoke(context));
         }
     }
 }

--- a/src/System.CommandLine/SuggestDirective.cs
+++ b/src/System.CommandLine/SuggestDirective.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine
     {
         public SuggestDirective() : base("suggest")
         {
-            SetSynchronousHandler(SyncHandler);
+            SetHandler(SyncHandler);
         }
 
         private int SyncHandler(InvocationContext context)

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -76,28 +76,6 @@ namespace System.CommandLine
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="CliAction"/> for the symbol. The handler represents the action
-        /// that will be performed when the symbol is invoked.
-        /// </summary>
-        /// <remarks>
-        /// <para>Use one of the <see cref="SetHandler(Func{InvocationContext, Int32})" /> overloads to construct a handler.</para>
-        /// <para>If the handler is not specified, parser errors will be generated for command line input that
-        /// invokes this symbol.</para></remarks>
-        public CliAction? Handler { get; set; }
-
-        /// <summary>
-        /// Sets a synchronous symbol handler. The handler should return an exit code.
-        /// </summary>
-        public void SetHandler(Func<InvocationContext, int> handler)
-            => Handler = new AnonymousCliAction(handler);
-
-        /// <summary>
-        /// Sets an asynchronous symbol handler. The handler should return an exit code.
-        /// </summary>
-        public void SetHandler(Func<InvocationContext, CancellationToken, Task<int>> handler)
-            => Handler = new AnonymousCliAction(handler);
-
-        /// <summary>
         /// Gets completions for the symbol.
         /// </summary>
         public abstract IEnumerable<CompletionItem> GetCompletions(CompletionContext context);

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -3,10 +3,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Completions;
-using System.CommandLine.Invocation;
 using System.Diagnostics;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace System.CommandLine
 {

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -3,7 +3,10 @@
 
 using System.Collections.Generic;
 using System.CommandLine.Completions;
+using System.CommandLine.Invocation;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace System.CommandLine
 {
@@ -71,6 +74,28 @@ namespace System.CommandLine
                 }
             }
         }
+
+        /// <summary>
+        /// Gets or sets the <see cref="CliAction"/> for the symbol. The handler represents the action
+        /// that will be performed when the symbol is invoked.
+        /// </summary>
+        /// <remarks>
+        /// <para>Use one of the <see cref="SetHandler(Func{InvocationContext, Int32})" /> overloads to construct a handler.</para>
+        /// <para>If the handler is not specified, parser errors will be generated for command line input that
+        /// invokes this symbol.</para></remarks>
+        public CliAction? Handler { get; set; }
+
+        /// <summary>
+        /// Sets a synchronous symbol handler. The handler should return an exit code.
+        /// </summary>
+        public void SetHandler(Func<InvocationContext, int> handler)
+            => Handler = new AnonymousCliAction(handler);
+
+        /// <summary>
+        /// Sets an asynchronous symbol handler. The handler should return an exit code.
+        /// </summary>
+        public void SetHandler(Func<InvocationContext, CancellationToken, Task<int>> handler)
+            => Handler = new AnonymousCliAction(handler);
 
         /// <summary>
         /// Gets completions for the symbol.


### PR DESCRIPTION
Overall it was way easier than I expected.

This PR:

1. Replaces `ICommandHandler` with `CliAction`
2. Renames `Command.SetHandler` with `Command.SetAction`. 
3. Changes the exit code approach: every successful program should return 0, so to avoid verbosity command actions provided by `Command.SetAction` do not need to return an int. In case somebody wants to reuturn an int, they need to implement  their own `CliAction` type (pay for play) 
5. Extends Options and Directives with `Action` property, but not `SetAction` methods (no need to, as it should be rare to have active options and directives that don't need custom types)
6. It does not expose the new action types, I want to do it in a separate PR, where I am going to write tests for them and move the configuration to these types.

Contributes to #2071



