### PR TITLE
merge ParseDirectiveAction and ParseResultExtensions into one internal type

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -265,8 +265,6 @@ System.CommandLine.Parsing
     public static System.CommandLine.ParseResult Parse(System.CommandLine.Command command, System.Collections.Generic.IReadOnlyList<System.String> args, System.CommandLine.CommandLineConfiguration configuration = null)
     public static System.CommandLine.ParseResult Parse(System.CommandLine.Command command, System.String commandLine, System.CommandLine.CommandLineConfiguration configuration = null)
     public static System.Collections.Generic.IEnumerable<System.String> SplitCommandLine(System.String commandLine)
-  public static class ParseResultExtensions
-    public static System.String Diagram(this System.CommandLine.ParseResult parseResult)
   public abstract class SymbolResult
     public SymbolResult Parent { get; }
     public System.Collections.Generic.IReadOnlyList<Token> Tokens { get; }

--- a/src/System.CommandLine.Rendering.Tests/ViewRenderingTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/ViewRenderingTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.CommandLine.IO;
-using System.CommandLine.Parsing;
 using System.CommandLine.Rendering.Views;
 using System.CommandLine.Tests.Utility;
 using System.Drawing;
@@ -35,7 +33,7 @@ namespace System.CommandLine.Rendering.Tests
 
             config.Invoke("");
 
-            terminal.Out.ToString().Should().Contain(parseResult.Diagram());
+            terminal.Out.ToString().Should().Contain(parseResult.ToString());
         }
 
         [Theory]

--- a/src/System.CommandLine.Tests/Utility/ParseResultExtensions.cs
+++ b/src/System.CommandLine.Tests/Utility/ParseResultExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+
+namespace System.CommandLine.Tests
+{
+    internal static class ParseResultExtensions
+    {
+        internal static string Diagram(this ParseResult parseResult)
+        {
+            TextWriter outputBefore = parseResult.Configuration.Output;
+
+            try
+            {
+                parseResult.Configuration.Output = new StringWriter();
+                new ParseDirective().Action.Invoke(parseResult);
+                return parseResult.Configuration.Output.ToString()
+                    .TrimEnd(); // the directive adds a new line, tests that used to rely on Diagram extension method don't expect it
+            }
+            finally
+            {
+                // some of the tests check the Output after getting the Diagram
+                parseResult.Configuration.Output = outputBefore;
+            }
+        }
+    }
+}

--- a/src/System.CommandLine/ParseDirective.cs
+++ b/src/System.CommandLine/ParseDirective.cs
@@ -1,11 +1,10 @@
 ﻿using System.CommandLine.Parsing;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.CommandLine
 {
     /// <summary>
-    /// Enables the use of the <c>[parse]</c> directive, which when specified on the command line will short circuit normal command handling and display a diagram explaining the parse result for the command line input.
+    /// Enables the use of the <c>[parse]</c> directive, which when specified on the command line will short 
+    /// circuit normal command handling and display a diagram explaining the parse result for the command line input.
     /// </summary>
     public sealed class ParseDirective : Directive
     {
@@ -26,24 +25,6 @@ namespace System.CommandLine
         {
             get => _action ??= new ParseDirectiveAction(DefaultErrorExitCode);
             set => _action = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        private sealed class ParseDirectiveAction : CliAction
-        {
-            private readonly int _errorExitCode;
-
-            internal ParseDirectiveAction(int errorExitCode) => _errorExitCode = errorExitCode;
-
-            public override int Invoke(ParseResult parseResult)
-            {
-                parseResult.Configuration.Output.WriteLine(parseResult.Diagram());
-                return parseResult.Errors.Count == 0 ? 0 : _errorExitCode;
-            }
-
-            public override Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken = default)
-                => cancellationToken.IsCancellationRequested
-                    ? Task.FromCanceled<int>(cancellationToken)
-                    : Task.FromResult(Invoke(parseResult));
         }
     }
 }

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -194,7 +194,7 @@ namespace System.CommandLine
         }
 
         /// <inheritdoc />
-        public override string ToString() => $"{nameof(ParseResult)}: {this.Diagram()}";
+        public override string ToString() => ParseDirectiveAction.Diagram(this).ToString();
 
         /// <summary>
         /// Gets the result, if any, for the specified argument.


### PR DESCRIPTION
make ParseDirectiveAction.InvokeAsync actually async: use the new `WriteLine(StringBuilder, CancellationToken)` overload

main goal: expose fewer public types (`ParseResultExtensions` in this case)