### PR TITLE
Fix duplicate errors appended

### DIFF
--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -31,10 +31,11 @@ namespace System.CommandLine.Parsing
                 {
                     // This is not lazy on the assumption that almost everything the user enters will be used, and ArgumentResult is no longer used for defaults
                     // TODO: Make sure errors are added
-                    var conversionValue = GetArgumentConversionResult().Value;
+                    ArgumentConversionResult argumentConversionValue = GetArgumentConversionResult();
+                    var conversionValue = argumentConversionValue.Value;
                     var locations = Tokens.Select(token => token.Location).ToArray();
                     //TODO: Remove this wrapper later
-                    _valueResult = new ValueResult(Argument, conversionValue, locations, ArgumentResult.GetValueResultOutcome(GetArgumentConversionResult()?.Result)); // null is temporary here
+                    _valueResult = new ValueResult(Argument, conversionValue, locations, GetValueResultOutcome(argumentConversionValue.Result));
                 }
                 return _valueResult;
             }

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -37,7 +37,7 @@ namespace System.CommandLine.Parsing
                     var conversionValue = ArgumentConversionResult.Value;
                     var locations = Tokens.Select(token => token.Location).ToArray();
                     //TODO: Remove this wrapper later
-                    _valueResult = new ValueResult(Option, conversionValue, locations, ArgumentResult.GetValueResultOutcome(ArgumentConversionResult?.Result)); // null is temporary here
+                    _valueResult = new ValueResult(Option, conversionValue, locations, ArgumentResult.GetValueResultOutcome(ArgumentConversionResult.Result));
                 }
                 return _valueResult;
             }

--- a/src/System.CommandLine/Parsing/SymbolResultTree.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultTree.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Parsing
         internal List<CliToken>? UnmatchedTokens;
 */
 
-        // TODO: Looks like this is a SymboNode/linked list because a symbol may appear multiple
+        // TODO: Looks like this is a SymbolNode/linked list because a symbol may appear multiple
         // places in the tree and multiple symbols will have the same short name. The question is 
         // whether creating the multiple node instances is faster than just using lists. Could well be.
         private Dictionary<string, SymbolNode>? _symbolsByName;


### PR DESCRIPTION
Fixes #2392.
This is a port from the fix on main. However due to additional work that is currently being done on Powerderhouse it is forcing the creation of the ArgumentConversionResult as part of parsing. This is due to the invocation SymbolResultTree.GetValueResultDictionary() which forces the evaluation of all ArgumentConversionResults. This is adding an additional test to make sure that the behavior is not re-introduced. This also fixes a few NRT issues and a comment typo.
