### PR TITLE
Fix #2210

### DIFF
--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -8,6 +8,7 @@ using System.CommandLine.Utility;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using Xunit;
 
 namespace System.CommandLine.Tests.Binding
@@ -193,6 +194,30 @@ namespace System.CommandLine.Tests.Binding
                 .GetValue(option)
                 .Should()
                 .BeTrue();
+        }
+
+        [Fact] // https://github.com/dotnet/command-line-api/issues/2210
+        public void Nullable_bool_with_unparseable_argument_does_not_throw()
+        {
+            CliRootCommand rootCommand = new();
+            CliOption<bool?> option = new("--test");
+            rootCommand.Options.Add(option);
+            var result = rootCommand.Parse("--test ouch");
+
+            result.Invoking(r =>  r.GetValue(option))
+                  .Should().NotThrow();
+        }
+
+        [Fact] // https://github.com/dotnet/command-line-api/issues/2210
+        public void Bool_with_unparseable_argument_does_not_throw()
+        {
+            CliRootCommand rootCommand = new();
+            CliOption<bool> option = new("--test");
+            rootCommand.Options.Add(option);
+            var result = rootCommand.Parse("--test ouch");
+
+            result.Invoking(r => r.GetValue(option))
+                  .Should().NotThrow();
         }
 
         [Theory]

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -135,6 +135,7 @@ namespace System.CommandLine
         public T? GetValue<T>(string name)
         {
             var command = CommandResult.Command;
+
             if (_namedResults is null)
             {
                 // A null value means that given name exists, but was not parsed
@@ -180,12 +181,12 @@ namespace System.CommandLine
                 }
             }
 
-            static T? Convert(ArgumentConversionResult validatedResult)
+            static T Convert(ArgumentConversionResult validatedResult)
             {
                 var convertedResult = validatedResult.ConvertIfNeeded(typeof(T));
 
-                if (validatedResult.Result == ArgumentConversionResultType.Successful
-                    && convertedResult.Result == ArgumentConversionResultType.NoArgument)
+                if (validatedResult is { Result: ArgumentConversionResultType.Successful }
+                    && convertedResult is { Result: ArgumentConversionResultType.NoArgument })
                 {
                     // invalid cast has been detected, InvalidCastException will be thrown
                     return (T)validatedResult.Value!;

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -246,9 +246,10 @@ namespace System.CommandLine.Parsing
                         break;
                     }
                 }
-                else if (argument.ValueType == typeof(bool) && 
+                else if ((argument.ValueType == typeof(bool) || argument.ValueType == typeof(bool?))  && 
                          !bool.TryParse(CurrentToken.Value, out _))
                 {
+                    // Don't greedily consume the following token for bool. The presence of the option token (i.e. a flag) is sufficient.
                     break;
                 }
 


### PR DESCRIPTION
This fixes #2210. The issue was that `bool` parsing had a special case in place so that it doesn't consume the following token if that token can't be parsed as a bool. This lets the unparseable token by consumed by a different symbol, which is typically the intent.

The fix includes `bool?` in that special case.