### PR TITLE
rename ParseDiagramDirective To DiagramDirective

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -116,6 +116,10 @@ System.CommandLine
   public static class CompletionSourceExtensions
     public static System.Void Add(this System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> completionSources, System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.String>> completionsDelegate)
     public static System.Void Add(this System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> completionSources, System.String[] completions)
+  public class DiagramDirective : CliDirective
+    .ctor()
+    public CliAction Action { get; set; }
+    public System.Int32 ParseErrorReturnValue { get; set; }
   public class EnvironmentVariablesDirective : CliDirective
     .ctor()
     public CliAction Action { get; set; }
@@ -124,10 +128,6 @@ System.CommandLine
     public static CliOption<System.IO.DirectoryInfo> AcceptExistingOnly(this CliOption<System.IO.DirectoryInfo> option)
     public static CliOption<System.IO.FileSystemInfo> AcceptExistingOnly(this CliOption<System.IO.FileSystemInfo> option)
     public static CliOption<T> AcceptExistingOnly<T>(this CliOption<T> option)
-  public class ParseDiagramDirective : CliDirective
-    .ctor()
-    public CliAction Action { get; set; }
-    public System.Int32 ParseErrorReturnValue { get; set; }
   public class ParseResult
     public CliAction Action { get; }
     public System.CommandLine.Parsing.CommandResult CommandResult { get; }

--- a/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_ParseResult.cs
+++ b/src/System.CommandLine.Benchmarks/CommandLine/Perf_Parser_ParseResult.cs
@@ -27,7 +27,7 @@ namespace System.CommandLine.Benchmarks.CommandLine
 
             _configuration = new CommandLineConfiguration(new CliRootCommand { option })
             {
-                Directives = { new ParseDiagramDirective() },
+                Directives = { new DiagramDirective() },
                 Output = _output
             };
         }

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -75,7 +75,7 @@ namespace System.CommandLine.Suggest
             {
                 Directives =
                 {
-                    new ParseDiagramDirective(),
+                    new DiagramDirective(),
                     new SuggestDirective(),
                 }
             };

--- a/src/System.CommandLine.Tests/ParseDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/ParseDirectiveTests.cs
@@ -9,17 +9,17 @@ using Xunit.Abstractions;
 
 namespace System.CommandLine.Tests
 {
-    public class ParseDirectiveTests
+    public class DiagramDirectiveTests
     {
         private readonly ITestOutputHelper output;
 
-        public ParseDirectiveTests(ITestOutputHelper output)
+        public DiagramDirectiveTests(ITestOutputHelper output)
         {
             this.output = output;
         }
 
         [Fact]
-        public async Task Parse_directive_writes_parse_diagram()
+        public async Task Diagram_directive_writes_parse_diagram()
         {
             var rootCommand = new CliRootCommand();
             var subcommand = new CliCommand("subcommand");
@@ -30,10 +30,10 @@ namespace System.CommandLine.Tests
             CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter(),
-                Directives = { new ParseDiagramDirective() }
+                Directives = { new DiagramDirective() }
             };
 
-            var result = rootCommand.Parse("[parse] subcommand -c 34 --nonexistent wat", config);
+            var result = rootCommand.Parse("[diagram] subcommand -c 34 --nonexistent wat", config);
 
             output.WriteLine(result.Diagram());
 
@@ -46,17 +46,17 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public async Task When_parse_directive_is_used_the_help_is_not_displayed()
+        public async Task When_diagram_directive_is_used_the_help_is_not_displayed()
         {
             CliRootCommand rootCommand = new ();
 
             CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter(),
-                Directives = { new ParseDiagramDirective() }
+                Directives = { new DiagramDirective() }
             };
 
-            var result = rootCommand.Parse("[parse] --help", config);
+            var result = rootCommand.Parse("[diagram] --help", config);
 
             output.WriteLine(result.Diagram());
 
@@ -69,17 +69,17 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public async Task When_parse_directive_is_used_the_version_is_not_displayed()
+        public async Task When_diagram_directive_is_used_the_version_is_not_displayed()
         {
             CliRootCommand rootCommand = new();
 
             CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter(),
-                Directives = { new ParseDiagramDirective() }
+                Directives = { new DiagramDirective() }
             };
 
-            var result = rootCommand.Parse("[parse] --version", config);
+            var result = rootCommand.Parse("[diagram] --version", config);
 
             output.WriteLine(result.Diagram());
 
@@ -92,7 +92,7 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public async Task When_there_are_no_errors_then_parse_directive_sets_exit_code_0()
+        public async Task When_there_are_no_errors_then_diagram_directive_sets_exit_code_0()
         {
             CliRootCommand command = new ()
             {
@@ -102,16 +102,16 @@ namespace System.CommandLine.Tests
             CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter(),
-                Directives = { new ParseDiagramDirective() }
+                Directives = { new DiagramDirective() }
             };
 
-            var exitCode = await command.Parse("[parse] -x 123", config).InvokeAsync();
+            var exitCode = await command.Parse("[diagram] -x 123", config).InvokeAsync();
 
             exitCode.Should().Be(0);
         }
 
         [Fact]
-        public async Task When_there_are_errors_then_parse_directive_sets_exit_code_1()
+        public async Task When_there_are_errors_then_diagram_directive_sets_exit_code_1()
         {
             CliRootCommand command = new()
             {
@@ -121,16 +121,16 @@ namespace System.CommandLine.Tests
             CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter(),
-                Directives = { new ParseDiagramDirective() }
+                Directives = { new DiagramDirective() }
             };
 
-            var exitCode = await command.Parse("[parse] -x not-an-int", config).InvokeAsync();
+            var exitCode = await command.Parse("[diagram] -x not-an-int", config).InvokeAsync();
 
             exitCode.Should().Be(1);
         }
 
         [Fact]
-        public async Task When_there_are_errors_then_parse_directive_sets_exit_code_to_custom_value()
+        public async Task When_there_are_errors_then_diagram_directive_sets_exit_code_to_custom_value()
         {
             CliRootCommand command = new ()
             {
@@ -140,13 +140,13 @@ namespace System.CommandLine.Tests
             CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter(),
-                Directives = { new ParseDiagramDirective
+                Directives = { new DiagramDirective
                 {
                     ParseErrorReturnValue = 42
                 } }
             };
 
-            int exitCode = await config.InvokeAsync("[parse] -x not-an-int");
+            int exitCode = await config.InvokeAsync("[diagram] -x not-an-int");
 
             exitCode.Should().Be(42);
         }

--- a/src/System.CommandLine.Tests/Utility/ParseResultExtensions.cs
+++ b/src/System.CommandLine.Tests/Utility/ParseResultExtensions.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Tests
             try
             {
                 parseResult.Configuration.Output = new StringWriter();
-                new ParseDiagramDirective().Action.Invoke(parseResult);
+                new DiagramDirective().Action.Invoke(parseResult);
                 return parseResult.Configuration.Output.ToString()
                     .TrimEnd(); // the directive adds a new line, tests that used to rely on Diagram extension method don't expect it
             }

--- a/src/System.CommandLine/ParseDiagramDirective.cs
+++ b/src/System.CommandLine/ParseDiagramDirective.cs
@@ -3,24 +3,24 @@
 namespace System.CommandLine
 {
     /// <summary>
-    /// Enables the use of the <c>[parse]</c> directive, which when specified on the command line will short 
+    /// Enables the use of the <c>[diagram]</c> directive, which when specified on the command line will short 
     /// circuit normal command handling and display a diagram explaining the parse result for the command line input.
     /// </summary>
-    public sealed class ParseDiagramDirective : CliDirective
+    public sealed class DiagramDirective : CliDirective
     {
         private CliAction? _action;
 
         /// <summary>
-        /// Writes a diagram of the parse result to the console.
+        /// Writes a diagram of the parse result to the output.
         /// </summary>
-        public ParseDiagramDirective() : base("parse")
+        public DiagramDirective() : base("diagram")
         {
         }
 
         /// <inheritdoc />
         public override CliAction? Action
         {
-            get => _action ??= new ParseDiagramAction(ParseErrorReturnValue);
+            get => _action ??= new DiagramAction(ParseErrorReturnValue);
             set => _action = value ?? throw new ArgumentNullException(nameof(value));
         }
 

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -194,7 +194,7 @@ namespace System.CommandLine
         }
 
         /// <inheritdoc />
-        public override string ToString() => ParseDiagramAction.Diagram(this).ToString();
+        public override string ToString() => DiagramAction.Diagram(this).ToString();
 
         /// <summary>
         /// Gets the result, if any, for the specified argument.

--- a/src/System.CommandLine/Parsing/ParseDiagramAction.cs
+++ b/src/System.CommandLine/Parsing/ParseDiagramAction.cs
@@ -11,14 +11,14 @@ using System.Threading;
 namespace System.CommandLine.Parsing
 {
     /// <summary>
-    /// Implements the <c>[parse]</c> directive action, which when specified on the command line 
+    /// Implements the <c>[diagram]</c> directive action, which when specified on the command line 
     /// will short circuit normal command handling and display a diagram explaining the parse result for the command line input.
     /// </summary>
-    internal sealed class ParseDiagramAction : CliAction
+    internal sealed class DiagramAction : CliAction
     {
         private readonly int _parseErrorReturnValue;
 
-        internal ParseDiagramAction(int parseErrorReturnValue) => _parseErrorReturnValue = parseErrorReturnValue;
+        internal DiagramAction(int parseErrorReturnValue) => _parseErrorReturnValue = parseErrorReturnValue;
 
         public override int Invoke(ParseResult parseResult)
         {
@@ -79,7 +79,7 @@ namespace System.CommandLine.Parsing
 
             switch (symbolResult)
             {
-                case DirectiveResult directiveResult when directiveResult.Directive is not ParseDiagramDirective:
+                case DirectiveResult directiveResult when directiveResult.Directive is not DiagramDirective:
                     break;
                 case ArgumentResult argumentResult:
                 {

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -321,7 +321,7 @@ namespace System.CommandLine.Parsing
 
                 _action = directive.Action;
 
-                if (directive is ParseDiagramDirective)
+                if (directive is DiagramDirective)
                 {
                     _isParseRequested = true;
                 }


### PR DESCRIPTION
The naming is a subjective topic, but in my opinion `DiagramDirective` is a better name. Also `[diagram]` is better at expressing what this directive does than `[parse]`

@jonsequitur @KathleenDollard @Keboo thoughts?