### PR TITLE
Renamed `Location.Start` to `Location.Index`

### DIFF
--- a/src/System.CommandLine/Parsing/Location.cs
+++ b/src/System.CommandLine/Parsing/Location.cs
@@ -29,11 +29,11 @@ namespace System.CommandLine.Parsing
         internal static Location FromOuterLocation(string text, int start, Location outerLocation, int offset = 0)
             => new(text, outerLocation.Source, start, outerLocation, offset);
 
-        public Location(string text, string source, int start, Location? outerLocation, int offset = 0)
+        public Location(string text, string source, int index, Location? outerLocation, int offset = 0)
         {
             Text = text;
             Source = source;
-            Start = start;
+            Index = index;
             Length = text.Length;
             Offset = offset;
             OuterLocation = outerLocation;
@@ -41,7 +41,7 @@ namespace System.CommandLine.Parsing
 
         public string Text { get; }
         public string Source { get; }
-        public int Start { get; }
+        public int Index { get; }
         public int Offset { get; }
         public int Length { get; }
         public Location? OuterLocation { get; }
@@ -50,7 +50,7 @@ namespace System.CommandLine.Parsing
             => Source == Implicit;
 
         public override string ToString()
-            => $"{(OuterLocation is null ? "" : OuterLocation.ToString() + "; ")}{Text} from {Source}[{Start}, {Length}, {Offset}]";
+            => $"{(OuterLocation is null ? "" : OuterLocation.ToString() + "; ")}{Text} from {Source}[{Index}, {Length}, {Offset}]";
 
     }
 }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -78,7 +78,7 @@ namespace System.CommandLine.Parsing
             var maxSkippedPositions = configuration.PreProcessedLocations is null
                                     || !configuration.PreProcessedLocations.Any()
                                         ? 0
-                                        : configuration.PreProcessedLocations.Max(x => x.Start);
+                                        : configuration.PreProcessedLocations.Max(x => x.Index);
 
 
             var validTokens = GetValidTokens(rootCommand);
@@ -111,7 +111,7 @@ namespace System.CommandLine.Parsing
 
                     if (i <= maxSkippedPositions
                         && configuration.PreProcessedLocations is not null
-                        && configuration.PreProcessedLocations.Any(x => x.Start == i))
+                        && configuration.PreProcessedLocations.Any(x => x.Index == i))
                     {
                         continue;
                     }
@@ -229,7 +229,7 @@ namespace System.CommandLine.Parsing
                             {
                                 string value = alias.Slice(i + 1).ToString();
                                 tokenList.Add(Argument(value,
-                                    Location.FromOuterLocation(value, outerLocation.Start, outerLocation, i + 1)));
+                                    Location.FromOuterLocation(value, outerLocation.Index, outerLocation, i + 1)));
                                 return true;
                             }
 
@@ -241,7 +241,7 @@ namespace System.CommandLine.Parsing
                                     // Invalid_char_in_bundle_causes_rest_to_be_interpreted_as_value
                                     string value = alias.Slice(i).ToString();
                                     tokenList.Add(Argument(value,
-                                        Location.FromOuterLocation(value, outerLocation.Start, outerLocation, i)));
+                                        Location.FromOuterLocation(value, outerLocation.Index, outerLocation, i)));
                                     return true;
                                 }
 
@@ -249,7 +249,7 @@ namespace System.CommandLine.Parsing
                             }
 
                             tokenList.Add(new CliToken(candidate, found.TokenType, found.Symbol,
-                                Location.FromOuterLocation(candidate, outerLocation.Start, outerLocation, i + 1)));
+                                Location.FromOuterLocation(candidate, outerLocation.Index, outerLocation, i + 1)));
 
                             if (i != alias.Length - 1 && ((CliOption)found.Symbol).Greedy)
                             {
@@ -260,7 +260,7 @@ namespace System.CommandLine.Parsing
                                 }
 
                                 string value = alias.Slice(index).ToString();
-                                tokenList.Add(Argument(value, Location.FromOuterLocation(value, outerLocation.Start, outerLocation, index)));
+                                tokenList.Add(Argument(value, Location.FromOuterLocation(value, outerLocation.Index, outerLocation, index)));
                                 return true;
                             }
                         }


### PR DESCRIPTION
Start may imply position in string, and this is position in the args array or response file.