### PR TITLE
Remove redundant SourceBuildTrimNetFrameworkTargets property

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>command-line-api</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
   </PropertyGroup>
 
   <Target Name="ConfigureInnerBuildArg" BeforeTargets="GetSourceBuildCommandConfiguration">


### PR DESCRIPTION
Part of dotnet/source-build#3503