### PR TITLE
subcommand completions should include root command recursive options completions

### DIFF
--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -246,7 +246,29 @@ namespace System.CommandLine.Tests
                   .Should()
                   .BeEquivalentTo("test");
         }
-        
+
+
+        [Fact]
+        public void Command_GetCompletions_include_recursive_options_of_root_command()
+        {
+            CliRootCommand rootCommand = new()
+            {
+                new CliCommand("sub")
+                {
+                    new CliOption<int>("--option")
+                }
+            };
+
+            var result = rootCommand.Parse("sub --option 123 ");
+
+            _output.WriteLine(result.ToString());
+
+            result.GetCompletions()
+                  .Select(item => item.Label)
+                  .Should()
+                  .BeEquivalentTo("--help", "-?", "-h", "/?", "/h");
+        }
+
         [Fact]
         public void When_one_option_has_been_specified_then_it_and_its_siblings_will_still_be_suggested()
         {

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -247,7 +247,6 @@ namespace System.CommandLine.Tests
                   .BeEquivalentTo("test");
         }
 
-
         [Fact]
         public void Command_GetCompletions_include_recursive_options_of_root_command()
         {
@@ -436,7 +435,7 @@ namespace System.CommandLine.Tests
             result.GetCompletions(commandLine.Length + 1)
                   .Select(item => item.Label)
                   .Should()
-                  .BeEquivalentTo("rainier");
+                  .BeEquivalentTo("--help", "-?", "-h", "/?", "/h", "rainier");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ParseResultTests.cs
+++ b/src/System.CommandLine.Tests/ParseResultTests.cs
@@ -54,6 +54,23 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void GetResult_can_be_used_for_root_command_itself()
+        {
+            CliRootCommand rootCommand = new()
+            {
+                new CliCommand("the-command")
+                {
+                    new CliOption<int>("-c")
+                }
+            };
+
+            var result = rootCommand.Parse("the-command -c 123");
+
+            result.RootCommandResult.Command.Should().BeSameAs(rootCommand);
+            result.GetResult(rootCommand).Should().BeSameAs(result.RootCommandResult);
+        }
+
+        [Fact]
         public void Command_will_not_accept_a_command_if_a_sibling_command_has_already_been_accepted()
         {
             var command = new CliCommand("outer")

--- a/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
@@ -79,9 +79,9 @@ namespace System.CommandLine.Tests
         }
 
         [Theory]
-        [InlineData("[suggest:4] \"eat\"")]
-        [InlineData("[suggest:6] \"eat --\"")]
-        public async Task It_writes_suggestions_for_option_aliases_under_subcommand(string commandLine)
+        [InlineData("[suggest:4] \"eat\"", new[] { "--fruit", "--help", "--vegetable", "-?", "-h", "/?", "/h" })]
+        [InlineData("[suggest:6] \"eat --\"", new[] { "--fruit", "--help", "--vegetable" })]
+        public async Task It_writes_suggestions_for_option_aliases_under_subcommand(string commandLine, string[] expectedCompletions)
         {
             CliRootCommand rootCommand = new() { _eatCommand };
             CliConfiguration config = new(rootCommand)
@@ -94,10 +94,12 @@ namespace System.CommandLine.Tests
 
             await result.InvokeAsync();
 
+            string expected = string.Join(NewLine, expectedCompletions) + NewLine;
+
             config.Output
                    .ToString()
                    .Should()
-                   .Be($"--fruit{NewLine}--vegetable{NewLine}");
+                   .Be(expected);
         }
 
         [Theory]

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -36,6 +36,7 @@ namespace System.CommandLine.Parsing
                 _configuration.RootCommand,
                 CurrentToken,
                 _symbolResultTree);
+            _symbolResultTree.Add(_configuration.RootCommand, _rootCommandResult);
 
             Advance();
         }


### PR DESCRIPTION
I've hit the issue when working on https://github.com/dotnet/sdk/pull/29131 which has some tests that ensures that for every subcommand the list of completions contains the completions for root command recursive options.

Explanation: we had logic which tried to achieve that, the problem was that `ParseResult.GetResult(rootCommand)` was always returning `null`, because root command itself was not added to our symbol tree dictionary

https://github.com/dotnet/command-line-api/blob/7058640c8f0c472c399bc063e14410a04cbe5ffd/src/System.CommandLine/CliCommand.cs#L269

