### PR TITLE
Fixing issue #2392

### DIFF
--- a/src/System.CommandLine.Tests/ParseDiagramTests.cs
+++ b/src/System.CommandLine.Tests/ParseDiagramTests.cs
@@ -47,6 +47,23 @@ namespace System.CommandLine.Tests
                   .Be("[ command ![ -x <ar> ] ]");
         }
 
+        // https://github.com/dotnet/command-line-api/issues/2392
+        [Fact]
+        public void Parse_diagram_with_option_argument_error_only_one_error_is_returned()
+        {
+            var command = new CliCommand("the-command")
+            {
+                new CliOption<int[]>("-x") { Arity = new ArgumentArity(2, 3)}
+            };
+
+            ParseResult parseResult = command.Parse("-x 1 -x 2 -x 3 -x 4");
+            _ = parseResult.Diagram();
+
+            parseResult.Errors
+                       .Should()
+                       .ContainSingle();
+        }
+
         [Fact]
         public void Parse_diagram_shows_type_conversion_errors()
         {

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -1560,7 +1560,22 @@ namespace System.CommandLine.Tests
                    .Should()
                    .Contain(LocalizationResources.UnrecognizedCommandOrArgument("4"));
         }
-        
+
+        [Fact]
+        public void When_the_number_of_option_arguments_are_greater_than_maximum_arity_then_an_error_is_returned()
+        {
+            var command = new CliCommand("the-command")
+            {
+                new CliOption<int[]>("-x") { Arity = new ArgumentArity(2, 3)}
+            };
+
+            command.Parse("-x 1 -x 2 -x 3 -x 4")
+                   .Errors
+                   .Select(e => e.Message)
+                   .Should()
+                   .Contain(LocalizationResources.OptionArgumentsMaximumExceeded("-x", 3, 4));
+        }
+
         [Fact]
         public void Tokens_are_not_split_if_the_part_before_the_delimiter_is_not_an_option()
         {

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -99,11 +99,20 @@ namespace System.CommandLine
                 {
                     if (!optionResult.Option.AllowMultipleArgumentsPerToken)
                     {
-                        error = ArgumentConversionResult.Failure(
-                            argumentResult,
-                            LocalizationResources.ExpectsOneArgument(optionResult),
-                            ArgumentConversionResultType.FailedTooManyArguments);
-
+                        if (argumentResult.Argument.Arity.MaximumNumberOfValues > 1)
+                        {
+                            error = ArgumentConversionResult.Failure(
+                                 argumentResult,
+                                 LocalizationResources.OptionArgumentsMaximumExceeded(optionResult, argumentResult.Argument.Arity.MaximumNumberOfValues),
+                                 ArgumentConversionResultType.FailedTooManyArguments);
+                        }
+                        else
+                        {
+                            error = ArgumentConversionResult.Failure(
+                                argumentResult,
+                                LocalizationResources.ExpectsOneArgument(optionResult),
+                                ArgumentConversionResultType.FailedTooManyArguments);
+                        }
                         return false;
                     }
                 }

--- a/src/System.CommandLine/LocalizationResources.cs
+++ b/src/System.CommandLine/LocalizationResources.cs
@@ -14,10 +14,22 @@ namespace System.CommandLine
     internal static class LocalizationResources
     {
         /// <summary>
-        ///   Interpolates values into a localized string similar to Command &apos;{0}&apos; expects a single argument but {1} were provided.
+        ///   Interpolates values into a localized string similar to Option &apos;{0}&apos; expects a single argument but {1} were provided.
         /// </summary>
         internal static string ExpectsOneArgument(OptionResult optionResult)
             => GetResourceString(Properties.Resources.OptionExpectsOneArgument, GetOptionName(optionResult), optionResult.Tokens.Count);
+
+        /// <summary>
+        /// Interpolates values into a localized string similar to Option &apos;{0}&apos; expects at most {1} arguments but {2} were provided.
+        /// </summary>
+        internal static string OptionArgumentsMaximumExceeded(OptionResult optionResult, int maximumOptionArgumentsAllowed)
+           => OptionArgumentsMaximumExceeded(GetOptionName(optionResult), maximumOptionArgumentsAllowed, optionResult.Tokens.Count);
+
+        /// <summary>
+        /// Interpolates values into a localized string similar to Option &apos;{0}&apos; expects at most {1} arguments but {2} were provided.
+        /// </summary>
+        internal static string OptionArgumentsMaximumExceeded(string optionName, int maximumOptionArgumentsAllowed, int foundTokenCount)
+            => GetResourceString(Properties.Resources.OptionArgumentsMaximumExceeded, optionName, maximumOptionArgumentsAllowed, foundTokenCount);
 
         /// <summary>
         ///   Interpolates values into a localized string similar to Directory does not exist: {0}.

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -125,7 +125,7 @@ namespace System.CommandLine.Parsing
                 // When_there_is_an_arity_error_then_further_errors_are_not_reported
                 if (!ArgumentArity.Validate(argumentResult, out var error))
                 {
-                    optionResult.AddError(error.ErrorMessage!);
+                    argumentResult.AddError(error.ErrorMessage!);
                     continue;
                 }
 

--- a/src/System.CommandLine/Properties/Resources.Designer.cs
+++ b/src/System.CommandLine/Properties/Resources.Designer.cs
@@ -295,6 +295,15 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Option &apos;{0}&apos; expects at most {1} arguments but {2} were provided..
+        /// </summary>
+        internal static string OptionArgumentsMaximumExceeded {
+            get {
+                return ResourceManager.GetString("OptionArgumentsMaximumExceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Option &apos;{0}&apos; expects a single argument but {1} were provided..
         /// </summary>
         internal static string OptionExpectsOneArgument {

--- a/src/System.CommandLine/Properties/Resources.resx
+++ b/src/System.CommandLine/Properties/Resources.resx
@@ -225,4 +225,7 @@
   <data name="ArgumentConversionCannotParseForOption_Completions" xml:space="preserve">
     <value>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'. Did you mean one of the following?{3}</value>
   </data>
+  <data name="OptionArgumentsMaximumExceeded" xml:space="preserve">
+    <value>Option '{0}' expects at most {1} arguments but {2} were provided.</value>
+  </data>
 </root>


### PR DESCRIPTION
There were two problems addressed here.
First, the call to Diagram was causing the second error to be added to the ParseResult.Errors collection. The diagram call, was being invoked by the debugger as part of the ParseResult.ToString() method. Causing the number of errors to change when inspecting a parse result.

The second issue was the error message text. It was implying that the option expected a single value, when its arity allowed for more.