### PR TITLE
Update dotnet-suggest install instructions.

### DIFF
--- a/docs/dotnet-suggest.md
+++ b/docs/dotnet-suggest.md
@@ -27,8 +27,11 @@ echo '. ~/.dotnet-suggest-shim.zsh' >>~/.zshrc
 ```
 
 ### PowerShell
-```sh
-?
+
+Add the contents of [dotnet-suggest-shim.ps1](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1) to your PowerShell profile. You can find the expected path to your PowerShell profile by running the following in your console:
+
+```console
+> echo $profile
 ```
 
 (For other shells, please [look for](https://github.com/dotnet/command-line-api/issues?q=is%3Aissue+is%3Aopen+label%3A%22shell+suggestion%22) or open an [issue](https://github.com/dotnet/command-line-api/issues).)

--- a/docs/dotnet-suggest.md
+++ b/docs/dotnet-suggest.md
@@ -9,7 +9,7 @@ On the machine where you'd like to enable completion, you'll need to do two thin
 1. Install the `dotnet-suggest` global tool:
 
 ```sh
-dotnet tool install dotnet-suggest
+dotnet tool install -g dotnet-suggest
 ```
 
 2. Install the completion script.

--- a/docs/dotnet-suggest.md
+++ b/docs/dotnet-suggest.md
@@ -7,20 +7,28 @@ Command line apps built using `System.CommandLine` have built-in support for tab
 On the machine where you'd like to enable completion, you'll need to do two things.
 
 1. Install the `dotnet-suggest` global tool:
-   
-   [![Nuget](https://img.shields.io/nuget/v/dotnet-suggest.svg)](https://nuget.org/packages/dotnet-suggest)
 
-2. Add the appropriate shim script to your shell profile. You may have to create a shell profile file. The shim script will forward completion requests from your shell to the `dotnet-suggest` tool, which delegates to the appropriate `System.CommandLine`-based app.
-   
-   * For bash, add the contents of [dotnet-suggest-shim.bash](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash) to `~/.bash_profile`.
-   
-   * For zsh, add the contents of [dotnet-suggest-shim.zsh](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh) to `~/.zshrc`.
-  
-   * For PowerShell, add the contents of [dotnet-suggest-shim.ps1](https://github.com/dotnet/command-line-api/blob/master/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1) to your PowerShell profile. You can find the expected path to your PowerShell profile by running the following in your console:
+```sh
+dotnet tool install dotnet-suggest
+```
 
-```console
-> echo $profile
+2. Install the completion script.
+
+### bash
+```sh
+dotnet-suggest script bash >~/.dotnet-suggest-shim.bash
+echo '. ~/.dotnet-suggest-shim.bash' >>~/.bashrc
+```
+
+### zsh
+```sh
+dotnet-suggest script zsh >~/.dotnet-suggest-shim.zsh
+echo '. ~/.dotnet-suggest-shim.zsh' >>~/.zshrc
+```
+
+### PowerShell
+```sh
+?
 ```
 
 (For other shells, please [look for](https://github.com/dotnet/command-line-api/issues?q=is%3Aissue+is%3Aopen+label%3A%22shell+suggestion%22) or open an [issue](https://github.com/dotnet/command-line-api/issues).)
-

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash
@@ -1,4 +1,3 @@
-# dotnet suggest shell complete script start
 _dotnet_bash_complete()
 {
     local fullpath=`type -p ${COMP_WORDS[0]}`
@@ -27,4 +26,3 @@ _dotnet_bash_register_complete()
 }
 _dotnet_bash_register_complete
 export DOTNET_SUGGEST_SCRIPT_VERSION="1.0.2"
-# dotnet suggest shell complete script end

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash
@@ -25,6 +25,4 @@ _dotnet_bash_register_complete()
 }
 
 _dotnet_bash_register_complete
-
 export DOTNET_SUGGEST_SCRIPT_VERSION="1.0.3"
-

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1
@@ -1,4 +1,3 @@
-# dotnet suggest shell start
 if (Get-Command "dotnet-suggest" -errorAction SilentlyContinue)
 {
     $availableToComplete = (dotnet-suggest list) | Out-String
@@ -21,4 +20,3 @@ else
 }
 
 $env:DOTNET_SUGGEST_SCRIPT_VERSION = "1.0.2"
-# dotnet suggest script end

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1
@@ -1,3 +1,4 @@
+# dotnet suggest shell start
 if (Get-Command "dotnet-suggest" -errorAction SilentlyContinue)
 {
     $availableToComplete = (dotnet-suggest list) | Out-String
@@ -20,3 +21,4 @@ else
 }
 
 $env:DOTNET_SUGGEST_SCRIPT_VERSION = "1.0.2"
+# dotnet suggest script end

--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh
@@ -1,4 +1,3 @@
-# dotnet suggest shell complete script start
 _dotnet_zsh_complete()
 {
     # debug lines, uncomment to get state variables passed to this function
@@ -36,4 +35,3 @@ _dotnet_zsh_complete()
 compdef _dotnet_zsh_complete $(dotnet-suggest list)
 
 export DOTNET_SUGGEST_SCRIPT_VERSION="1.0.0"
-# dotnet suggest shell complete script end


### PR DESCRIPTION
- Add 'dotnet tool install' command for 'dotnet-suggest'.
- Use 'dotnet-suggest script' to obtain the shell scripts.
- Use .bashrc instead of .bash_profile for the bash script.
- Store the script in a separate file, and source it.
- Remove script start/end comments, they are not needed if the script is installed in a file.

@jonsequitur ptal.