### PR TITLE
Add official pipeline using 1ES template

### DIFF
--- a/.vsts-ci-official.yml
+++ b/.vsts-ci-official.yml
@@ -1,0 +1,183 @@
+variables:
+  - name: _TeamName
+    value: DotNetCore
+  - name: _DotNetArtifactsCategory
+    value: .NETCore
+  - name: Codeql.Enabled
+    value: true
+
+# CI and PR triggers
+trigger:
+  batch: true
+  branches:
+    include:
+    - main
+
+pr:
+  autoCancel: false
+  branches:
+    include:
+    - '*'
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      image: 1es-windows-2022-pt
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      displayName: Build and Test
+      jobs:
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          enableMicrobuild: true
+          enablePublishBuildArtifacts: true
+          enablePublishUsingPipelines: true
+          enablePublishTestResults: true
+          enablePublishBuildAssets: true
+          enableTelemetry: true
+          enableSourceBuild: true
+          helixRepo: dotnet/command-line-api
+          timeoutInMinutes: 180 # increase timeout since BAR publishing might wait a long time
+          jobs:
+          - job: Windows
+            pool:
+              # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
+              # Will eventually change this to two BYOC pools.
+              ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+                name: NetCore-Public
+                demands: ImageOverride -equals windows.vs2022.amd64.open
+              ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+                name: NetCore1ESPool-Internal
+                demands: ImageOverride -equals windows.vs2022.amd64
+            variables:
+            # Only enable publishing in official builds.
+            - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+              # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
+              - group: DotNet-Symbol-Server-Pats
+              - group: Publish-Build-Assets
+              - name: _OfficialBuildArgs
+                value: /p:DotNetSignType=$(_SignType)
+                      /p:TeamName=$(_TeamName)
+                      /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                      /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                      /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                      /p:PublishToSymbolServer=true
+                      /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
+                      /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
+              - name: _PublishUsingPipelines
+                value: true
+            # else
+            - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+              - name: _OfficialBuildArgs
+                value: ''
+            strategy:
+              matrix:
+                ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+                  Debug:
+                    _BuildConfig: Debug
+                    _SignType: test
+                    _BuildArgs:
+
+                Release:
+                  _BuildConfig: Release
+                  # PRs or external builds are not signed.
+                  ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+                    _SignType: test
+                  ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+                    _SignType: real
+                    _BuildArgs: $(_OfficialBuildArgs)
+
+            templateContext:
+              outputs:
+              - output: pipelineArtifact
+                displayName: Upload package artifacts
+                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+                targetPath: artifacts/packages/
+                artifactName: artifacts
+              - output: pipelineArtifact
+                displayName: Publish Artifact Symbols
+                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+                targetPath: '$(Build.SourcesDirectory)\artifacts\SymStore\$(_BuildConfig)'
+                artifactName: 'NativeSymbols'
+
+            steps:
+            - checkout: self
+              clean: true
+            - script: eng\common\cibuild.cmd
+                -configuration $(_BuildConfig)
+                -prepareMachine
+                $(_BuildArgs)
+              displayName: Build and Publish
+
+          - job: Ubuntu
+            displayName: Ubuntu
+            pool:
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                name: NetCore-Svc-Public
+                demands: ImageOverride -equals 1es-ubuntu-2004-open
+              ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+                name: NetCore1ESPool-Svc-Internal
+                demands: ImageOverride -equals 1es-ubuntu-2004
+              os: linux
+            strategy:
+              matrix:
+                ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+                  Debug:
+                    _BuildConfig: Debug
+                    _SignType: none
+                Release:
+                  _BuildConfig: Release
+                  _SignType: none
+            steps:
+            - checkout: self
+              clean: true
+            - bash: |
+                wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+                sudo apt-add-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-9 main"
+                sudo apt-get update
+            - bash: |
+                sudo apt-get install cmake clang-9 libicu66 uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev
+            - script: eng/common/cibuild.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+              displayName: Build
+
+          - job: MacOS
+            displayName: MacOS
+            pool:
+              name: Azure Pipelines
+              image: macOS-latest
+              os: macOS
+            strategy:
+              matrix:
+                ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+                  Debug:
+                    _BuildConfig: Debug
+                    _SignType: none
+                    _DotNetPublishToBlobFeed: false
+                Release:
+                  _BuildConfig: Release
+                  _SignType: none
+                  _DotNetPublishToBlobFeed: false
+            steps:
+            - checkout: self
+              clean: true
+            - script: eng/common/cibuild.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+              displayName: Build
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - template: /eng/common/templates-official/post-build/post-build.yml@self

--- a/.vsts-ci-official.yml
+++ b/.vsts-ci-official.yml
@@ -31,7 +31,7 @@ extends:
   parameters:
     pool:
       name: NetCore1ESPool-Svc-Internal
-      image: 1es-windows-2022-pt
+      image: 1es-windows-2022
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling


### PR DESCRIPTION
- I cloned `.vsts-ci.yml` to be used for the official pipeline and then converted it; [here's the diff (for the first commit of this PR only)](https://github.com/dotnet/command-line-api/compare/4a5f10180acf992939d34c7002b06a2d7e4b904e...jjonescz:command-line-api:1es-pt?w=1)
  - I have intentionally not removed "dead code" from the pipeline to minimize the diff for now and also it can be reused later when we want to have 1ES template for public templates as well, see also [comment below](https://github.com/dotnet/command-line-api/pull/2361#discussion_r1539928196)
- Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2415809&view=results