### PR TITLE
Powderhouse subsystems and directives

### DIFF
--- a/src/System.CommandLine.Subsystems.Tests/AlternateSubsystems.cs
+++ b/src/System.CommandLine.Subsystems.Tests/AlternateSubsystems.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Directives;
 using System.CommandLine.Subsystems;
+using System.CommandLine.Subsystems.Annotations;
 
 namespace System.CommandLine.Subsystems.Tests
 {
@@ -64,6 +66,14 @@ namespace System.CommandLine.Subsystems.Tests
                 return base.TearDown(cliExit);
             }
         }
+
+        internal class StringDirectiveSubsystem(IAnnotationProvider? annotationProvider = null)
+            : DirectiveSubsystem("other",SubsystemKind.Other, annotationProvider)
+        { }
+
+        internal class BooleanDirectiveSubsystem(IAnnotationProvider? annotationProvider = null)
+            : DirectiveSubsystem("diagram", SubsystemKind.Other,  annotationProvider)
+        { }
 
     }
 }

--- a/src/System.CommandLine.Subsystems.Tests/AlternateSubsystems.cs
+++ b/src/System.CommandLine.Subsystems.Tests/AlternateSubsystems.cs
@@ -45,11 +45,11 @@ namespace System.CommandLine.Subsystems.Tests
             internal bool ExecutionWasRun;
             internal bool TeardownWasRun;
 
-            protected override CliConfiguration Initialize(CliConfiguration configuration)
+            protected override CliConfiguration Initialize(InitializationContext context)
             {
                 // marker hack needed because ConsoleHack not available in initialization
                 InitializationWasRun = true;
-                return base.Initialize(configuration);
+                return base.Initialize(context);
             }
 
             protected override CliExit Execute(PipelineContext pipelineContext)

--- a/src/System.CommandLine.Subsystems.Tests/DiagramSubsystemTests.cs
+++ b/src/System.CommandLine.Subsystems.Tests/DiagramSubsystemTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using System.CommandLine.Directives;
+using System.CommandLine.Parsing;
+using Xunit;
+
+namespace System.CommandLine.Subsystems.Tests;
+
+public class DiagramSubsystemTests
+{
+
+    [Theory]
+    [ClassData(typeof(TestData.Diagram))]
+    public void Diagram_is_activated_only_when_requested(string input, bool expectedIsActive)
+    {
+        CliRootCommand rootCommand = [new CliCommand("x")];
+        var configuration = new CliConfiguration(rootCommand);
+        var subsystem = new DiagramSubsystem();
+        var args = CliParser.SplitCommandLine(input).ToList().AsReadOnly();
+
+        Subsystem.Initialize(subsystem, configuration, args);
+        var parseResult = CliParser.Parse(rootCommand, input, configuration);
+        var isActive = Subsystem.GetIsActivated(subsystem, parseResult);
+
+        isActive.Should().Be(expectedIsActive);
+    }
+
+    [Theory]
+    [ClassData(typeof(TestData.Diagram))]
+    public void String_directive_supplies_string_or_default_and_is_activated_only_when_requested(string input, bool expectedIsActive)
+    {
+        CliRootCommand rootCommand = [new CliCommand("x")];
+        var configuration = new CliConfiguration(rootCommand);
+        var subsystem = new DiagramSubsystem();
+        var args = CliParser.SplitCommandLine(input).ToList().AsReadOnly();
+
+        Subsystem.Initialize(subsystem, configuration, args);
+        var parseResult = CliParser.Parse(rootCommand, input, configuration);
+        var isActive = Subsystem.GetIsActivated(subsystem, parseResult);
+
+        isActive.Should().Be(expectedIsActive);
+    }
+}

--- a/src/System.CommandLine.Subsystems.Tests/DirectiveSubsystemTests.cs
+++ b/src/System.CommandLine.Subsystems.Tests/DirectiveSubsystemTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using System.CommandLine.Directives;
+using System.CommandLine.Parsing;
+using Xunit;
+
+namespace System.CommandLine.Subsystems.Tests;
+
+public class DirectiveSubsystemTests
+{
+
+    // For Boolean tests see DiagramSubsystemTests
+
+    [Theory]
+    [ClassData(typeof(TestData.Directive))]
+    // TODO: Not sure why these tests are passing
+    public void String_directive_supplies_string_or_default_and_is_activated_only_when_requested(
+        string input, bool expectedBoolIsActive, bool expectedStringIsActive, string? expectedValue)
+    {
+        CliRootCommand rootCommand = [new CliCommand("x")];
+        var configuration = new CliConfiguration(rootCommand);
+        var stringSubsystem = new AlternateSubsystems.StringDirectiveSubsystem();
+        var boolSubsystem = new AlternateSubsystems.BooleanDirectiveSubsystem();
+        var args = CliParser.SplitCommandLine(input).ToList().AsReadOnly();
+
+        Subsystem.Initialize(stringSubsystem, configuration, args);
+        Subsystem.Initialize(boolSubsystem, configuration, args);
+
+        var parseResult = CliParser.Parse(rootCommand, input, configuration);
+        var stringIsActive = Subsystem.GetIsActivated(stringSubsystem, parseResult);
+        var boolIsActive = Subsystem.GetIsActivated(boolSubsystem, parseResult);
+        var actualValue = stringSubsystem.Value;
+
+        boolIsActive.Should().Be(expectedBoolIsActive);
+        stringIsActive.Should().Be(expectedStringIsActive);
+        actualValue.Should().Be(expectedValue);
+
+    }
+}

--- a/src/System.CommandLine.Subsystems.Tests/ResponseSubsystemTests.cs
+++ b/src/System.CommandLine.Subsystems.Tests/ResponseSubsystemTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using System.CommandLine.Directives;
+using System.CommandLine.Parsing;
+using Xunit;
+
+namespace System.CommandLine.Subsystems.Tests;
+
+public class ResponseSubsystemTests
+{
+
+    [Fact]
+    // TODO: Not sure why these tests are passing
+    public void Simple_response_file_contributes_to_parsing()
+    {
+        var option = new CliOption<string>("--hello");
+        var rootCommand = new CliRootCommand { option };
+        var configuration = new CliConfiguration(rootCommand);
+        var subsystem = new ResponseSubsystem();
+        string[] args = ["@Response_1.rsp"];
+
+        Subsystem.Initialize(subsystem, configuration, args);
+
+        var parseResult = CliParser.Parse(rootCommand, args, configuration);
+        var value = parseResult.GetValue(option);
+
+        value.Should().Be("world");
+    }
+}

--- a/src/System.CommandLine.Subsystems.Tests/Response_1.rsp
+++ b/src/System.CommandLine.Subsystems.Tests/Response_1.rsp
@@ -1,0 +1,1 @@
+﻿--hello world

--- a/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
+++ b/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Content Include="TestApps/**/*.csproj" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestApps/**/*.cs" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Response_1.rsp" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,6 +32,7 @@
     -->
     <Compile Include="AlternateSubsystems.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="ResponseSubsystemTests.cs" />
     <Compile Include="DirectiveSubsystemTests.cs" />
     <Compile Include="DiagramSubsystemTests.cs" />
     <Compile Include="PipelineTests.cs" />

--- a/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
+++ b/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="AlternateSubsystems.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="DirectiveSubsystemTests.cs" />
+    <Compile Include="DiagramSubsystemTests.cs" />
     <Compile Include="PipelineTests.cs" />
     <Compile Include="TestData.cs" />
     <Compile Include="VersionFunctionalTests.cs" />

--- a/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
+++ b/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="AlternateSubsystems.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="PipelineTests.cs" />
+    <Compile Include="TestData.cs" />
     <Compile Include="VersionFunctionalTests.cs" />
     <Compile Include="VersionSubsystemTests.cs" />
   </ItemGroup>

--- a/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
+++ b/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
@@ -31,6 +31,7 @@
     -->
     <Compile Include="AlternateSubsystems.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="DirectiveSubsystemTests.cs" />
     <Compile Include="PipelineTests.cs" />
     <Compile Include="TestData.cs" />
     <Compile Include="VersionFunctionalTests.cs" />

--- a/src/System.CommandLine.Subsystems.Tests/TestData.cs
+++ b/src/System.CommandLine.Subsystems.Tests/TestData.cs
@@ -30,4 +30,29 @@ internal class TestData
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
+
+    internal class Directive : IEnumerable<object[]>
+    {
+        private readonly List<object[]> _data =
+        [
+            ["[diagram]", true, false, null],
+            ["[other:Hello]", false, true, "Hello"],
+            ["[diagram] x", true, false, null],
+            ["[diagram] -o", true, false, null],
+            ["[diagram] -v", true, false, null],
+            ["[diagram] x -v", true, false, null],
+            ["[diagramX]", false, false, null],
+            ["[diagram] [other:Hello]", true, true, "Hello"],
+            ["x", false, false, null],
+            ["-o", false, false, null],
+            ["x -x", false, false, null],
+            [null, false, false, null],
+            ["", false, false, null],
+            //["[diagram] [other Goodbye]", true, true, "Goodbye"],This is a new test that demos new feature, but is also broken
+        ];
+
+        public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
 }

--- a/src/System.CommandLine.Subsystems.Tests/TestData.cs
+++ b/src/System.CommandLine.Subsystems.Tests/TestData.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Reflection;
+
+namespace System.CommandLine.Subsystems.Tests;
+
+internal class TestData
+{
+    internal static readonly string? AssemblyVersionString = (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly())
+                                     ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                                     ?.InformationalVersion;
+
+    internal class Version : IEnumerable<object[]>
+    {
+        // This data only works if the CLI has a --version with a -v alias and also has a -x option
+        private readonly List<object[]> _data =
+        [
+            ["--version", true],
+            ["-v", true],
+            ["-vx", true],
+            ["-xv", true],
+            ["-x", false],
+            [null, false],
+            ["", false],
+        ];
+
+        public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/System.CommandLine.Subsystems.Tests/TestData.cs
+++ b/src/System.CommandLine.Subsystems.Tests/TestData.cs
@@ -31,6 +31,30 @@ internal class TestData
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
+    internal class Diagram : IEnumerable<object[]>
+    {
+        // The tests define an x command, but -o and -v are just random values
+        private readonly List<object[]> _data =
+        [
+            ["[diagram]", true],
+            ["[diagram] x", true],
+            ["[diagram] -o", true],
+            ["[diagram] -v", true],
+            ["[diagram] x -v", true],
+            ["[diagramX]", false],
+            ["[diagram] [other]", true],
+            ["x", false],
+            ["-o", false],
+            ["x -x", false],
+            [null, false],
+            ["", false]
+        ];
+
+        public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
     internal class Directive : IEnumerable<object[]>
     {
         private readonly List<object[]> _data =

--- a/src/System.CommandLine.Subsystems.Tests/VersionSubsystemTests.cs
+++ b/src/System.CommandLine.Subsystems.Tests/VersionSubsystemTests.cs
@@ -1,23 +1,21 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Reflection;
 using FluentAssertions;
 using Xunit;
 using System.CommandLine.Parsing;
 
 namespace System.CommandLine.Subsystems.Tests
 {
-
     public class VersionSubsystemTests
     {
         [Fact]
         public void When_version_subsystem_is_used_the_version_option_is_added_to_the_root()
         {
             var rootCommand = new CliRootCommand
-                             {
-                                 new CliOption<bool>("-x")
-                             };
+            {
+                new CliOption<bool>("-x") // add option that is expected for the test data used here
+            };
             var configuration = new CliConfiguration(rootCommand);
             var pipeline = new Pipeline
             {
@@ -32,20 +30,18 @@ namespace System.CommandLine.Subsystems.Tests
                 .Count(x => x.Name == "--version")
                 .Should()
                 .Be(1);
-
         }
 
         [Theory]
-        [InlineData("--version", true)]
-        [InlineData("-v", true)]
-        [InlineData("-x", false)]
-        [InlineData("", false)]
+        [ClassData(typeof(TestData.Version))]
         public void Version_is_activated_only_when_requested(string input, bool result)
         {
-            CliRootCommand rootCommand = new();
+            CliRootCommand rootCommand = [new CliOption<bool>("-x")]; // add random option as empty CLIs are rare
             var configuration = new CliConfiguration(rootCommand);
             var versionSubsystem = new VersionSubsystem();
-            Subsystem.Initialize(versionSubsystem, configuration);
+            var args = CliParser.SplitCommandLine(input).ToList().AsReadOnly();
+
+            Subsystem.Initialize(versionSubsystem, configuration, args);
 
             var parseResult = CliParser.Parse(rootCommand, input, configuration);
             var isActive = Subsystem.GetIsActivated(versionSubsystem, parseResult);

--- a/src/System.CommandLine.Subsystems/CompletionSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/CompletionSubsystem.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine;
 public class CompletionSubsystem : CliSubsystem
 {
     public CompletionSubsystem(IAnnotationProvider? annotationProvider = null)
-        : base(CompletionAnnotations.Prefix, annotationProvider, SubsystemKind.Completion)
+        : base(CompletionAnnotations.Prefix, SubsystemKind.Completion, annotationProvider)
     { }
 
     // TODO: Figure out trigger for completions

--- a/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Subsystems;
+using System.Text;
+using System.CommandLine.Parsing;
+
+namespace System.CommandLine.Directives;
+
+public class DiagramSubsystem( IAnnotationProvider? annotationProvider = null)
+    : DirectiveSubsystem("diagram", SubsystemKind.Diagram, annotationProvider)
+{
+    //protected internal override bool GetIsActivated(ParseResult? parseResult)
+    //   => parseResult is not null && option is not null && parseResult.GetValue(option);
+
+    protected internal override CliExit Execute(PipelineContext pipelineContext)
+    {
+        // Gather locations
+        //var locations = pipelineContext.ParseResult.LocationMap
+        //                   .Concat(Map(pipelineContext.ParseResult.Configuration.PreProcessedLocations));
+
+        pipelineContext.ConsoleHack.WriteLine("Output diagram");
+        return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);
+    }
+
+
+    // TODO: Capture logic in previous diagramming, shown below
+    /// <summary>
+    /// Formats a string explaining a parse result.
+    /// </summary>
+    /// <param name="parseResult">The parse result to be diagrammed.</param>
+    /// <returns>A string containing a diagram of the parse result.</returns>
+    internal static StringBuilder Diagram(ParseResult parseResult)
+    {
+        var builder = new StringBuilder(100);
+
+
+        Diagram(builder, parseResult.RootCommandResult, parseResult);
+
+        // TODO: Unmatched tokens
+        /*
+        var unmatchedTokens = parseResult.UnmatchedTokens;
+        if (unmatchedTokens.Count > 0)
+        {
+            builder.Append("   ???-->");
+
+            for (var i = 0; i < unmatchedTokens.Count; i++)
+            {
+                var error = unmatchedTokens[i];
+                builder.Append(' ');
+                builder.Append(error);
+            }
+        }
+        */
+
+        return builder;
+    }
+
+    private static void Diagram(
+        StringBuilder builder,
+        SymbolResult symbolResult,
+        ParseResult parseResult)
+    {
+        if (parseResult.Errors.Any(e => e.SymbolResult == symbolResult))
+        {
+            builder.Append('!');
+        }
+
+/*
+        switch (symbolResult)
+        {
+            // TODO: Directives
+            case DirectiveResult { Directive: not DiagramDirective }:
+                break;
+
+            // TODO: This logic is deeply tied to internal types/properties. These aren't things we probably want to expose like SymbolNode. See #2349 for alternatives
+            case ArgumentResult argumentResult:
+                {
+                    var includeArgumentName =
+                        argumentResult.Argument.FirstParent!.Symbol is CliCommand { HasArguments: true, Arguments.Count: > 1 };
+
+                    if (includeArgumentName)
+                    {
+                        builder.Append("[ ");
+                        builder.Append(argumentResult.Argument.Name);
+                        builder.Append(' ');
+                    }
+
+                    if (argumentResult.Argument.Arity.MaximumNumberOfValues > 0)
+                    {
+                        ArgumentConversionResult conversionResult = argumentResult.GetArgumentConversionResult();
+                        switch (conversionResult.Result)
+                        {
+                            case ArgumentConversionResultType.NoArgument:
+                                break;
+                            case ArgumentConversionResultType.Successful:
+                                switch (conversionResult.Value)
+                                {
+                                    case string s:
+                                        builder.Append($"<{s}>");
+                                        break;
+
+                                    case IEnumerable items:
+                                        builder.Append('<');
+                                        builder.Append(
+                                            string.Join("> <",
+                                                        items.Cast<object>().ToArray()));
+                                        builder.Append('>');
+                                        break;
+
+                                    default:
+                                        builder.Append('<');
+                                        builder.Append(conversionResult.Value);
+                                        builder.Append('>');
+                                        break;
+                                }
+
+                                break;
+
+                            default: // failures
+                                builder.Append('<');
+                                builder.Append(string.Join("> <", symbolResult.Tokens.Select(t => t.Value)));
+                                builder.Append('>');
+
+                                break;
+                        }
+                    }
+
+                    if (includeArgumentName)
+                    {
+                        builder.Append(" ]");
+                    }
+
+                    break;
+                }
+
+            default:
+                {
+                    OptionResult? optionResult = symbolResult as OptionResult;
+
+                    if (optionResult is { Implicit: true })
+                    {
+                        builder.Append('*');
+                    }
+
+                    builder.Append("[ ");
+
+                    if (optionResult is not null)
+                    {
+                        builder.Append(optionResult.IdentifierToken?.Value ?? optionResult.Option.Name);
+                    }
+                    else
+                    {
+                        builder.Append(((CommandResult)symbolResult).IdentifierToken.Value);
+                    }
+
+                    foreach (SymbolResult child in symbolResult.SymbolResultTree.GetChildren(symbolResult))
+                    {
+                        if (child is ArgumentResult arg &&
+                            (arg.Argument.ValueType == typeof(bool) ||
+                             arg.Argument.Arity.MaximumNumberOfValues == 0))
+                        {
+                            continue;
+                        }
+
+                        builder.Append(' ');
+
+                        Diagram(builder, child, parseResult);
+                    }
+
+                    builder.Append(" ]");
+                    break;
+                }
+            }
+        }
+*/
+    }
+}

--- a/src/System.CommandLine.Subsystems/Directives/DirectiveSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Directives/DirectiveSubsystem.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Parsing;
+using System.CommandLine.Subsystems;
+
+namespace System.CommandLine.Directives;
+
+public abstract class DirectiveSubsystem : CliSubsystem
+{
+    public string? Value { get; private set; }
+    public bool Found { get; private set; }
+    public string Id { get; }
+    public Location? Location { get; private set; }
+
+    public DirectiveSubsystem(string name, SubsystemKind kind, IAnnotationProvider? annotationProvider = null, string? id = null)
+        : base(name, kind, annotationProvider: annotationProvider)
+    {
+        Id = id ?? name;
+    }
+
+    protected internal override CliConfiguration Initialize(InitializationContext context)
+    {
+        for (int i = 0; i < context.Args.Count; i++)
+        {
+            var arg = context.Args[i];
+            if (arg[0] == '[') // It looks like a directive, see if it is the one we want
+            {
+                var start = arg.IndexOf($"[{Id}");
+                // Protect against matching substrings, such as "diagramX" matching "diagram" - but longer string may be valid for a different directive and we may still find the one we want
+                if (start >= 0)
+                {
+                    var end = arg.IndexOf("]", start) + 1;
+                    var nextChar = arg[start + Id.Length + 1];
+                    if (nextChar is ']' or ':')
+                    {
+                        Found = true;
+                        if (nextChar == ':')
+                        {
+                            Value = arg[(start + Id.Length + 2)..(end - 1)];
+                        }
+                        Location = new Location(arg.Substring(start, end - start), Location.User, i, null, start);
+                        context.Configuration.AddPreprocessedLocation(Location);
+                        break;
+                    }
+                }
+            }
+            else if (i > 0) // First position might be ExeName, but directives are not legal after other tokens appear
+            {
+                break;
+            }
+        }
+
+        return context.Configuration;
+    }
+
+    protected internal override bool GetIsActivated(ParseResult? parseResult)
+        => Found;
+
+}

--- a/src/System.CommandLine.Subsystems/Directives/ResponseSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Directives/ResponseSubsystem.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.CommandLine.Parsing;
+using System.CommandLine.Subsystems;
+
+namespace System.CommandLine.Directives;
+
+public class ResponseSubsystem()
+    : CliSubsystem("Response", SubsystemKind.Response, null)
+{
+    protected internal override CliConfiguration Initialize(InitializationContext context)
+    {
+        context.Configuration.ResponseFileTokenReplacer = Replacer;
+        return context.Configuration;
+    }
+
+    public static (List<string>? tokens, List<string>? errors) Replacer(string responseSourceName)
+    {
+        try
+        {
+            // TODO: Include checks from previous system.
+            var contents = File.ReadAllText(responseSourceName);
+            return (CliParser.SplitCommandLine(contents).ToList(), null);
+        }
+        catch
+        {
+            // TODO: Switch to proper errors
+            return (null,
+                    errors:
+                    [
+                        $"Failed to open response file {responseSourceName}"
+                    ]);
+        }
+    }
+
+    // TODO: File handling from previous system - ensure these checks are done (note: no tests caught these oversights
+    /* internal static bool TryReadResponseFile(
+         string filePath,
+         out IReadOnlyList<string>? newTokens,
+         out string? error)
+     {
+         try
+         {
+             newTokens = ExpandResponseFile(filePath).ToArray();
+             error = null;
+             return true;
+         }
+         catch (FileNotFoundException)
+         {
+             error = LocalizationResources.ResponseFileNotFound(filePath);
+         }
+         catch (IOException e)
+         {
+             error = LocalizationResources.ErrorReadingResponseFile(filePath, e);
+         }
+
+         newTokens = null;
+         return false;
+
+         static IEnumerable<string> ExpandResponseFile(string filePath)
+         {
+             var lines = File.ReadAllLines(filePath);
+
+             for (var i = 0; i < lines.Length; i++)
+             {
+                 var line = lines[i];
+
+                 foreach (var p in SplitLine(line))
+                 {
+                     if (GetReplaceableTokenValue(p) is { } path)
+                     {
+                         foreach (var q in ExpandResponseFile(path))
+                         {
+                             yield return q;
+                         }
+                     }
+                     else
+                     {
+                         yield return p;
+                     }
+                 }
+             }
+         }
+
+         static IEnumerable<string> SplitLine(string line)
+         {
+             var arg = line.Trim();
+
+             if (arg.Length == 0 || arg[0] == '#')
+             {
+                 yield break;
+             }
+
+             foreach (var word in CliParser.SplitCommandLine(arg))
+             {
+                 yield return word;
+             }
+         }
+     }
+    */
+
+}

--- a/src/System.CommandLine.Subsystems/ErrorReportingSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/ErrorReportingSubsystem.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine;
 public class ErrorReportingSubsystem : CliSubsystem
 {
     public ErrorReportingSubsystem(IAnnotationProvider? annotationProvider = null)
-        : base(ErrorReportingAnnotations.Prefix, annotationProvider, SubsystemKind.ErrorReporting)
+        : base(ErrorReportingAnnotations.Prefix, SubsystemKind.ErrorReporting, annotationProvider)
     { }
 
     // TODO: Stash option rather than using string

--- a/src/System.CommandLine.Subsystems/HelpSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/HelpSubsystem.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine;
 //          .With(help.Description, "Greet the user");
 //
 public class HelpSubsystem(IAnnotationProvider? annotationProvider = null) 
-    : CliSubsystem(HelpAnnotations.Prefix, annotationProvider: annotationProvider, SubsystemKind.Help)
+    : CliSubsystem(HelpAnnotations.Prefix, SubsystemKind.Help, annotationProvider)
 {
     public void SetDescription(CliSymbol symbol, string description) 
         => SetAnnotation(symbol, HelpAnnotations.Description, description);
@@ -29,15 +29,16 @@ public class HelpSubsystem(IAnnotationProvider? annotationProvider = null)
     public AnnotationAccessor<string> Description 
         => new(this, HelpAnnotations.Description);
 
-    protected internal override CliConfiguration Initialize(CliConfiguration configuration)
+    protected internal override CliConfiguration Initialize(InitializationContext context)
     {
         var option = new CliOption<bool>("--help", ["-h"])
         {
+            // TODO: Why don't we accept bool like any other bool option?
             Arity = ArgumentArity.Zero
         };
-        configuration.RootCommand.Add(option);
+        context.Configuration.RootCommand.Add(option);
 
-        return configuration;
+        return context.Configuration;
     }
 
     protected internal override bool GetIsActivated(ParseResult? parseResult)

--- a/src/System.CommandLine.Subsystems/StandardPipeline.cs
+++ b/src/System.CommandLine.Subsystems/StandardPipeline.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Directives;
+
 namespace System.CommandLine;
 
 public class StandardPipeline : Pipeline
-{ 
+{
     public StandardPipeline() {
         Help = new HelpSubsystem();
         Version = new VersionSubsystem();
-        ErrorReporting = new ErrorReportingSubsystem();
         Completion = new CompletionSubsystem();
+        Diagram = new DiagramSubsystem();
+        ErrorReporting = new ErrorReportingSubsystem();
     }
 }

--- a/src/System.CommandLine.Subsystems/Subsystems/Annotations/DiagramAnnotations.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Annotations/DiagramAnnotations.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine.Subsystems.Annotations;
+
+/// <summary>
+/// IDs for well-known diagram annotations.
+/// </summary>
+public static class DiagramAnnotations
+{
+    public static string Prefix { get; } = nameof(SubsystemKind.Diagram);
+
+}

--- a/src/System.CommandLine.Subsystems/Subsystems/CliSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/CliSubsystem.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.CommandLine.Subsystems.Annotations;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.CommandLine.Subsystems;
@@ -12,7 +11,7 @@ namespace System.CommandLine.Subsystems;
 /// <param name="annotationProvider"></param>
 public abstract class CliSubsystem
 {
-    protected CliSubsystem(string name, IAnnotationProvider? annotationProvider, SubsystemKind subsystemKind)
+    protected CliSubsystem(string name, SubsystemKind subsystemKind, IAnnotationProvider? annotationProvider)
     {
         Name = name;
         _annotationProvider = annotationProvider;
@@ -115,7 +114,8 @@ public abstract class CliSubsystem
     /// <param name="configuration">The CLI configuration, which contains the RootCommand for customization</param>
     /// <returns>True if parsing should continue</returns> // there might be a better design that supports a message
     // TODO: Because of this and similar usage, consider combining CLI declaration and config. ArgParse calls this the parser, which I like
-    protected internal virtual CliConfiguration Initialize(CliConfiguration configuration) => configuration;
+    protected internal virtual CliConfiguration Initialize(InitializationContext context)
+        => context.Configuration;
 
     // TODO: Determine if this is needed.
     protected internal virtual CliExit TearDown(CliExit cliExit) 

--- a/src/System.CommandLine.Subsystems/Subsystems/InitializationContext.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/InitializationContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine.Subsystems;
+
+public class InitializationContext(CliConfiguration configuration, IReadOnlyList<string> args)
+{
+    public CliConfiguration Configuration { get; } = configuration;
+    public IReadOnlyList<string> Args { get; } = args;
+}

--- a/src/System.CommandLine.Subsystems/Subsystems/Subsystem.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Subsystem.cs
@@ -5,8 +5,8 @@ namespace System.CommandLine.Subsystems;
 
 public class Subsystem
 {
-    public static void Initialize(CliSubsystem subsystem, CliConfiguration configuration)
-        => subsystem.Initialize(configuration);
+    public static void Initialize(CliSubsystem subsystem, CliConfiguration configuration, IReadOnlyList<string> args)
+        => subsystem.Initialize(new InitializationContext(configuration, args));
 
     public static CliExit Execute(CliSubsystem subsystem, PipelineContext pipelineContext)
         => subsystem.Execute(pipelineContext);
@@ -14,15 +14,15 @@ public class Subsystem
     public static bool GetIsActivated(CliSubsystem subsystem, ParseResult parseResult)
         => subsystem.GetIsActivated(parseResult);
 
-    public static CliExit ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack = null) 
-        => new(subsystem.ExecuteIfNeeded(new PipelineContext(parseResult,  rawInput, null,consoleHack)));
+    public static CliExit ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack = null)
+        => new(subsystem.ExecuteIfNeeded(new PipelineContext(parseResult, rawInput, null, consoleHack)));
 
     public static CliExit Execute(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack = null)
         => subsystem.Execute(new PipelineContext(parseResult, rawInput, null, consoleHack));
 
 
-    internal static PipelineContext ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack, PipelineContext? pipelineContext = null) 
-        => subsystem.ExecuteIfNeeded(pipelineContext ?? new PipelineContext(parseResult, rawInput, null,consoleHack));
+    internal static PipelineContext ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack, PipelineContext? pipelineContext = null)
+        => subsystem.ExecuteIfNeeded(pipelineContext ?? new PipelineContext(parseResult, rawInput, null, consoleHack));
 
     internal static PipelineContext ExecuteIfNeeded(CliSubsystem subsystem, PipelineContext pipelineContext)
         => subsystem.ExecuteIfNeeded(pipelineContext);

--- a/src/System.CommandLine.Subsystems/Subsystems/SubsystemKind.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/SubsystemKind.cs
@@ -11,4 +11,5 @@ public enum SubsystemKind
     ErrorReporting,
     Completion,
     Diagram,
+    Response,
 }

--- a/src/System.CommandLine.Subsystems/Subsystems/SubsystemKind.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/SubsystemKind.cs
@@ -10,4 +10,5 @@ public enum SubsystemKind
     Version,
     ErrorReporting,
     Completion,
+    Diagram,
 }

--- a/src/System.CommandLine.Subsystems/VersionSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/VersionSubsystem.cs
@@ -12,7 +12,7 @@ public class VersionSubsystem : CliSubsystem
     private string? specificVersion = null;
 
     public VersionSubsystem(IAnnotationProvider? annotationProvider = null)
-        : base(VersionAnnotations.Prefix, annotationProvider, SubsystemKind.Version)
+        : base(VersionAnnotations.Prefix, SubsystemKind.Version, annotationProvider)
     {
     }
 
@@ -34,16 +34,15 @@ public class VersionSubsystem : CliSubsystem
             ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
             ?.InformationalVersion;
 
-
-    protected internal override CliConfiguration Initialize(CliConfiguration configuration)
+    protected internal override CliConfiguration Initialize(InitializationContext context)
     {
         var option = new CliOption<bool>("--version", ["-v"])
         {
             Arity = ArgumentArity.Zero
         };
-        configuration.RootCommand.Add(option);
+        context.Configuration.RootCommand.Add(option);
 
-        return configuration;
+        return context.Configuration;
     }
 
     // TODO: Stash option rather than using string

--- a/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/EndToEndTestApp.csproj
+++ b/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/EndToEndTestApp.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(TargetFrameworkForNETSDK)</TargetFramework>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/src/System.CommandLine.Suggest/dotnet-suggest.csproj
+++ b/src/System.CommandLine.Suggest/dotnet-suggest.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>dotnet-suggest</PackageId>
     <ToolCommandName>dotnet-suggest</ToolCommandName>
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64;linux-x64</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64;linux-x64;osx-arm64</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
 
     <DotnetSuggestBuildNumber>.1</DotnetSuggestBuildNumber>

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -16,11 +16,20 @@ namespace System.CommandLine.Tests
 {
     public partial class ParserTests
     {
+        // TODO: Update testing strategy if we use Location in equality. Some will break
+        private readonly Location dummyLocation = new("", Location.Internal, -1, null);
+
         private T GetValue<T>(ParseResult parseResult, CliOption<T> option)
             => parseResult.GetValue(option);
 
         private T GetValue<T>(ParseResult parseResult, CliArgument<T> argument)
             => parseResult.GetValue(argument);
+
+        //[Fact]
+        //public void FailureTest()
+        //{
+        //    Assert.True(false);
+        //}
 
         [Fact]
         public void An_option_can_be_checked_by_object_instance()
@@ -1447,10 +1456,10 @@ namespace System.CommandLine.Tests
                 .Tokens
                 .Should()
                 .BeEquivalentTo(
-                    new CliToken("1", CliTokenType.Argument, argument),
-                    new CliToken("2", CliTokenType.Argument, argument),
-                    new CliToken("3", CliTokenType.Argument, argument));
-                }
+                    new CliToken("1", CliTokenType.Argument, argument,dummyLocation),
+                    new CliToken("2", CliTokenType.Argument, argument, dummyLocation),
+                    new CliToken("3", CliTokenType.Argument, argument, dummyLocation));
+        }
 
         [Fact]
         public void Command_argument_arity_can_be_a_range_with_a_lower_bound_greater_than_1()
@@ -1469,19 +1478,19 @@ namespace System.CommandLine.Tests
                 .Tokens
                 .Should()
                 .BeEquivalentTo(
-                    new CliToken("1", CliTokenType.Argument, argument),
-                    new CliToken("2", CliTokenType.Argument, argument),
-                    new CliToken("3", CliTokenType.Argument, argument));
+                    new CliToken("1", CliTokenType.Argument, argument, dummyLocation),
+                    new CliToken("2", CliTokenType.Argument, argument, dummyLocation),
+                    new CliToken("3", CliTokenType.Argument, argument, dummyLocation));
             CliParser.Parse(command, "1 2 3 4 5")
                 .CommandResult
                 .Tokens
                 .Should()
                 .BeEquivalentTo(
-                    new CliToken("1", CliTokenType.Argument, argument),
-                    new CliToken("2", CliTokenType.Argument, argument),
-                    new CliToken("3", CliTokenType.Argument, argument),
-                    new CliToken("4", CliTokenType.Argument, argument),
-                    new CliToken("5", CliTokenType.Argument, argument));
+                    new CliToken("1", CliTokenType.Argument, argument, dummyLocation),
+                    new CliToken("2", CliTokenType.Argument, argument, dummyLocation),
+                    new CliToken("3", CliTokenType.Argument, argument, dummyLocation),
+                    new CliToken("4", CliTokenType.Argument, argument, dummyLocation),
+                    new CliToken("5", CliTokenType.Argument, argument, dummyLocation));
         }
 
 // TODO: Validation?
@@ -1541,9 +1550,9 @@ namespace System.CommandLine.Tests
                 .Tokens
                 .Should()
                 .BeEquivalentTo(
-                    new CliToken("1", CliTokenType.Argument, default),
-                    new CliToken("2", CliTokenType.Argument, default),
-                    new CliToken("3", CliTokenType.Argument, default));
+                    new CliToken("1", CliTokenType.Argument, default, dummyLocation),
+                    new CliToken("2", CliTokenType.Argument, default, dummyLocation),
+                    new CliToken("3", CliTokenType.Argument, default, dummyLocation));
         }
 
         [Fact]
@@ -1561,19 +1570,19 @@ namespace System.CommandLine.Tests
                 .Tokens
                 .Should()
                 .BeEquivalentTo(
-                    new CliToken("1", CliTokenType.Argument, default),
-                    new CliToken("2", CliTokenType.Argument, default),
-                    new CliToken("3", CliTokenType.Argument, default));
+                    new CliToken("1", CliTokenType.Argument, default, dummyLocation),
+                    new CliToken("2", CliTokenType.Argument, default, dummyLocation),
+                    new CliToken("3", CliTokenType.Argument, default, dummyLocation));
             CliParser.Parse(command, "-x 1 -x 2 -x 3 -x 4 -x 5")
                 .GetResult(option)
                 .Tokens
                 .Should()
                 .BeEquivalentTo(
-                    new CliToken("1", CliTokenType.Argument, default),
-                    new CliToken("2", CliTokenType.Argument, default),
-                    new CliToken("3", CliTokenType.Argument, default),
-                    new CliToken("4", CliTokenType.Argument, default),
-                    new CliToken("5", CliTokenType.Argument, default));
+                    new CliToken("1", CliTokenType.Argument, default, dummyLocation),
+                    new CliToken("2", CliTokenType.Argument, default, dummyLocation),
+                    new CliToken("3", CliTokenType.Argument, default, dummyLocation),
+                    new CliToken("4", CliTokenType.Argument, default, dummyLocation),
+                    new CliToken("5", CliTokenType.Argument, default, dummyLocation));
         }
 
 // TODO: Validation?

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -25,6 +25,7 @@ namespace System.CommandLine
 
         internal ParseResult(
             CliConfiguration configuration,
+// TODO: determine how rootCommandResult and commandResult differ
             CommandResult rootCommandResult,
             CommandResult commandResult,
             List<CliToken> tokens,

--- a/src/System.CommandLine/Parsing/CliParser.cs
+++ b/src/System.CommandLine/Parsing/CliParser.cs
@@ -138,6 +138,7 @@ namespace System.CommandLine.Parsing
             bool IsAtEndOfInput() => pos == memory.Length;
         }
 
+        // TODO: I'd like a name change where all refs to the string args passed to main are "args" and arguments refers to CLI arguments
         private static ParseResult Parse(
             CliCommand rootCommand,
             IReadOnlyList<string> arguments,
@@ -151,11 +152,11 @@ namespace System.CommandLine.Parsing
 
             configuration ??= new CliConfiguration(rootCommand);
 
-            CliTokenizer.Tokenize(
+            Tokenizer.Tokenize(
                 arguments,
                 rootCommand,
+                configuration,
                 inferRootCommand: rawInput is not null,
-                configuration.EnablePosixBundling,
                 out List<CliToken> tokens,
                 out List<string>? tokenizationErrors);
 

--- a/src/System.CommandLine/Parsing/CliToken.cs
+++ b/src/System.CommandLine/Parsing/CliToken.cs
@@ -3,6 +3,8 @@
 
 namespace System.CommandLine.Parsing
 {
+    // TODO: Include location in equality
+
     // FIXME: should CliToken be public or internal? made internal for now
     // FIXME: should CliToken be a struct?
     /// <summary>
@@ -10,35 +12,39 @@ namespace System.CommandLine.Parsing
     /// </summary>
     internal sealed class CliToken : IEquatable<CliToken>
     {
-        internal const int ImplicitPosition = -1;
+        public static CliToken CreateFromOtherToken(CliToken otherToken, string? arg, Location location)
+            => new(arg, otherToken.Type, otherToken.Symbol, location);
 
         /// <param name="value">The string value of the token.</param>
         /// <param name="type">The type of the token.</param>
         /// <param name="symbol">The symbol represented by the token</param>
+        /// <param name="location">The location of the token</param>
+        /*
         public CliToken(string? value, CliTokenType type, CliSymbol symbol)
         {
             Value = value ?? "";
             Type = type;
             Symbol = symbol;
-            Position = ImplicitPosition;
+            Location = Location.CreateImplicit(value, value is null ? 0 : value.Length);
         }
-       
-        internal CliToken(string? value, CliTokenType type, CliSymbol? symbol, int position)
+        */
+
+        internal CliToken(string? value, CliTokenType type, CliSymbol? symbol, Location location)
         {
             Value = value ?? "";
             Type = type;
             Symbol = symbol;
-            Position = position;
+            Location = location;
         }
 
-        internal int Position { get; }
+        internal Location Location { get; }
 
         /// <summary>
         /// The string value of the token.
         /// </summary>
         public string Value { get; }
 
-        internal bool Implicit => Position == ImplicitPosition;
+        internal bool Implicit => Location.IsImplicit;
 
         /// <summary>
         /// The type of the token.

--- a/src/System.CommandLine/Parsing/Location.cs
+++ b/src/System.CommandLine/Parsing/Location.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace System.CommandLine.Parsing
+{
+    public record Location
+    {
+        public const string Implicit = "Implicit";
+        public const string Internal = "Internal";
+        public const string User = "User";
+        public const string Response = "Response";
+
+        internal static Location CreateRoot(string exeName, bool isImplicit, int start)
+            => new(exeName, isImplicit ? Internal : User, start, null);
+        internal static Location CreateImplicit(string text, Location outerLocation, int offset = 0)
+           => new(text, Implicit, -1, outerLocation, offset);
+        internal static Location CreateInternal(string text, Location? outerLocation = null, int offset = 0)
+           => new(text, Internal, -1, outerLocation, offset);
+        internal static Location CreateUser(string text, int start, Location outerLocation, int offset = 0)
+            => new(text, User, start, outerLocation, offset);
+        internal static Location CreateResponse(string responseSourceName, int start, Location outerLocation, int offset = 0)
+            => new(responseSourceName, $"{Response}:{responseSourceName}", start, outerLocation, offset);
+
+        internal static Location FromOuterLocation(string text, int start, Location outerLocation, int offset = 0)
+            => new(text, outerLocation.Source, start, outerLocation, offset);
+
+        public Location(string text, string source, int start, Location? outerLocation, int offset = 0)
+        {
+            Text = text;
+            Source = source;
+            Start = start;
+            Length = text.Length;
+            Offset = offset;
+            OuterLocation = outerLocation;
+        }
+
+        public string Text { get; }
+        public string Source { get; }
+        public int Start { get; }
+        public int Offset { get; }
+        public int Length { get; }
+        public Location? OuterLocation { get; }
+
+        public bool IsImplicit
+            => Source == Implicit;
+
+        public override string ToString()
+            => $"{(OuterLocation is null ? "" : OuterLocation.ToString() + "; ")}{Source} [{Start}, {Length}, {Offset}]";
+
+    }
+}

--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Parsing\CliToken.cs" />
     <Compile Include="Parsing\CliTokenType.cs" />
     <Compile Include="Parsing\CommandResult.cs" />
+    <Compile Include="Parsing\Location.cs" />
     <Compile Include="Parsing\OptionResult.cs" />
     <Compile Include="Parsing\ParseError.cs" />
     <Compile Include="Parsing\ParseOperation.cs" />


### PR DESCRIPTION
This addresses some of the issues raised in #2342 regarding directives (not response files environment variables(..

Remains in draft because: 

* There are more changes to the Tokenizer than I expected to evaluate directives separately - these changes extended to several files
* I put some data onto the CLI Configuration, because I didn't know where to put it. When we determine how to carry information, we need to plan a way to tuck it away, probably similar to the SubSystem static class for subsystems. 
* A major piece of information is where the Tokenizer should begin. There are two reasons for this - the exe name may or may not be included in the args array and we need to deal with this, and Initialize methods for subsystems may have handled some of the args. We are limiting that handling to the start of the args array.
* There are numerous naming and other issues to resolve, but I wanted to get the basics out for folks to look at before I am mostly busy next week. 