### PR TITLE
Adds an optional case sensitive property to most tokens, defaulting to true

### DIFF
--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -90,6 +90,13 @@ namespace System.CommandLine.Tests
 
             option.Aliases.Contains("O").Should().BeFalse();
         }
+        [Fact]
+        public void Option_aliases_are_case_insensitive_while_option_is_case_insensitive()
+        {
+            var option = new CliOption<string>("name", caseSensitive: false, "o");
+
+            option.Aliases.Contains("O").Should().BeTrue();
+        }
 
         [Fact]
         public void Aliases_contains_prefixed_short_value()

--- a/src/System.CommandLine/AliasSet.cs
+++ b/src/System.CommandLine/AliasSet.cs
@@ -8,16 +8,16 @@ namespace System.CommandLine
     {
         private readonly HashSet<string> _aliases;
 
-        internal AliasSet() => _aliases = new(StringComparer.Ordinal);
+        internal AliasSet(bool caseSensitive) => _aliases = new(caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
 
-        internal AliasSet(string[] aliases)
+        internal AliasSet(string[] aliases, bool caseSensitive)
         {
             foreach (string alias in aliases)
             {
                 CliSymbol.ThrowIfEmptyOrWithWhitespaces(alias, nameof(alias));
             }
 
-            _aliases = new(aliases, StringComparer.Ordinal);
+            _aliases = new(aliases, caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
         }
 
         public int Count => _aliases.Count;
@@ -28,6 +28,7 @@ namespace System.CommandLine
             => _aliases.Add(CliSymbol.ThrowIfEmptyOrWithWhitespaces(item, nameof(item)));
 
         internal bool Overlaps(AliasSet other) => _aliases.Overlaps(other._aliases);
+
 
         // a struct based enumerator for avoiding allocations
         public HashSet<string>.Enumerator GetEnumerator() => _aliases.GetEnumerator();

--- a/src/System.CommandLine/CliArgument.cs
+++ b/src/System.CommandLine/CliArgument.cs
@@ -19,7 +19,7 @@ namespace System.CommandLine
         private List<Func<CompletionContext, IEnumerable<CompletionItem>>>? _completionSources = null;
         private List<Action<ArgumentResult>>? _validators = null;
 
-        private protected CliArgument(string name) : base(name, allowWhitespace: true)
+        private protected CliArgument(string name, bool caseSensitive = true) : base(name, allowWhitespace: true, caseSensitive: caseSensitive)
         {
         }
 

--- a/src/System.CommandLine/CliCommand.cs
+++ b/src/System.CommandLine/CliCommand.cs
@@ -35,7 +35,8 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="name">The name of the command.</param>
         /// <param name="description">The description of the command, shown in help.</param>
-        public CliCommand(string name, string? description = null) : base(name)
+        /// <param name="caseSensitive">Whether the command is case sensitive.</param>
+        public CliCommand(string name, string? description = null, bool caseSensitive = true) : base(name, caseSensitive: caseSensitive)
             => Description = description;
 
         /// <summary>
@@ -89,7 +90,7 @@ namespace System.CommandLine
         /// Gets the unique set of strings that can be used on the command line to specify the command.
         /// </summary>
         /// <remarks>The collection does not contain the <see cref="CliSymbol.Name"/> of the Command.</remarks>
-        public ICollection<string> Aliases => _aliases ??= new();
+        public ICollection<string> Aliases => _aliases ??= new(CaseSensitive);
 
         /// <summary>
         /// Gets or sets the <see cref="CliAction"/> for the Command. The handler represents the action
@@ -308,6 +309,7 @@ namespace System.CommandLine
         }
 
         internal bool EqualsNameOrAlias(string name)
-            => Name.Equals(name, StringComparison.Ordinal) || (_aliases is not null && _aliases.Contains(name));
+            => Name.Equals(name, CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase)
+            || (_aliases is not null && _aliases.Contains(name, CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase));
     }
 }

--- a/src/System.CommandLine/CliConfiguration.cs
+++ b/src/System.CommandLine/CliConfiguration.cs
@@ -176,12 +176,12 @@ namespace System.CommandLine
                     {
                         CliSymbol symbol2 = GetChild(j, command, out AliasSet? aliases2);
 
-                        if (symbol1.Name.Equals(symbol2.Name, StringComparison.Ordinal)
-                            || (aliases1 is not null && aliases1.Contains(symbol2.Name)))
+                        if (symbol1.Name.Equals(symbol2.Name, symbol1.CaseSensitive && symbol2.CaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase)
+                            || (aliases1 is not null && aliases1.Contains(symbol2.Name, symbol1.CaseSensitive && symbol2.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase)))
                         {
                             throw new CliConfigurationException($"Duplicate alias '{symbol2.Name}' found on command '{command.Name}'.");
                         }
-                        else if (aliases2 is not null && aliases2.Contains(symbol1.Name))
+                        else if (aliases2 is not null && aliases2.Contains(symbol1.Name, symbol1.CaseSensitive && symbol2.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase))
                         {
                             throw new CliConfigurationException($"Duplicate alias '{symbol1.Name}' found on command '{command.Name}'.");
                         }

--- a/src/System.CommandLine/CliDirective.cs
+++ b/src/System.CommandLine/CliDirective.cs
@@ -22,8 +22,9 @@ namespace System.CommandLine
         /// Initializes a new instance of the Directive class.
         /// </summary>
         /// <param name="name">The name of the directive. It can't contain whitespaces.</param>
-        public CliDirective(string name)
-            : base(name)
+        /// <param name="caseSensitive">Whether the directive is case sensitive.</param>
+        public CliDirective(string name, bool caseSensitive = true)
+            : base(name, caseSensitive: caseSensitive)
         {
         }
 

--- a/src/System.CommandLine/CliOption.cs
+++ b/src/System.CommandLine/CliOption.cs
@@ -17,11 +17,11 @@ namespace System.CommandLine
         internal AliasSet? _aliases;
         private List<Action<OptionResult>>? _validators;
 
-        private protected CliOption(string name, string[] aliases) : base(name)
+        private protected CliOption(string name, string[] aliases, bool caseSensitive = true) : base(name, caseSensitive: caseSensitive)
         {
             if (aliases is { Length: > 0 }) 
             {
-                _aliases = new(aliases);
+                _aliases = new(aliases, caseSensitive);
             }
         }
 
@@ -102,7 +102,7 @@ namespace System.CommandLine
         /// Gets the unique set of strings that can be used on the command line to specify the Option.
         /// </summary>
         /// <remarks>The collection does not contain the <see cref="CliSymbol.Name"/> of the Option.</remarks>
-        public ICollection<string> Aliases => _aliases ??= new();
+        public ICollection<string> Aliases => _aliases ??= new(CaseSensitive);
 
         /// <summary>
         /// Gets or sets the <see cref="CliAction"/> for the Option. The handler represents the action

--- a/src/System.CommandLine/CliOption{T}.cs
+++ b/src/System.CommandLine/CliOption{T}.cs
@@ -20,9 +20,19 @@ namespace System.CommandLine
             : this(name, aliases, new CliArgument<T>(name))
         {
         }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CliOption"/> class.
+        /// </summary>
+        /// <param name="name">The name of the option. It's used for parsing, displaying Help and creating parse errors.</param>>
+        /// <param name="caseSensitive">Whether the option is case sensitive.</param>
+        /// <param name="aliases">Optional aliases. Used for parsing, suggestions and displayed in Help.</param>
+        public CliOption(string name, bool caseSensitive, params string[] aliases)
+            : this(name, aliases, new CliArgument<T>(name), caseSensitive)
+        {
+        }
 
-        private protected CliOption(string name, string[] aliases, CliArgument<T> argument)
-            : base(name, aliases)
+        private protected CliOption(string name, string[] aliases, CliArgument<T> argument, bool caseSensitive = true)
+            : base(name, aliases, caseSensitive)
         {
             argument.AddParent(this);
             _argument = argument;

--- a/src/System.CommandLine/CliRootCommand.cs
+++ b/src/System.CommandLine/CliRootCommand.cs
@@ -25,7 +25,8 @@ namespace System.CommandLine
         private static string? _executableVersion;
 
         /// <param name="description">The description of the command, shown in help.</param>
-        public CliRootCommand(string description = "") : base(ExecutableName, description)
+        /// <param name="caseSensitive">Whether the option is case sensitive.</param>
+        public CliRootCommand(string description = "", bool caseSensitive = true) : base(ExecutableName, description, caseSensitive)
         {
             Options.Add(new HelpOption());
             Options.Add(new VersionOption()); 

--- a/src/System.CommandLine/CliSymbol.cs
+++ b/src/System.CommandLine/CliSymbol.cs
@@ -12,9 +12,10 @@ namespace System.CommandLine
     /// </summary>
     public abstract class CliSymbol
     {
-        private protected CliSymbol(string name, bool allowWhitespace = false)
+        private protected CliSymbol(string name, bool allowWhitespace = false, bool caseSensitive = true)
         {
             Name = ThrowIfEmptyOrWithWhitespaces(name, nameof(name), allowWhitespace);
+            CaseSensitive = caseSensitive;
         }
 
         /// <summary>
@@ -53,6 +54,8 @@ namespace System.CommandLine
         /// Gets or sets a value indicating whether the symbol is hidden.
         /// </summary>
         public bool Hidden { get; set; }
+
+        internal bool CaseSensitive { get; set; } = true;
 
         /// <summary>
         /// Gets the parent symbols.

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -155,10 +155,28 @@ namespace System.CommandLine.Parsing
                         switch (token.Type)
                         {
                             case CliTokenType.Option:
+                                if (token?.Symbol?.CaseSensitive ?? false)
+                                {
+                                    // If the option is case sensitive, we need to make sure that the match was sensitive
+                                    if(!arg.Equals(token.Value, StringComparison.Ordinal))
+                                    {
+                                        // it doesn't match, so we need to keep going
+                                        break;
+                                    }
+                                }
                                 tokenList.Add(Option(arg, (CliOption)token.Symbol!));
                                 break;
 
                             case CliTokenType.Command:
+                                if (token?.Symbol?.CaseSensitive ?? false)
+                                {
+                                    // If the option is case sensitive, we need to make sure that the match was sensitive
+                                    if (!arg.Equals(token.Value, StringComparison.Ordinal))
+                                    {
+                                        // it doesn't match, so we need to keep going
+                                        break;
+                                    }
+                                }
                                 CliCommand cmd = (CliCommand)token.Symbol!;
                                 if (cmd != currentCommand)
                                 {
@@ -412,7 +430,7 @@ namespace System.CommandLine.Parsing
 
         private static Dictionary<string, CliToken> ValidTokens(this CliCommand command)
         {
-            Dictionary<string, CliToken> tokens = new(StringComparer.Ordinal);
+            Dictionary<string, CliToken> tokens = new(command.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
 
             if (command is CliRootCommand { Directives: IList<CliDirective> directives })
             {


### PR DESCRIPTION
This is one way that #133 could be addressed. I am not 100% sure I hit all the test cases as I was adding them, but I hope I did. This PR would add an optional "caseSensitive" boolean to the constructors for most of the CliToken derivatives, defaulting to true. This would allow an application author to define the case sensitivity of their CLI tool at a granular level, which would hopefully support most use cases.

The downside to doing it this way is that it would (effectively) change some of the public API signatures (though most people's code should remain compatible without changes).