### PR TITLE
Remove unnecessary Microsoft.CSharp pkg references

### DIFF
--- a/src/System.CommandLine.NamingConventionBinder.Tests/System.CommandLine.NamingConventionBinder.Tests.csproj
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/System.CommandLine.NamingConventionBinder.Tests.csproj
@@ -27,7 +27,6 @@
   
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="5.4.7" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -42,7 +42,6 @@
   
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="5.4.7" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />


### PR DESCRIPTION
Microsoft.CSharp is provided inbox on both .NET Framework and modern .NET. It's only required when targeting .NET Standard.