### PR TITLE
introduce `SymbolResult.Errors`

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -256,6 +256,7 @@ System.CommandLine.Parsing
     public SymbolResult SymbolResult { get; }
     public System.String ToString()
   public abstract class SymbolResult
+    public System.Collections.Generic.IEnumerable<ParseError> Errors { get; }
     public SymbolResult Parent { get; }
     public System.Collections.Generic.IReadOnlyList<Token> Tokens { get; }
     public System.Void AddError(System.String errorMessage)

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -123,7 +123,7 @@ namespace System.CommandLine.Parsing
         /// <inheritdoc/>
         public override void AddError(string errorMessage)
         {
-            SymbolResultTree.AddError(new ParseError(errorMessage, Parent is OptionResult option ? option : this));
+            SymbolResultTree.AddError(new ParseError(errorMessage, AppliesToPublicSymbolResult));
             _conversionResult = ArgumentConversionResult.Failure(this, errorMessage, ArgumentConversionResultType.Failed);
         }
 
@@ -188,17 +188,29 @@ namespace System.CommandLine.Parsing
                 return ArgumentConversionResult.Success(this, value);
             }
 
-            return ReportErrorIfNeeded(ArgumentConversionResult.ArgumentConversionCannotParse(this, Argument.ValueType, Tokens[0].Value));
+            return ReportErrorIfNeeded(
+                ArgumentConversionResult.ArgumentConversionCannotParse(
+                    this,
+                    Argument.ValueType,
+                    Tokens.Count > 0 
+                        ? Tokens[0].Value
+                        : ""));
 
             ArgumentConversionResult ReportErrorIfNeeded(ArgumentConversionResult result)
             {
                 if (result.Result >= ArgumentConversionResultType.Failed)
                 {
-                    SymbolResultTree.AddError(new ParseError(result.ErrorMessage!, Parent is OptionResult option ? option : this));
+                    SymbolResultTree.AddError(new ParseError(result.ErrorMessage!, AppliesToPublicSymbolResult));
                 }
 
                 return result;
             }
         }
+
+        /// <summary>
+        /// Since Option.Argument is an internal implementation detail, this ArgumentResult applies to the OptionResult in public API if the parent is an OptionResult.
+        /// </summary>
+        private SymbolResult AppliesToPublicSymbolResult => 
+            Parent is OptionResult optionResult ? optionResult : this;
     }
 }

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.CommandLine.Binding;
+using System.Linq;
 
 namespace System.CommandLine.Parsing
 {
@@ -18,6 +18,31 @@ namespace System.CommandLine.Parsing
         {
             SymbolResultTree = symbolResultTree;
             Parent = parent;
+        }
+
+        /// <summary>
+        /// The parse errors associated with this symbol result.
+        /// </summary>
+        public IEnumerable<ParseError> Errors
+        {
+            get
+            {
+                var parseErrors = SymbolResultTree.Errors;
+
+                if (parseErrors is null)
+                {
+                    yield break;
+                }
+
+                for (var i = 0; i < parseErrors.Count; i++)
+                {
+                    var parseError = parseErrors[i];
+                    if (parseError.SymbolResult == this)
+                    {
+                        yield return parseError;
+                    }
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This property makes it possible to inspect results of other symbols from within a custom parser.