### PR TITLE
Improve default exception handler to support aggregated canceling.

### DIFF
--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -126,6 +126,10 @@ namespace System.CommandLine.Invocation
 
         private static int DefaultExceptionHandler(Exception exception, CliConfiguration config)
         {
+            if (exception is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
+            {
+                exception = aggregateException.InnerExceptions[0];
+            }
             if (exception is not OperationCanceledException)
             {
                 ConsoleHelpers.ResetTerminalForegroundColor();


### PR DESCRIPTION
Take in account the case when an `OperationCanceledException` is wrapped into an `AggregateException`. 