### PR TITLE
Help uses symbol to lookup if help is selected

### DIFF
--- a/src/System.CommandLine.Subsystems/HelpSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/HelpSubsystem.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine.Subsystems.Annotations;
 using System.CommandLine.Subsystems;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace System.CommandLine;
 
@@ -18,31 +19,30 @@ namespace System.CommandLine;
 public class HelpSubsystem(IAnnotationProvider? annotationProvider = null) 
     : CliSubsystem(HelpAnnotations.Prefix, SubsystemKind.Help, annotationProvider)
 {
-    public void SetDescription(CliSymbol symbol, string description) 
-        => SetAnnotation(symbol, HelpAnnotations.Description, description);
+    public CliOption<bool> HelpOption { get; } =new CliOption<bool>("--help", ["-h"])
+            {
+                // TODO: Why don't we accept bool like any other bool option?
+                    Arity = ArgumentArity.Zero
+            };
 
+public void SetDescription(CliSymbol symbol, string description) 
+        => SetAnnotation(symbol, HelpAnnotations.Description, description);
     public string GetDescription(CliSymbol symbol) 
         => TryGetAnnotation<string>(symbol, HelpAnnotations.Description, out var value)
             ? value
             : "";
-
     public AnnotationAccessor<string> Description 
         => new(this, HelpAnnotations.Description);
 
     protected internal override CliConfiguration Initialize(InitializationContext context)
     {
-        var option = new CliOption<bool>("--help", ["-h"])
-        {
-            // TODO: Why don't we accept bool like any other bool option?
-            Arity = ArgumentArity.Zero
-        };
-        context.Configuration.RootCommand.Add(option);
+        context.Configuration.RootCommand.Add(HelpOption);
 
         return context.Configuration;
     }
 
     protected internal override bool GetIsActivated(ParseResult? parseResult)
-        => parseResult is not null && parseResult.GetValue<bool>("--help");
+        => parseResult is not null && parseResult.GetValue(HelpOption);
 
     protected internal override CliExit Execute(PipelineContext pipelineContext)
     {

--- a/src/System.CommandLine.Subsystems/HelpSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/HelpSubsystem.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine.Subsystems.Annotations;
 using System.CommandLine.Subsystems;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace System.CommandLine;
 
@@ -16,22 +15,24 @@ namespace System.CommandLine;
 //        var command = new CliCommand("greet")
 //          .With(help.Description, "Greet the user");
 //
-public class HelpSubsystem(IAnnotationProvider? annotationProvider = null) 
+public class HelpSubsystem(IAnnotationProvider? annotationProvider = null)
     : CliSubsystem(HelpAnnotations.Prefix, SubsystemKind.Help, annotationProvider)
 {
-    public CliOption<bool> HelpOption { get; } =new CliOption<bool>("--help", ["-h"])
-            {
-                // TODO: Why don't we accept bool like any other bool option?
-                    Arity = ArgumentArity.Zero
-            };
+    public CliOption<bool> HelpOption { get; } = new CliOption<bool>("--help", ["-h"])
+    {
+        // TODO: Why don't we accept bool like any other bool option?
+        Arity = ArgumentArity.Zero
+    };
 
-public void SetDescription(CliSymbol symbol, string description) 
+    public void SetDescription(CliSymbol symbol, string description)
         => SetAnnotation(symbol, HelpAnnotations.Description, description);
-    public string GetDescription(CliSymbol symbol) 
+
+    public string GetDescription(CliSymbol symbol)
         => TryGetAnnotation<string>(symbol, HelpAnnotations.Description, out var value)
             ? value
             : "";
-    public AnnotationAccessor<string> Description 
+
+    public AnnotationAccessor<string> Description
         => new(this, HelpAnnotations.Description);
 
     protected internal override CliConfiguration Initialize(InitializationContext context)


### PR DESCRIPTION
Using symbol instead of string for perf and robustness