### PR TITLE
Fix extra newline on writing error output

### DIFF
--- a/src/System.CommandLine/Invocation/ParseErrorAction.cs
+++ b/src/System.CommandLine/Invocation/ParseErrorAction.cs
@@ -104,7 +104,10 @@ public sealed class ParseErrorAction : SynchronousCliAction
             }
         }
 
-        parseResult.Configuration.Output.WriteLine();
+        if (unmatchedTokens.Count != 0)
+        {
+            parseResult.Configuration.Output.WriteLine();
+        }
 
         static IEnumerable<string> GetPossibleTokens(CliCommand targetSymbol, string token)
         {


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/pull/33126

## Summary
`ParseErrorAction` has `ShowTypoCorrections` enabled by default. The processing for typo corrections involves looking through unmatched tokens and writing suggestions to the `Output` stream. However, if there are no unmatched tokens (and therefore, no suggestions to be made) this processing was adding a random extra newline to the output stream. This change in behavior is causing a test to fail in the SDK since that test expects no output in the Output stream on failure for that certain test scenario. I've added a condition to only output the extra newline if any unmatched tokens are present.