### PR TITLE
Fix race conditions when building command-line-api

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,4 +13,9 @@
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
+	<Target Name="PublishAfterBuild"
+         AfterTargets="Build"
+         DependsOnTargets="Publish"
+         Condition="'$(PublishAfterBuild)' == 'true'" />
+
 </Project>

--- a/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/EndToEndTestApp.csproj
+++ b/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/EndToEndTestApp.csproj
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(TargetFrameworkForNETSDK)</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
+++ b/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(TargetFrameworkForNETSDK)</TargetFramework>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);EndToEndTestApp\**</DefaultExcludesInProjectFolder>
 
-    <TestAssetsPath>$([System.IO.Path]::GetFullPath('$(OutputPath)'))/TestAssets</TestAssetsPath>
     <Rid Condition="'$(OS)' == 'Windows_NT'">win-x64</Rid>
     <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">osx-x64</Rid>
     <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">linux-x64</Rid>
@@ -23,11 +22,9 @@
     <ProjectReference Include="..\System.CommandLine.Tests\System.CommandLine.Tests.csproj" />
 
     <!-- Sequence into build to make sure that publish assets are available for tests. -->
-    <ProjectReference Include="../System.CommandLine.Suggest/dotnet-suggest.csproj"
-                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath);PublishAfterBuild=true"
-                      ReferenceOutputAssembly="false" />
-    <ProjectReference Include="EndToEndTestApp/EndToEndTestApp.csproj"
-                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath);PublishAfterBuild=true"
+    <ProjectReference Include="EndToEndTestApp/EndToEndTestApp.csproj;
+                               ../System.CommandLine.Suggest/dotnet-suggest.csproj"
+                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(OutputPath)/TestAssets;PublishAfterBuild=true"
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
+++ b/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
@@ -24,10 +24,10 @@
 
     <!-- Sequence into build to make sure that publish assets are available for tests. -->
     <ProjectReference Include="../System.CommandLine.Suggest/dotnet-suggest.csproj"
-                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath)"
+                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath);PublishAfterBuild=true"
                       ReferenceOutputAssembly="false" />
     <ProjectReference Include="EndToEndTestApp/EndToEndTestApp.csproj"
-                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath)"
+                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath);PublishAfterBuild=true"
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
+++ b/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
@@ -18,30 +18,32 @@
     <ProjectReference Include="..\System.CommandLine.Tests\System.CommandLine.Tests.csproj" />
   </ItemGroup>
 
-  <Target Name="DotnetSuggestIntegrationTestAssets" BeforeTargets="Build" Condition="'$(Configuration)' == 'Release'">
+  <Target Name="DotnetSuggestIntegrationTestAssets"
+          BeforeTargets="Build"
+          Condition="'$(Configuration)' == 'Release' and
+                     '$(_SuppressAllTargets)' != 'true'">
     <PropertyGroup>
       <TestAssetsPath>$([System.IO.Path]::GetFullPath('$(OutputPath)'))/TestAssets</TestAssetsPath>
+      <Rid Condition="'$(OS)' == 'Windows_NT'">win-x64</Rid>
+      <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">osx-x64</Rid>
+      <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">linux-x64</Rid>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-      <Rid>win-x64</Rid>
-    </PropertyGroup>
+    <MSBuild Projects="../System.CommandLine.Suggest/dotnet-suggest.csproj"
+             Targets="Restore"
+             AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);ForceRestoreToEvaluateSeparately=1" />
 
-    <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">
-      <Rid>osx-x64</Rid>
-    </PropertyGroup>
+    <MSBuild Projects="../System.CommandLine.Suggest/dotnet-suggest.csproj"
+             Targets="Build;Publish"
+             AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath)" />
 
-    <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">
-      <Rid>linux-x64</Rid>
-    </PropertyGroup>
+    <MSBuild Projects="EndToEndTestApp/EndToEndTestApp.csproj"
+             Targets="Restore"
+             AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);ForceRestoreToEvaluateSeparately=1" />
 
-    <MSBuild BuildInParallel="False" Projects="../System.CommandLine.Suggest/dotnet-suggest.csproj" Targets="Restore" Properties="UseAppHost=true;SelfContained=false;RuntimeIdentifier=$(Rid);ForceRestoreToEvaluateSeparately=1;Configuration=Release" />
-
-    <MSBuild BuildInParallel="False" Projects="../System.CommandLine.Suggest/dotnet-suggest.csproj" Targets="Build;Publish" Properties="UseAppHost=true;SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath);Configuration=Release" />
-    
-    <MSBuild BuildInParallel="False" Projects="EndToEndTestApp/EndToEndTestApp.csproj" Targets="Restore" Properties="UseAppHost=true;SelfContained=false;RuntimeIdentifier=$(Rid);ForceRestoreToEvaluateSeparately=1;Configuration=Release" />
-
-    <MSBuild BuildInParallel="False" Projects="EndToEndTestApp/EndToEndTestApp.csproj" Targets="Build;Publish" Properties="UseAppHost=true;SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath);Configuration=Release" />
+    <MSBuild Projects="EndToEndTestApp/EndToEndTestApp.csproj"
+             Targets="Build;Publish"
+             AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath)" />
   </Target>
 
 </Project>

--- a/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
+++ b/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
@@ -3,6 +3,11 @@
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkForNETSDK)</TargetFramework>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);EndToEndTestApp\**</DefaultExcludesInProjectFolder>
+
+    <TestAssetsPath>$([System.IO.Path]::GetFullPath('$(OutputPath)'))/TestAssets</TestAssetsPath>
+    <Rid Condition="'$(OS)' == 'Windows_NT'">win-x64</Rid>
+    <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">osx-x64</Rid>
+    <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">linux-x64</Rid>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,34 +21,14 @@
   <ItemGroup>
     <ProjectReference Include="..\System.CommandLine.Suggest\dotnet-suggest.csproj" />
     <ProjectReference Include="..\System.CommandLine.Tests\System.CommandLine.Tests.csproj" />
+
+    <!-- Sequence into build to make sure that publish assets are available for tests. -->
+    <ProjectReference Include="../System.CommandLine.Suggest/dotnet-suggest.csproj"
+                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath)"
+                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="EndToEndTestApp/EndToEndTestApp.csproj"
+                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath)"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
-
-  <Target Name="DotnetSuggestIntegrationTestAssets"
-          BeforeTargets="Build"
-          Condition="'$(Configuration)' == 'Release' and
-                     '$(_SuppressAllTargets)' != 'true'">
-    <PropertyGroup>
-      <TestAssetsPath>$([System.IO.Path]::GetFullPath('$(OutputPath)'))/TestAssets</TestAssetsPath>
-      <Rid Condition="'$(OS)' == 'Windows_NT'">win-x64</Rid>
-      <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">osx-x64</Rid>
-      <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">linux-x64</Rid>
-    </PropertyGroup>
-
-    <MSBuild Projects="../System.CommandLine.Suggest/dotnet-suggest.csproj"
-             Targets="Restore"
-             AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);ForceRestoreToEvaluateSeparately=1" />
-
-    <MSBuild Projects="../System.CommandLine.Suggest/dotnet-suggest.csproj"
-             Targets="Build;Publish"
-             AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath)" />
-
-    <MSBuild Projects="EndToEndTestApp/EndToEndTestApp.csproj"
-             Targets="Restore"
-             AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);ForceRestoreToEvaluateSeparately=1" />
-
-    <MSBuild Projects="EndToEndTestApp/EndToEndTestApp.csproj"
-             Targets="Build;Publish"
-             AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(TestAssetsPath)" />
-  </Target>
 
 </Project>

--- a/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
+++ b/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
@@ -3,10 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(TargetFrameworkForNETSDK)</TargetFramework>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);EndToEndTestApp\**</DefaultExcludesInProjectFolder>
-
-    <Rid Condition="'$(OS)' == 'Windows_NT'">win-x64</Rid>
-    <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">osx-x64</Rid>
-    <Rid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">linux-x64</Rid>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +20,7 @@
     <!-- Sequence into build to make sure that publish assets are available for tests. -->
     <ProjectReference Include="EndToEndTestApp/EndToEndTestApp.csproj;
                                ../System.CommandLine.Suggest/dotnet-suggest.csproj"
-                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(Rid);PublishDir=$(OutputPath)/TestAssets;PublishAfterBuild=true"
+                      AdditionalProperties="SelfContained=false;RuntimeIdentifier=$(NETCoreSdkPortableRuntimeIdentifier);PublishDir=$(OutputPath)/TestAssets;PublishAfterBuild=true"
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/src/System.CommandLine.Suggest/dotnet-suggest.csproj
+++ b/src/System.CommandLine.Suggest/dotnet-suggest.csproj
@@ -23,7 +23,7 @@
 
   <!-- Remove the PublishDir global property to avoid System.CommandLine being built twice with different global properties (race condition). -->
   <ItemGroup>
-    <ProjectReference Include="..\System.CommandLine\System.CommandLine.csproj" GlobalPropertiesToRemove="PublishDir" />
+    <ProjectReference Include="..\System.CommandLine\System.CommandLine.csproj" GlobalPropertiesToRemove="PublishDir;PublishAfterBuild" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.CommandLine.Suggest/dotnet-suggest.csproj
+++ b/src/System.CommandLine.Suggest/dotnet-suggest.csproj
@@ -18,12 +18,12 @@
 
   <PropertyGroup>
     <!--No warning for the scripts, it is part of the content, not to execuate-->
-    <NoWarn>$(NoWarn);NU5110;NU5111;</NoWarn>
+    <NoWarn>$(NoWarn);NU5110;NU5111</NoWarn>
   </PropertyGroup>
 
-
+  <!-- Remove the PublishDir global property to avoid System.CommandLine being built twice with different global properties (race condition). -->
   <ItemGroup>
-    <ProjectReference Include="..\System.CommandLine\System.CommandLine.csproj" />
+    <ProjectReference Include="..\System.CommandLine\System.CommandLine.csproj" GlobalPropertiesToRemove="PublishDir" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,12 +40,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
-  <!-- Workaround https://github.com/dotnet/arcade/issues/2233 -->
-  <Target Name="_InitializeAssemblyVersion" BeforeTargets="GetAssemblyVersion">
-    <PropertyGroup>
-      <FileVersion></FileVersion>
-    </PropertyGroup>
-  </Target>
 
 </Project>


### PR DESCRIPTION
Failures observed in https://github.com/dotnet/installer/pull/18762 when building command-line-api inside the VMR.

System.CommandLine was built twice, with different global properties but to the same output path which resulted in binclashes.

Example:
> /vmr/.dotnet/sdk/9.0.100-preview.2.24103.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(284,5): error MSB4018: The "GenerateDepsFile" task failed unexpectedly. [/vmr/src/command-line-api/src/System.CommandLine/System.CommandLine.csproj::TargetFramework=net7.0]
/vmr/.dotnet/sdk/9.0.100-preview.2.24103.2/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(284,5): error MSB4018: System.IO.IOException: The process cannot access the file '/vmr/src/command-line-api/artifacts/bin/System.CommandLine/Release/net7.0/System.CommandLine.deps.json' because it is being used by another process. [/vmr/src/command-line-api/src/System.CommandLine/System.CommandLine.csproj::TargetFramework=net7.0]
