### PR TITLE
Remove src/Directory.Build.(props/targets) from solution since they do not exist.

### DIFF
--- a/System.CommandLine.sln
+++ b/System.CommandLine.sln
@@ -23,10 +23,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E5B1EC71-0FC4-4FAA-9C65-32D5016FBC45}"
-	ProjectSection(SolutionItems) = preProject
-		src\Directory.Build.props = src\Directory.Build.props
-		src\Directory.Build.targets = src\Directory.Build.targets
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.CommandLine", "src\System.CommandLine\System.CommandLine.csproj", "{0BE8E56E-7580-4526-BE24-D304E1779724}"
 EndProject


### PR DESCRIPTION
(Note that the Directory.Build.(props/targets) at the root of the repository are still included under "Solution Items".)