### PR TITLE
Remove DotNet-Blob-Feed variable from .vsts-ci.yml

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -48,17 +48,12 @@ stages:
         variables:
         # Only enable publishing in official builds.
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
           # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-          - group: DotNet-Blob-Feed
           - group: DotNet-Symbol-Server-Pats
           - group: Publish-Build-Assets
           - name: _OfficialBuildArgs
             value: /p:DotNetSignType=$(_SignType)
                   /p:TeamName=$(_TeamName)
-                  /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                  /p:DotNetPublishBlobFeedUrl=https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-                  /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
                   /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                   /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                   /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
@@ -77,7 +72,6 @@ stages:
               Debug:
                 _BuildConfig: Debug
                 _SignType: test
-                _DotNetPublishToBlobFeed: false
                 _BuildArgs:
 
             Release:
@@ -85,10 +79,8 @@ stages:
               # PRs or external builds are not signed.
               ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
                 _SignType: test
-                _DotNetPublishToBlobFeed: false
               ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 _SignType: real
-                _DotNetPublishToBlobFeed: true
                 _BuildArgs: $(_OfficialBuildArgs)
         steps:
         - checkout: self
@@ -128,11 +120,9 @@ stages:
               Debug:
                 _BuildConfig: Debug
                 _SignType: none
-                _DotNetPublishToBlobFeed : false
             Release:
               _BuildConfig: Release
               _SignType: none
-              _DotNetPublishToBlobFeed : false
         steps:
         - checkout: self
           clean: true


### PR DESCRIPTION
It is no longer used and being removed from arcade: https://github.com/dotnet/arcade/issues/13963

@jonsequitur 