### PR TITLE
Add `OptionResult.IdentifierTokenCount` property

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -247,6 +247,7 @@ System.CommandLine.Parsing
     public System.Collections.Generic.IReadOnlyList<System.String> Values { get; }
   public class OptionResult : SymbolResult
     public Token IdentifierToken { get; }
+    public System.Int32 IdentifierTokenCount { get; }
     public System.Boolean Implicit { get; }
     public System.CommandLine.CliOption Option { get; }
     public T GetValueOrDefault<T>()

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -89,7 +89,7 @@ namespace System.CommandLine.Tests
             }
 
             [Fact]
-            public void GetDefaultValue_returns_null_when_parse_delegate_returns_true_without_setting_a_value()
+            public void GetDefaultValue_returns_null_when_custom_parser_returns_true_without_setting_a_value()
             {
                 var argument = new CliArgument<string>("arg")
                 {
@@ -405,7 +405,7 @@ namespace System.CommandLine.Tests
             }
 
             [Fact]
-            public void Multiple_command_arguments_can_have_custom_parse_delegates()
+            public void Multiple_arguments_can_have_custom_parsers()
             {
                 var root = new CliRootCommand
                 {
@@ -500,7 +500,7 @@ namespace System.CommandLine.Tests
             }
 
             [Fact]
-            public void Parse_delegate_is_called_once_per_parse_operation_when_input_is_provided()
+            public void Custom_parser_is_called_once_per_parse_operation_when_input_is_provided()
             {
                 var i = 0;
 

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Binding;
@@ -39,7 +39,13 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The token that was parsed to specify the option.
         /// </summary>
+        /// <remarks>An identifier token is a token that matches either the option's name or one of its aliases.</remarks>
         public Token? IdentifierToken { get; }
+
+        /// <summary>
+        /// The number of occurrences of an identifier token matching the option.
+        /// </summary>
+        public int IdentifierTokenCount { get; internal set; }
 
         /// <inheritdoc/>
         public override string ToString() => $"{nameof(OptionResult)}: {IdentifierToken?.Value ?? Option.Name} {string.Join(" ", Tokens.Select(t => t.Value))}";

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -217,6 +217,8 @@ namespace System.CommandLine.Parsing
                 optionResult = (OptionResult)symbolResult;
             }
 
+            optionResult.IdentifierTokenCount++;
+
             Advance();
 
             ParseOptionArguments(optionResult);
@@ -243,7 +245,8 @@ namespace System.CommandLine.Parsing
                         break;
                     }
                 }
-                else if (argument.ValueType == typeof(bool) && !bool.TryParse(CurrentToken.Value, out _))
+                else if (argument.ValueType == typeof(bool) && 
+                         !bool.TryParse(CurrentToken.Value, out _))
                 {
                     break;
                 }
@@ -276,8 +279,11 @@ namespace System.CommandLine.Parsing
 
             if (argumentCount == 0)
             {
-                ArgumentResult argumentResult = new(optionResult.Option.Argument, _symbolResultTree, optionResult);
-                _symbolResultTree.Add(optionResult.Option.Argument, argumentResult);
+                if (!_symbolResultTree.ContainsKey(argument))
+                {
+                    var argumentResult = new ArgumentResult(argument, _symbolResultTree, optionResult);
+                    _symbolResultTree.Add(argument, argumentResult);
+                }
             }
         }
 


### PR DESCRIPTION
This introduces a property, `OptionResult.IdentifierTokenCount`, that can be used to provide a solution to #669.

This property exposes the number of times an identifier token was encountered for a given option. This value is incremented once per token regardless of whether the option name or one of its aliases was parsed.

It also fixes an `ArgumentException` that would occur when `-v -v -v` was parsed.