### PR TITLE
[PoC] Getting parsed values with all SCL goodness but without plenty of code

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1622,4 +1622,20 @@ namespace System.CommandLine.Tests
             GetValue(result, option).Should().BeEmpty();
         }
     }
+
+    public class ProofOfConceptTests
+    {
+        [Fact]
+        public void CanDefineSymbolsJustOnceToGetParsedValues()
+        {
+            (string target, int? count, bool resolve) = ProofOfConcept.Parse("-n 10 -a microsoft.com",
+                new CliArgument<string>("target_name"),
+                new CliOption<int?>("-n") { Description = "Number of echo requests to send" },
+                new CliOption<bool>("-a") { Description = "Resolve addresses to hostnames." });
+
+            Assert.Equal(10, count.Value);
+            Assert.True(resolve);
+            Assert.Equal("microsoft.com", target);
+        }
+    }
 }

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -9,7 +9,7 @@ using System.IO;
 namespace System.CommandLine
 {
     /// <inheritdoc cref="CliArgument" />
-    public class CliArgument<T> : CliArgument
+    public class CliArgument<T> : CliArgument, ICliSymbol<T>
     {
         private Func<ArgumentResult, T?>? _customParser;
 

--- a/src/System.CommandLine/CliOption{T}.cs
+++ b/src/System.CommandLine/CliOption{T}.cs
@@ -7,7 +7,7 @@ namespace System.CommandLine
 {
     /// <inheritdoc cref="CliOption" />
     /// <typeparam name="T">The <see cref="System.Type"/> that the option's arguments are expected to be parsed as.</typeparam>
-    public class CliOption<T> : CliOption
+    public class CliOption<T> : CliOption, ICliSymbol<T>
     {
         internal readonly CliArgument<T> _argument;
 

--- a/src/System.CommandLine/ICliSymbol.cs
+++ b/src/System.CommandLine/ICliSymbol.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine
+{
+    public interface ICliSymbol<T>
+    {
+
+    }
+}

--- a/src/System.CommandLine/Parsing/ProofOfConcept.cs
+++ b/src/System.CommandLine/Parsing/ProofOfConcept.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine.Parsing
+{
+    public static class ProofOfConcept
+    {
+        public static (T1?, T2?) Parse<T1, T2>(string args, ICliSymbol<T1> symbol1, ICliSymbol<T2> symbol2)
+        {
+            CliRootCommand command = new();
+
+            Add(symbol1, command);
+            Add(symbol2, command);
+
+            ParseResult parseResult = command.Parse(args);
+
+            return (GetValue(parseResult, symbol1), GetValue(parseResult, symbol2));
+        }
+
+        public static (T1?, T2?, T3?) Parse<T1, T2, T3>(string args, ICliSymbol<T1> symbol1, ICliSymbol<T2> symbol2, ICliSymbol<T3> symbol3)
+        {
+            CliRootCommand command = new();
+
+            Add(symbol1, command);
+            Add(symbol2, command);
+            Add(symbol3, command);
+
+            ParseResult parseResult = command.Parse(args);
+
+            return (GetValue(parseResult, symbol1), GetValue(parseResult, symbol2), GetValue(parseResult, symbol3));
+        }
+
+        public static (T1?, T2?, T3?, T4?) Parse<T1, T2, T3, T4>(string args, ICliSymbol<T1> symbol1, ICliSymbol<T2> symbol2, ICliSymbol<T3> symbol3, ICliSymbol<T4> symbol4)
+        {
+            CliRootCommand command = new();
+
+            Add(symbol1, command);
+            Add(symbol2, command);
+            Add(symbol3, command);
+            Add(symbol4, command);
+
+            ParseResult parseResult = command.Parse(args);
+
+            return (GetValue(parseResult, symbol1), GetValue(parseResult, symbol2), GetValue(parseResult, symbol3), GetValue(parseResult, symbol4));
+        }
+
+        public static (T1?, T2?, T3?, T4?, T5?) Parse<T1, T2, T3, T4, T5>(string args, ICliSymbol<T1> symbol1, ICliSymbol<T2> symbol2, ICliSymbol<T3> symbol3, ICliSymbol<T4> symbol4, ICliSymbol<T5> symbol5)
+        {
+            CliRootCommand command = new();
+
+            Add(symbol1, command);
+            Add(symbol2, command);
+            Add(symbol3, command);
+            Add(symbol4, command);
+            Add(symbol5, command);
+
+            ParseResult parseResult = command.Parse(args);
+
+            return (GetValue(parseResult, symbol1), GetValue(parseResult, symbol2), GetValue(parseResult, symbol3), GetValue(parseResult, symbol4), GetValue(parseResult, symbol5));
+        }
+
+        private static void Add<T>(ICliSymbol<T> symbol, CliCommand command)
+        {
+            if (symbol is CliOption<T> option)
+            {
+                command.Options.Add(option);
+            }
+            else if (symbol is CliArgument<T> argument)
+            {
+                command.Arguments.Add(argument);
+            }
+        }
+
+        private static T? GetValue<T>(ParseResult parseResult, ICliSymbol<T> symbol)
+        {
+            if (symbol is CliOption<T> option)
+            {
+                return parseResult.GetValue<T>(option);
+            }
+            else if (symbol is CliArgument<T> argument)
+            {
+                return parseResult.GetValue<T>(argument);
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
@jeffhandley based on our recent discussion I wanted to share a proof of concept of an API that allows for just getting the parsed values without the usual ceremony. My point is not to get it merged, just to share my idea and include it in the next discussion.

```cs
(string target, int? count, bool resolve) = ProofOfConcept.Parse("-n 10 -a microsoft.com",
    new CliArgument<string>("target_name"),
    new CliOption<int?>("-n") { Description = "Number of echo requests to send" },
    new CliOption<bool>("-a") { Description = "Resolve addresses to hostnames." });
```

The idea is simple:

- we introduce a new generic interface that both `CliOption<T>` and `CliArgument<T>` implement
- we provide a set of helper methods that return a value tuple `(T1, T2, ... TN-1, TN)` and accept `T1-N`-many implementations of the new interface
- each helper method creates a `CliRootCommand`, adds all the symbols, calls `Parse(args)` and calls `parseResult.GetValue<T>(symbol)` for each value



