### PR TITLE
Respect custom help builder during parse error reporting

### DIFF
--- a/src/System.CommandLine.Tests/UseParseErrorReportingTests.cs
+++ b/src/System.CommandLine.Tests/UseParseErrorReportingTests.cs
@@ -60,5 +60,46 @@ namespace System.CommandLine.Tests
 
             result.Should().Be(42);
         }
+
+        [Fact]
+        public void User_can_customize_help_printed_on_parse_error()
+        {
+            CustomHelpBuilder customHelpBuilder = new();
+
+            CliRootCommand root = new ();
+            root.Options.Clear();
+            root.Options.Add(new HelpOption()
+            {
+                Action = new HelpAction()
+                {
+                    Builder = customHelpBuilder
+                }
+            });
+
+            CliConfiguration config = new(root)
+            {
+                EnableParseErrorReporting = true
+            };
+
+            customHelpBuilder.WasUsed.Should().BeFalse();
+
+            ParseResult parseResult = root.Parse("-bla", config);
+
+            int result = parseResult.Invoke();
+            result.Should().Be(1);
+            customHelpBuilder.WasUsed.Should().BeTrue();
+        }
+
+        private sealed class CustomHelpBuilder : HelpBuilder
+        {
+            internal bool WasUsed = false;
+
+            public override void Write(HelpContext context)
+            {
+                WasUsed = true;
+
+                base.Write(context);
+            }
+        }
     }
 }

--- a/src/System.CommandLine/Invocation/ParseErrorAction.cs
+++ b/src/System.CommandLine/Invocation/ParseErrorAction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Help;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,7 +24,9 @@ namespace System.CommandLine.Invocation
 
             ConsoleHelpers.ResetTerminalForegroundColor();
 
-            new HelpOption().Action!.Invoke(parseResult);
+            HelpOption helpOption = parseResult.RootCommandResult.Command.Options.FirstOrDefault(option => option is HelpOption) as HelpOption ?? new HelpOption();
+
+            helpOption.Action!.Invoke(parseResult);
 
             return 1;
         }


### PR DESCRIPTION
It may be the last bug for https://github.com/dotnet/sdk/pull/29131 (at leas I hope so)