### PR TITLE
Make ArgumentResult, OptionResult and CommandResult `internal`

### DIFF
--- a/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
@@ -35,7 +35,7 @@ public class DiagramSubsystem( IAnnotationProvider? annotationProvider = null)
         var builder = new StringBuilder(100);
 
 
-        Diagram(builder, parseResult.RootCommandResult, parseResult);
+        //Diagram(builder, parseResult.RootCommandResult, parseResult);
 
         // TODO: Unmatched tokens
         /*

--- a/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
@@ -35,6 +35,7 @@ public class DiagramSubsystem( IAnnotationProvider? annotationProvider = null)
         var builder = new StringBuilder(100);
 
 
+        // TODO: Reinstate this when ready to implement
         //Diagram(builder, parseResult.RootCommandResult, parseResult);
 
         // TODO: Unmatched tokens

--- a/src/System.CommandLine/CliArgument{T}.cs
+++ b/src/System.CommandLine/CliArgument{T}.cs
@@ -34,7 +34,7 @@ namespace System.CommandLine
         /// the delegate is also invoked when an input was provided.
         /// </remarks>
         */
-        public Func<ArgumentResult, T>? DefaultValueFactory { get; set; }
+        internal Func<ArgumentResult, T>? DefaultValueFactory { get; set; }
 
 // TODO: custom parsers
 /*

--- a/src/System.CommandLine/CliOption{T}.cs
+++ b/src/System.CommandLine/CliOption{T}.cs
@@ -30,7 +30,7 @@ namespace System.CommandLine
         }
 
         /// <inheritdoc cref="CliArgument{T}.DefaultValueFactory" />
-        public Func<ArgumentResult, T>? DefaultValueFactory
+        internal Func<ArgumentResult, T>? DefaultValueFactory
         {
             get => _argument.DefaultValueFactory;
             set => _argument.DefaultValueFactory = value;

--- a/src/System.CommandLine/ParseResult.cs
+++ b/src/System.CommandLine/ParseResult.cs
@@ -87,7 +87,7 @@ namespace System.CommandLine
         /// <summary>
         /// A result indicating the command specified in the command line input.
         /// </summary>
-        public CommandResult CommandResult { get; }
+        internal CommandResult CommandResult { get; }
 
         /// <summary>
         /// The configuration used to produce the parse result.
@@ -97,7 +97,7 @@ namespace System.CommandLine
         /// <summary>
         /// Gets the root command result.
         /// </summary>
-        public CommandResult RootCommandResult => _rootCommandResult;
+        internal CommandResult RootCommandResult => _rootCommandResult;
 
         /// <summary>
         /// Gets the parse errors found while parsing command line input.
@@ -180,7 +180,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="argument">The argument for which to find a result.</param>
         /// <returns>A result for the specified argument, or <see langword="null"/> if it was not provided and no default was configured.</returns>
-        public ArgumentResult? GetResult(CliArgument argument) =>
+        internal ArgumentResult? GetResult(CliArgument argument) =>
             _rootCommandResult.GetResult(argument);
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="command">The command for which to find a result.</param>
         /// <returns>A result for the specified command, or <see langword="null"/> if it was not provided.</returns>
-        public CommandResult? GetResult(CliCommand command) =>
+        internal CommandResult? GetResult(CliCommand command) =>
             _rootCommandResult.GetResult(command);
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="option">The option for which to find a result.</param>
         /// <returns>A result for the specified option, or <see langword="null"/> if it was not provided and no default was configured.</returns>
-        public OptionResult? GetResult(CliOption option) =>
+        internal OptionResult? GetResult(CliOption option) =>
             _rootCommandResult.GetResult(option);
 
 // TODO: Directives

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
     /// <summary>
     /// A result produced when parsing an <see cref="Argument"/>.
     /// </summary>
-    public sealed class ArgumentResult : SymbolResult
+    internal sealed class ArgumentResult : SymbolResult
     {
         private ArgumentConversionResult? _conversionResult;
         private bool _onlyTakeHasBeenCalled;

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
     /// <summary>
     /// A result produced when parsing a <see cref="Command" />.
     /// </summary>
-    public sealed class CommandResult : SymbolResult
+    internal sealed class CommandResult : SymbolResult
     {
         internal CommandResult(
             CliCommand command,

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Parsing
     /// <summary>
     /// A result produced when parsing an <see cref="Option" />.
     /// </summary>
-    public sealed class OptionResult : SymbolResult
+    internal sealed class OptionResult : SymbolResult
     {
         private ArgumentConversionResult? _argumentConversionResult;
 

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -70,21 +70,21 @@ namespace System.CommandLine.Parsing
         /// </summary>
         /// <param name="argument">The argument for which to find a result.</param>
         /// <returns>An argument result if the argument was matched by the parser or has a default value; otherwise, <c>null</c>.</returns>
-        public ArgumentResult? GetResult(CliArgument argument) => SymbolResultTree.GetResult(argument);
+        internal ArgumentResult? GetResult(CliArgument argument) => SymbolResultTree.GetResult(argument);
 
         /// <summary>
         /// Finds a result for the specific command anywhere in the parse tree, including parent and child symbol results.
         /// </summary>
         /// <param name="command">The command for which to find a result.</param>
         /// <returns>An command result if the command was matched by the parser; otherwise, <c>null</c>.</returns>
-        public CommandResult? GetResult(CliCommand command) => SymbolResultTree.GetResult(command);
+        internal CommandResult? GetResult(CliCommand command) => SymbolResultTree.GetResult(command);
 
         /// <summary>
         /// Finds a result for the specific option anywhere in the parse tree, including parent and child symbol results.
         /// </summary>
         /// <param name="option">The option for which to find a result.</param>
         /// <returns>An option result if the option was matched by the parser or has a default value; otherwise, <c>null</c>.</returns>
-        public OptionResult? GetResult(CliOption option) => SymbolResultTree.GetResult(option);
+        internal OptionResult? GetResult(CliOption option) => SymbolResultTree.GetResult(option);
 
 // TODO: directives
 /*


### PR DESCRIPTION
ArgumentResult and OptionResult are being replaced with the more API friendly ValueResult. 

CommandResult is being replaced with the more API friendly class that has the temporary name of CommandValueResult.