### PR TITLE
dotnet-suggest script: use appropriate line-endings.

### DIFF
--- a/src/System.CommandLine.Suggest.Tests/SuggestionShellScriptHandlerTest.cs
+++ b/src/System.CommandLine.Suggest.Tests/SuggestionShellScriptHandlerTest.cs
@@ -38,6 +38,7 @@ namespace System.CommandLine.Suggest.Tests
             await _configuration.InvokeAsync("script bash");
 
             _configuration.Output.ToString().Should().Contain("_dotnet_bash_complete()");
+            _configuration.Output.ToString().Should().NotContain("\r\n");
         }
 
         [Fact]
@@ -48,6 +49,7 @@ namespace System.CommandLine.Suggest.Tests
             await _configuration.InvokeAsync("script powershell");
 
             _configuration.Output.ToString().Should().Contain("Register-ArgumentCompleter");
+            _configuration.Output.ToString().Should().Contain("\r\n");
         }
 
         [Fact]
@@ -58,6 +60,7 @@ namespace System.CommandLine.Suggest.Tests
             await _configuration.InvokeAsync("script zsh");
             
             _configuration.Output.ToString().Should().Contain("_dotnet_zsh_complete()");
+            _configuration.Output.ToString().Should().NotContain("\r\n");
         }
     }
 }

--- a/src/System.CommandLine.Suggest/SuggestionShellScriptHandler.cs
+++ b/src/System.CommandLine.Suggest/SuggestionShellScriptHandler.cs
@@ -13,24 +13,37 @@ namespace System.CommandLine.Suggest
             switch (shellType)
             {
                 case ShellType.Bash:
-                    PrintToConsoleFrom(output, "dotnet-suggest-shim.bash");
+                    PrintToConsoleFrom(output, "dotnet-suggest-shim.bash", useUnixLineEndings: true);
                     break;
                 case ShellType.PowerShell:
-                    PrintToConsoleFrom(output, "dotnet-suggest-shim.ps1");
+                    PrintToConsoleFrom(output, "dotnet-suggest-shim.ps1", useUnixLineEndings: false);
                     break;
                 case ShellType.Zsh:
-                    PrintToConsoleFrom(output, "dotnet-suggest-shim.zsh");
+                    PrintToConsoleFrom(output, "dotnet-suggest-shim.zsh", useUnixLineEndings: true);
                     break;
                 default:
                     throw new SuggestionShellScriptException($"Shell '{shellType}' is not supported.");
             }
         }
 
-        private static void PrintToConsoleFrom(TextWriter output, string scriptName)
+        private static void PrintToConsoleFrom(TextWriter output, string scriptName, bool useUnixLineEndings)
         {
             var assemblyLocation = Assembly.GetAssembly(typeof(SuggestionShellScriptHandler)).Location;
             var directory = Path.GetDirectoryName(assemblyLocation);
-            output.Write(File.ReadAllText(Path.Combine(directory, scriptName)));
+            string scriptContent = File.ReadAllText(Path.Combine(directory, scriptName));
+            bool hasUnixLineEndings = !scriptContent.Contains("\r\n");
+            if (hasUnixLineEndings != useUnixLineEndings)
+            {
+                if (useUnixLineEndings)
+                {
+                    scriptContent = scriptContent.Replace("\r\n", "\n");
+                }
+                else
+                {
+                    scriptContent = scriptContent.Replace("\n", "\r\n");
+                }
+            }
+            output.Write(scriptContent);
         }
     }
 }


### PR DESCRIPTION
Use Windows line-endings when printing the PowerShell script, and Unix line-endings when printing the bash and zsh scripts.

@jonsequitur @adamsitnik ptal.