### PR TITLE
Powderhouse - Fix 2392 Error Message

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -1624,6 +1624,21 @@ namespace System.CommandLine.Tests
                 .Select(e => e.Message)
                 .Should()
                 .Contain(LocalizationResources.UnrecognizedCommandOrArgument("4"));
+        }
+
+        [Fact]
+        public void When_the_number_of_option_arguments_are_greater_than_maximum_arity_then_an_error_is_returned()
+        {
+            var command = new CliCommand("the-command")
+            {
+                new CliOption<int[]>("-x") { Arity = new ArgumentArity(2, 3)}
+            };
+
+            CliParser.Parse(command, "-x 1 -x 2 -x 3 -x 4")
+                   .Errors
+                   .Select(e => e.Message)
+                   .Should()
+                   .Contain(LocalizationResources.OptionArgumentsMaximumExceeded("-x", 3, 4));
         }
 
         // TODO: Tests tokens which is no longer exposed, and should be replaced with equivalent test using ParseResult

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -99,11 +99,20 @@ namespace System.CommandLine
                 {
                     if (!optionResult.Option.AllowMultipleArgumentsPerToken)
                     {
-                        error = ArgumentConversionResult.Failure(
-                            argumentResult,
-                            LocalizationResources.ExpectsOneArgument(optionResult),
-                            ArgumentConversionResultType.FailedTooManyArguments);
-
+                        if (argumentResult.Argument.Arity.MaximumNumberOfValues > 1)
+                        {
+                            error = ArgumentConversionResult.Failure(
+                                 argumentResult,
+                                 LocalizationResources.OptionArgumentsMaximumExceeded(optionResult, argumentResult.Argument.Arity.MaximumNumberOfValues),
+                                 ArgumentConversionResultType.FailedTooManyArguments);
+                        }
+                        else
+                        {
+                            error = ArgumentConversionResult.Failure(
+                                argumentResult,
+                                LocalizationResources.ExpectsOneArgument(optionResult),
+                                ArgumentConversionResultType.FailedTooManyArguments);
+                        }
                         return false;
                     }
                 }

--- a/src/System.CommandLine/LocalizationResources.cs
+++ b/src/System.CommandLine/LocalizationResources.cs
@@ -14,10 +14,23 @@ namespace System.CommandLine
     internal static class LocalizationResources
     {
         /// <summary>
-        ///   Interpolates values into a localized string similar to Command &apos;{0}&apos; expects a single argument but {1} were provided.
+        ///   Interpolates values into a localized string similar to Option &apos;{0}&apos; expects a single argument but {1} were provided.
         /// </summary>
         internal static string ExpectsOneArgument(OptionResult optionResult)
             => GetResourceString(Properties.Resources.OptionExpectsOneArgument, GetOptionName(optionResult), optionResult.Tokens.Count);
+
+        /// <summary>
+        /// Interpolates values into a localized string similar to Option &apos;{0}&apos; expects at most {1} arguments but {2} were provided.
+        /// </summary>
+        internal static string OptionArgumentsMaximumExceeded(OptionResult optionResult, int maximumOptionArgumentsAllowed)
+           => OptionArgumentsMaximumExceeded(GetOptionName(optionResult), maximumOptionArgumentsAllowed, optionResult.Tokens.Count);
+
+        /// <summary>
+        /// Interpolates values into a localized string similar to Option &apos;{0}&apos; expects at most {1} arguments but {2} were provided.
+        /// </summary>
+        internal static string OptionArgumentsMaximumExceeded(string optionName, int maximumOptionArgumentsAllowed, int foundTokenCount)
+            => GetResourceString(Properties.Resources.OptionArgumentsMaximumExceeded, optionName, maximumOptionArgumentsAllowed, foundTokenCount);
+
 /*
         /// <summary>
         ///   Interpolates values into a localized string similar to Directory does not exist: {0}.

--- a/src/System.CommandLine/Properties/Resources.Designer.cs
+++ b/src/System.CommandLine/Properties/Resources.Designer.cs
@@ -295,6 +295,15 @@ namespace System.CommandLine.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Option &apos;{0}&apos; expects at most {1} arguments but {2} were provided..
+        /// </summary>
+        internal static string OptionArgumentsMaximumExceeded {
+            get {
+                return ResourceManager.GetString("OptionArgumentsMaximumExceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Option &apos;{0}&apos; expects a single argument but {1} were provided..
         /// </summary>
         internal static string OptionExpectsOneArgument {

--- a/src/System.CommandLine/Properties/Resources.resx
+++ b/src/System.CommandLine/Properties/Resources.resx
@@ -225,4 +225,7 @@
   <data name="ArgumentConversionCannotParseForOption_Completions" xml:space="preserve">
     <value>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'. Did you mean one of the following?{3}</value>
   </data>
+  <data name="OptionArgumentsMaximumExceeded" xml:space="preserve">
+    <value>Option '{0}' expects at most {1} arguments but {2} were provided.</value>
+  </data>
 </root>

--- a/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.cs.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Znak se v cestě nepovoluje: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.de.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.de.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Zeichen in Pfad nicht zulässig: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.es.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.es.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Carácter no permitido en una ruta: '{0}'.</target>
         <note></note>
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="translated">La opción '{0}' espera un solo argumento, pero se proporcionaron {1}.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.fr.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Caractère non autorisé dans un chemin : '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.it.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.it.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Il carattere non è consentito in un percorso: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ja.xlf
@@ -132,6 +132,11 @@
         <target state="translated">パスで使用することが許可されていない文字: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
@@ -132,6 +132,11 @@
         <target state="translated">경로에 사용할 수 없는 문자: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pl.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Znak jest niedozwolony w ścieżce: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.pt-BR.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Caractere não permitido em um caminho: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ru.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Недопустимый символ в пути: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.tr.xlf
@@ -132,6 +132,11 @@
         <target state="translated">Yolda '{0}' karakterine izin verilmiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hans.xlf
@@ -132,6 +132,11 @@
         <target state="translated">路径中不允许的字符: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>

--- a/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.zh-Hant.xlf
@@ -132,6 +132,11 @@
         <target state="translated">路徑中不允許的字元: '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionArgumentsMaximumExceeded">
+        <source>Option '{0}' expects at most {1} arguments but {2} were provided.</source>
+        <target state="new">Option '{0}' expects at most {1} arguments but {2} were provided.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
         <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>


### PR DESCRIPTION
Add additional error message to provide a good error message when the argument arity more than 1.

The previous error message was similar to "Option '-x' expects a single argument but 4 were provided."
After this fix the error message is similar to: "Option '-x' expects at most 3 arguments but 4 were provided."