### PR TITLE
Improve help sections layout.

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -184,7 +184,7 @@ System.CommandLine.Help
   public class HelpBuilder
     .ctor(System.Int32 maxWidth = 2147483647)
     public System.Int32 MaxWidth { get; }
-    public System.Void CustomizeLayout(System.Func<HelpContext,System.Collections.Generic.IEnumerable<System.Action<HelpContext>>> getLayout)
+    public System.Void CustomizeLayout(System.Func<HelpContext,System.Collections.Generic.IEnumerable<System.Func<HelpContext,System.Boolean>>> getLayout)
     public System.Void CustomizeSymbol(System.CommandLine.CliSymbol symbol, System.Func<HelpContext,System.String> firstColumnText = null, System.Func<HelpContext,System.String> secondColumnText = null, System.Func<HelpContext,System.String> defaultValue = null)
     public System.Void CustomizeSymbol(System.CommandLine.CliSymbol symbol, System.String firstColumnText = null, System.String secondColumnText = null, System.String defaultValue = null)
     public TwoColumnHelpRow GetTwoColumnRow(System.CommandLine.CliSymbol symbol, HelpContext context)
@@ -192,18 +192,18 @@ System.CommandLine.Help
     public System.Void Write(System.CommandLine.CliCommand command, System.IO.TextWriter writer)
     public System.Void WriteColumns(System.Collections.Generic.IReadOnlyList<TwoColumnHelpRow> items, HelpContext context)
    static class Default
-    public static System.Action<HelpContext> AdditionalArgumentsSection()
-    public static System.Action<HelpContext> CommandArgumentsSection()
-    public static System.Action<HelpContext> CommandUsageSection()
+    public static System.Func<HelpContext,System.Boolean> AdditionalArgumentsSection()
+    public static System.Func<HelpContext,System.Boolean> CommandArgumentsSection()
+    public static System.Func<HelpContext,System.Boolean> CommandUsageSection()
     public static System.String GetArgumentDefaultValue(System.CommandLine.CliArgument argument)
     public static System.String GetArgumentDescription(System.CommandLine.CliArgument argument)
     public static System.String GetArgumentUsageLabel(System.CommandLine.CliArgument argument)
     public static System.String GetCommandUsageLabel(System.CommandLine.CliCommand symbol)
-    public static System.Collections.Generic.IEnumerable<System.Action<HelpContext>> GetLayout()
+    public static System.Collections.Generic.IEnumerable<System.Func<HelpContext,System.Boolean>> GetLayout()
     public static System.String GetOptionUsageLabel(System.CommandLine.CliOption symbol)
-    public static System.Action<HelpContext> OptionsSection()
-    public static System.Action<HelpContext> SubcommandsSection()
-    public static System.Action<HelpContext> SynopsisSection()
+    public static System.Func<HelpContext,System.Boolean> OptionsSection()
+    public static System.Func<HelpContext,System.Boolean> SubcommandsSection()
+    public static System.Func<HelpContext,System.Boolean> SynopsisSection()
   public class HelpContext
     .ctor(HelpBuilder helpBuilder, System.CommandLine.CliCommand command, System.IO.TextWriter output, System.CommandLine.ParseResult parseResult = null)
     public System.CommandLine.CliCommand Command { get; }

--- a/src/System.CommandLine.Tests/Help/Approvals/HelpBuilderTests.Help_layout_has_not_changed.approved.txt
+++ b/src/System.CommandLine.Tests/Help/Approvals/HelpBuilderTests.Help_layout_has_not_changed.approved.txt
@@ -22,5 +22,3 @@ Options:
                                                                                              multi-line
                                                                                              description
 
-
-

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -123,7 +123,7 @@ public partial class HelpBuilder
         /// <summary>
         /// Gets the default sections to be written for command line help.
         /// </summary>
-        public static IEnumerable<Action<HelpContext>> GetLayout()
+        public static IEnumerable<Func<HelpContext, bool>> GetLayout()
         {
             yield return SynopsisSection();
             yield return CommandUsageSection();
@@ -136,49 +136,51 @@ public partial class HelpBuilder
         /// <summary>
         /// Writes a help section describing a command's synopsis.
         /// </summary>
-        public static Action<HelpContext> SynopsisSection() =>
+        public static Func<HelpContext, bool> SynopsisSection() =>
             ctx =>
             {
                 ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpDescriptionTitle(), ctx.Command.Description, ctx.Output);
+                return true;
             };
 
         /// <summary>
         /// Writes a help section describing a command's usage.
         /// </summary>
-        public static Action<HelpContext> CommandUsageSection() =>
+        public static Func<HelpContext, bool> CommandUsageSection() =>
             ctx =>
             {
                 ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpUsageTitle(), ctx.HelpBuilder.GetUsage(ctx.Command), ctx.Output);
+                return true;
             };
 
         ///  <summary>
         /// Writes a help section describing a command's arguments.
         ///  </summary>
-        public static Action<HelpContext> CommandArgumentsSection() =>
+        public static Func<HelpContext, bool> CommandArgumentsSection() =>
             ctx =>
             {
                 TwoColumnHelpRow[] commandArguments = ctx.HelpBuilder.GetCommandArgumentRows(ctx.Command, ctx).ToArray();
 
-                if (commandArguments.Length <= 0)
+                if (commandArguments.Length > 0)
                 {
-                    ctx.WasSectionSkipped = true;
-                    return;
+                    ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpArgumentsTitle(), null, ctx.Output);
+                    ctx.HelpBuilder.WriteColumns(commandArguments, ctx);
+                    return true;
                 }
 
-                ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpArgumentsTitle(), null, ctx.Output);
-                ctx.HelpBuilder.WriteColumns(commandArguments, ctx);
+                return false;
             };
 
         ///  <summary>
         /// Writes a help section describing a command's subcommands.
         ///  </summary>
-        public static Action<HelpContext> SubcommandsSection() =>
+        public static Func<HelpContext, bool> SubcommandsSection() =>
             ctx => ctx.HelpBuilder.WriteSubcommands(ctx);
 
         ///  <summary>
         /// Writes a help section describing a command's options.
         ///  </summary>
-        public static Action<HelpContext> OptionsSection() =>
+        public static Func<HelpContext, bool> OptionsSection() =>
             ctx =>
             {
                 List<TwoColumnHelpRow> optionRows = new();
@@ -230,21 +232,20 @@ public partial class HelpBuilder
                     current = parentCommand;
                 }
 
-                if (optionRows.Count <= 0)
+                if (optionRows.Count > 0)
                 {
-                    ctx.WasSectionSkipped = true;
-                    return;
+                    ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpOptionsTitle(), null, ctx.Output);
+                    ctx.HelpBuilder.WriteColumns(optionRows, ctx);
+                    return true;
                 }
 
-                ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpOptionsTitle(), null, ctx.Output);
-                ctx.HelpBuilder.WriteColumns(optionRows, ctx);
-                ctx.Output.WriteLine();
+                return false;
             };
 
         ///  <summary>
         /// Writes a help section describing a command's additional arguments, typically shown only when <see cref="CliCommand.TreatUnmatchedTokensAsErrors"/> is set to <see langword="true"/>.
         ///  </summary>
-        public static Action<HelpContext> AdditionalArgumentsSection() =>
+        public static Func<HelpContext, bool> AdditionalArgumentsSection() =>
             ctx => ctx.HelpBuilder.WriteAdditionalArguments(ctx);
     }
 }

--- a/src/System.CommandLine/Help/HelpContext.cs
+++ b/src/System.CommandLine/Help/HelpContext.cs
@@ -45,7 +45,5 @@ namespace System.CommandLine.Help
         /// A text writer to write output to.
         /// </summary>
         public TextWriter Output { get; }
-
-        internal bool WasSectionSkipped { get; set; }
     }
 }


### PR DESCRIPTION
Fix issue #2236
- get rid of the `HelpContext.WasSectionSkipped` mutable property.
- normalize space between sections.
- adapt unit tests and approvals.