### PR TITLE
Removes the custom `GetHashCode` and `Equals` overrides in `HelpOption` and `VerboseOption`

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -155,8 +155,6 @@ System.CommandLine
     .ctor()
     .ctor(System.String name, System.String[] aliases)
     public CliAction Action { get; set; }
-    public System.Boolean Equals(System.Object obj)
-    public System.Int32 GetHashCode()
 System.CommandLine.Completions
   public class CompletionContext
     public static CompletionContext Empty { get; }
@@ -220,8 +218,6 @@ System.CommandLine.Help
     .ctor()
     .ctor(System.String name, System.String[] aliases)
     public System.CommandLine.CliAction Action { get; set; }
-    public System.Boolean Equals(System.Object obj)
-    public System.Int32 GetHashCode()
   public class TwoColumnHelpRow, System.IEquatable<TwoColumnHelpRow>
     .ctor(System.String firstColumnText, System.String secondColumnText)
     public System.String FirstColumnText { get; }

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
@@ -405,6 +405,8 @@ namespace System.CommandLine.Tests.Help
                     Output = new StringWriter(),
                 };
 
+                var defaultHelp = GetDefaultHelp(config.RootCommand);
+
                 ParseResult parseResult = config.Parse("-h");
 
                 if (parseResult.Action is HelpAction helpAction)
@@ -415,7 +417,6 @@ namespace System.CommandLine.Tests.Help
                 parseResult.Invoke();
 
                 var output = config.Output.ToString();
-                var defaultHelp = GetDefaultHelp(config.RootCommand);
 
                 var expected = $"first{NewLine}{NewLine}{defaultHelp}last{NewLine}{NewLine}";
 

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -48,11 +48,6 @@ namespace System.CommandLine.Help
                 return;
             }
 
-            if (OnCustomize is {})
-            {
-                OnCustomize(context);
-            }
-
             foreach (var writeSection in GetLayout(context))
             {
                 writeSection(context);
@@ -65,8 +60,6 @@ namespace System.CommandLine.Help
 
             context.Output.WriteLine();
         }
-
-        internal Action<HelpContext>? OnCustomize { get; set; }
 
         /// <summary>
         /// Specifies custom help details for a specific symbol.

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -37,11 +37,5 @@ namespace System.CommandLine.Help
             get => _action ??= new HelpAction(); 
             set => _action = value ?? throw new ArgumentNullException(nameof(value));
         }
-
-        internal override bool Greedy => false;
-
-        public override bool Equals(object? obj) => obj is HelpOption;
-
-        public override int GetHashCode() => typeof(HelpOption).GetHashCode();
     }
 }

--- a/src/System.CommandLine/VersionOption.cs
+++ b/src/System.CommandLine/VersionOption.cs
@@ -61,10 +61,6 @@ namespace System.CommandLine
 
         internal override bool Greedy => false;
 
-        public override bool Equals(object? obj) => obj is VersionOption;
-
-        public override int GetHashCode() => typeof(VersionOption).GetHashCode();
-
         private sealed class VersionOptionAction : CliAction
         {
             public override int Invoke(ParseResult parseResult)


### PR DESCRIPTION
This fixes #2118.

It also fixed #2116.