### PR TITLE
Validation should not stop on the first reported error

### DIFF
--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -140,7 +140,7 @@ namespace System.CommandLine.Parsing
 
                     if (errorsBefore != SymbolResultTree.ErrorCount)
                     {
-                        break;
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
It's a fix for a bug that I've hit when working on updating SDK to the latest S.CL (https://github.com/dotnet/sdk/pull/29131)