### PR TITLE
Disable System.CommandLine trimming for source-build

### DIFF
--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -18,7 +18,7 @@
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0' and '$(DotNetBuildFromSource)' != 'true'">
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>


### PR DESCRIPTION
When attempting to [enable PVP flow](https://github.com/dotnet/source-build/issues/3043) for the command-line-api, a prebuilt was detected for `Microsoft.NET.ILLink.Tasks.7.0.100-1.23062.2`. This occurs as a result of the enablement of trimming for the System.CommandLine project.

To resolve this, I've changed the configuration to only enable trimming when not running source-build. I initially attempted to only apply this condition to the `EnableTrimAnalyzer` property but that did not prevent the loading of `Microsoft.NET.ILLink.Tasks`.

cc @jonsequitur  @mmitche @MichaelSimons 