### PR TITLE
When TreatUnmatchedTokensAsErrors is set to false, there should be no errors reported for unmatched tokens

### DIFF
--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -107,12 +107,18 @@ namespace System.CommandLine.Parsing
                 nextArgumentIndex++;
             }
 
+            CommandResult rootCommand = parent;
+            while (rootCommand.Parent is CommandResult nextLevel)
+            {
+                rootCommand = nextLevel;
+            }
+
             // When_tokens_are_passed_on_by_custom_parser_on_last_argument_then_they_become_unmatched_tokens
             while (tokensToPass > 0)
             {
                 CliToken unmatched = _tokens[numberOfTokens];
                 _tokens.RemoveAt(numberOfTokens);
-                SymbolResultTree.AddUnmatchedToken(unmatched, parent.Command.TreatUnmatchedTokensAsErrors ? parent : null);
+                SymbolResultTree.AddUnmatchedToken(unmatched, parent, rootCommand);
                 --tokensToPass;
             }
         }

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -359,8 +359,7 @@ namespace System.CommandLine.Parsing
                 return;
             }
 
-            _symbolResultTree.AddUnmatchedToken(CurrentToken,
-                _rootCommandResult.Command.TreatUnmatchedTokensAsErrors ? _rootCommandResult : null);
+            _symbolResultTree.AddUnmatchedToken(CurrentToken, _innermostCommandResult, _rootCommandResult);
         }
 
         private void Validate()

--- a/src/System.CommandLine/Parsing/SymbolResultTree.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultTree.cs
@@ -55,12 +55,17 @@ namespace System.CommandLine.Parsing
 
         internal void InsertFirstError(ParseError parseError) => (Errors ??= new()).Insert(0, parseError);
 
-        internal void AddUnmatchedToken(CliToken token, CommandResult? commandResult)
+        internal void AddUnmatchedToken(CliToken token, CommandResult commandResult, CommandResult rootCommandResult)
         {
             (UnmatchedTokens ??= new()).Add(token);
 
-            if (commandResult is not null)
+            if (commandResult.Command.TreatUnmatchedTokensAsErrors)
             {
+                if (commandResult != rootCommandResult && !rootCommandResult.Command.TreatUnmatchedTokensAsErrors)
+                {
+                    return;
+                }
+
                 AddError(new ParseError(LocalizationResources.UnrecognizedCommandOrArgument(token.Value), commandResult));
             }
         }


### PR DESCRIPTION
While working on https://github.com/dotnet/sdk/pull/29131 I've stumbled upon something that surprised me.

The `vstest` command does not define `TreatUnmatchedTokensAsErrors=false`

https://github.com/dotnet/sdk/blob/46b88e570832cbb40fb3be4490ea318a1ec786e9/src/Cli/dotnet/commands/dotnet-vstest/VSTestCommandParser.cs#L24-L32

but it's action is actually getting the unmatched tokens to get the "args"

https://github.com/dotnet/sdk/blob/46b88e570832cbb40fb3be4490ea318a1ec786e9/src/Cli/dotnet/commands/dotnet-vstest/Program.cs#L25

https://github.com/dotnet/sdk/blob/46b88e570832cbb40fb3be4490ea318a1ec786e9/src/Cli/dotnet/ParseResultExtensions.cs#L117-L139

The problem from S.CL perspective is that before recent redesign, even if parse errors were reported it was still possible to run the command just fine.

![image](https://github.com/dotnet/command-line-api/assets/6011991/9e9bdf3d-f91c-42c9-b4b1-53a6f85abe28)

Now when parse errors are reported the action is `ParseErrorAction` and the command is not invoked.

To fix it on the SDK side I decided to set `TreatUnmatchedTokensAsErrors=false` for this particular command and then realized that we were still reporting the errors for unmatched tokens (which is a bug in my opinion) and `ParseResult.Action` was `ParseErrorAction`.


The fix that I am proposing here: when `TreatUnmatchedTokensAsErrors=false`, we should not report parse errors for unmatched tokens, just add the token to the list of unmatched tokens.


