### PR TITLE
PipelineContext replaced with PipelineResult

### DIFF
--- a/src/System.CommandLine.Subsystems.Tests/AlternateSubsystems.cs
+++ b/src/System.CommandLine.Subsystems.Tests/AlternateSubsystems.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Subsystems.Tests
     {
         internal class AlternateVersion : VersionSubsystem
         {
-            protected override CliExit Execute(PipelineContext pipelineContext)
+            protected override CliExit Execute(PipelineResult pipelineContext)
             {
                 pipelineContext.ConsoleHack.WriteLine($"***{CliExecutable.ExecutableVersion}***");
                 pipelineContext.AlreadyHandled = true;
@@ -29,7 +29,7 @@ namespace System.CommandLine.Subsystems.Tests
 
             private CliSymbol Symbol { get; }
 
-            protected override CliExit Execute(PipelineContext pipelineContext)
+            protected override CliExit Execute(PipelineResult pipelineContext)
             {
                 TryGetAnnotation(Symbol, HelpAnnotations.Description, out string? description);
                 pipelineContext.ConsoleHack.WriteLine(description);
@@ -51,7 +51,7 @@ namespace System.CommandLine.Subsystems.Tests
                 return base.Initialize(context);
             }
 
-            protected override CliExit Execute(PipelineContext pipelineContext)
+            protected override CliExit Execute(PipelineResult pipelineContext)
             {
                 ExecutionWasRun = true;
                 return base.Execute(pipelineContext);

--- a/src/System.CommandLine.Subsystems.Tests/AlternateSubsystems.cs
+++ b/src/System.CommandLine.Subsystems.Tests/AlternateSubsystems.cs
@@ -10,11 +10,11 @@ namespace System.CommandLine.Subsystems.Tests
     {
         internal class AlternateVersion : VersionSubsystem
         {
-            protected override CliExit Execute(PipelineResult pipelineContext)
+            protected override CliExit Execute(PipelineResult pipelineResult)
             {
-                pipelineContext.ConsoleHack.WriteLine($"***{CliExecutable.ExecutableVersion}***");
-                pipelineContext.AlreadyHandled = true;
-                return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);
+                pipelineResult.ConsoleHack.WriteLine($"***{CliExecutable.ExecutableVersion}***");
+                pipelineResult.AlreadyHandled = true;
+                return CliExit.SuccessfullyHandled(pipelineResult.ParseResult);
             }
         }
 
@@ -29,12 +29,12 @@ namespace System.CommandLine.Subsystems.Tests
 
             private CliSymbol Symbol { get; }
 
-            protected override CliExit Execute(PipelineResult pipelineContext)
+            protected override CliExit Execute(PipelineResult pipelineResult)
             {
                 TryGetAnnotation(Symbol, HelpAnnotations.Description, out string? description);
-                pipelineContext.ConsoleHack.WriteLine(description);
-                pipelineContext.AlreadyHandled = true;
-                return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);
+                pipelineResult.ConsoleHack.WriteLine(description);
+                pipelineResult.AlreadyHandled = true;
+                return CliExit.SuccessfullyHandled(pipelineResult.ParseResult);
             }
         }
 
@@ -51,10 +51,10 @@ namespace System.CommandLine.Subsystems.Tests
                 return base.Initialize(context);
             }
 
-            protected override CliExit Execute(PipelineResult pipelineContext)
+            protected override CliExit Execute(PipelineResult pipelineResult)
             {
                 ExecutionWasRun = true;
-                return base.Execute(pipelineContext);
+                return base.Execute(pipelineResult);
             }
 
             protected override CliExit TearDown(CliExit cliExit)

--- a/src/System.CommandLine.Subsystems.Tests/VersionSubsystemTests.cs
+++ b/src/System.CommandLine.Subsystems.Tests/VersionSubsystemTests.cs
@@ -52,7 +52,7 @@ namespace System.CommandLine.Subsystems.Tests
         {
             var consoleHack = new ConsoleHack().RedirectToBuffer(true);
             var versionSubsystem = new VersionSubsystem();
-            Subsystem.Execute(versionSubsystem, new PipelineContext(null, "", null, consoleHack));
+            Subsystem.Execute(versionSubsystem, new PipelineResult(null, "", null, consoleHack));
             consoleHack.GetBuffer().Trim().Should().Be(Constants.version);
         }
 
@@ -64,7 +64,7 @@ namespace System.CommandLine.Subsystems.Tests
             {
                 SpecificVersion = "42"
             };
-            Subsystem.Execute(versionSubsystem, new PipelineContext(null, "", null, consoleHack));
+            Subsystem.Execute(versionSubsystem, new PipelineResult(null, "", null, consoleHack));
             consoleHack.GetBuffer().Trim().Should().Be("42");
         }
 
@@ -76,7 +76,7 @@ namespace System.CommandLine.Subsystems.Tests
             {
                 SpecificVersion = null
             };
-            Subsystem.Execute(versionSubsystem, new PipelineContext(null, "", null, consoleHack));
+            Subsystem.Execute(versionSubsystem, new PipelineResult(null, "", null, consoleHack));
             consoleHack.GetBuffer().Trim().Should().Be(Constants.version);
         }
 
@@ -88,7 +88,7 @@ namespace System.CommandLine.Subsystems.Tests
 
             var consoleHack = new ConsoleHack().RedirectToBuffer(true);
             var versionSubsystem = new VersionSubsystem();
-            Subsystem.Execute(versionSubsystem, new PipelineContext(null, "", null, consoleHack));
+            Subsystem.Execute(versionSubsystem, new PipelineResult(null, "", null, consoleHack));
             consoleHack.GetBuffer().Trim().Should().Be(Constants.version);
         }
 

--- a/src/System.CommandLine.Subsystems/CliExit.cs
+++ b/src/System.CommandLine.Subsystems/CliExit.cs
@@ -8,7 +8,7 @@ namespace System.CommandLine;
     // TODO: Consider what info is needed after invocation. If it's the whole pipeline context, consider collapsing this with that class.
 public class CliExit
 {
-    internal CliExit(PipelineContext pipelineContext)
+    internal CliExit(PipelineResult pipelineContext)
         : this(pipelineContext.ParseResult, pipelineContext.AlreadyHandled, pipelineContext.ExitCode)
     { }
 

--- a/src/System.CommandLine.Subsystems/CliExit.cs
+++ b/src/System.CommandLine.Subsystems/CliExit.cs
@@ -8,8 +8,8 @@ namespace System.CommandLine;
     // TODO: Consider what info is needed after invocation. If it's the whole pipeline context, consider collapsing this with that class.
 public class CliExit
 {
-    internal CliExit(PipelineResult pipelineContext)
-        : this(pipelineContext.ParseResult, pipelineContext.AlreadyHandled, pipelineContext.ExitCode)
+    internal CliExit(PipelineResult pipelineResult)
+        : this(pipelineResult.ParseResult, pipelineResult.AlreadyHandled, pipelineResult.ExitCode)
     { }
 
     private CliExit(ParseResult? parseResult, bool handled, int exitCode)

--- a/src/System.CommandLine.Subsystems/CompletionSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/CompletionSubsystem.cs
@@ -18,9 +18,9 @@ public class CompletionSubsystem : CliSubsystem
             ? false
             : false;
 
-    protected internal override CliExit Execute(PipelineResult pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineResult)
     {
-        pipelineContext.ConsoleHack.WriteLine("Not yet implemented");
-        return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);
+        pipelineResult.ConsoleHack.WriteLine("Not yet implemented");
+        return CliExit.SuccessfullyHandled(pipelineResult.ParseResult);
     }
 }

--- a/src/System.CommandLine.Subsystems/CompletionSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/CompletionSubsystem.cs
@@ -18,7 +18,7 @@ public class CompletionSubsystem : CliSubsystem
             ? false
             : false;
 
-    protected internal override CliExit Execute(PipelineContext pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineContext)
     {
         pipelineContext.ConsoleHack.WriteLine("Not yet implemented");
         return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);

--- a/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
@@ -13,7 +13,7 @@ public class DiagramSubsystem( IAnnotationProvider? annotationProvider = null)
     //protected internal override bool GetIsActivated(ParseResult? parseResult)
     //   => parseResult is not null && option is not null && parseResult.GetValue(option);
 
-    protected internal override CliExit Execute(PipelineContext pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineContext)
     {
         // Gather locations
         //var locations = pipelineContext.ParseResult.LocationMap

--- a/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Directives/DiagramSubsystem.cs
@@ -13,14 +13,14 @@ public class DiagramSubsystem( IAnnotationProvider? annotationProvider = null)
     //protected internal override bool GetIsActivated(ParseResult? parseResult)
     //   => parseResult is not null && option is not null && parseResult.GetValue(option);
 
-    protected internal override CliExit Execute(PipelineResult pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineResult)
     {
         // Gather locations
-        //var locations = pipelineContext.ParseResult.LocationMap
-        //                   .Concat(Map(pipelineContext.ParseResult.Configuration.PreProcessedLocations));
+        //var locations = pipelineResult.ParseResult.LocationMap
+        //                   .Concat(Map(pipelineResult.ParseResult.Configuration.PreProcessedLocations));
 
-        pipelineContext.ConsoleHack.WriteLine("Output diagram");
-        return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);
+        pipelineResult.ConsoleHack.WriteLine("Output diagram");
+        return CliExit.SuccessfullyHandled(pipelineResult.ParseResult);
     }
 
 

--- a/src/System.CommandLine.Subsystems/ErrorReportingSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/ErrorReportingSubsystem.cs
@@ -23,14 +23,14 @@ public class ErrorReportingSubsystem : CliSubsystem
         => parseResult is not null && parseResult.Errors.Any();
 
     // TODO: properly test execute directly when parse result is usable in tests
-    protected internal override CliExit Execute(PipelineContext pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineResult)
     {
-        var _ = pipelineContext.ParseResult
-            ?? throw new ArgumentException("The parse result has not been set", nameof(pipelineContext));
+        var _ = pipelineResult.ParseResult
+            ?? throw new ArgumentException("The parse result has not been set", nameof(pipelineResult));
 
-        Report(pipelineContext.ConsoleHack, pipelineContext.ParseResult.Errors);
+        Report(pipelineResult.ConsoleHack, pipelineResult.ParseResult.Errors);
 
-        return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);
+        return CliExit.SuccessfullyHandled(pipelineResult.ParseResult);
     }
 
     public void Report(ConsoleHack consoleHack, IReadOnlyList<ParseError> errors)

--- a/src/System.CommandLine.Subsystems/HelpSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/HelpSubsystem.cs
@@ -34,7 +34,7 @@ public class HelpSubsystem(IAnnotationProvider? annotationProvider = null)
     protected internal override bool GetIsActivated(ParseResult? parseResult)
         => parseResult is not null && parseResult.GetValue(HelpOption);
 
-    protected internal override CliExit Execute(PipelineContext pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineContext)
     {
         // TODO: Match testable output pattern
         pipelineContext.ConsoleHack.WriteLine("Help me!");

--- a/src/System.CommandLine.Subsystems/HelpSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/HelpSubsystem.cs
@@ -34,11 +34,11 @@ public class HelpSubsystem(IAnnotationProvider? annotationProvider = null)
     protected internal override bool GetIsActivated(ParseResult? parseResult)
         => parseResult is not null && parseResult.GetValue(HelpOption);
 
-    protected internal override CliExit Execute(PipelineResult pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineResult)
     {
         // TODO: Match testable output pattern
-        pipelineContext.ConsoleHack.WriteLine("Help me!");
-        return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);
+        pipelineResult.ConsoleHack.WriteLine("Help me!");
+        return CliExit.SuccessfullyHandled(pipelineResult.ParseResult);
     }
 
     public bool TryGetDescription (CliSymbol symbol, out string? description)

--- a/src/System.CommandLine.Subsystems/Pipeline.cs
+++ b/src/System.CommandLine.Subsystems/Pipeline.cs
@@ -62,9 +62,9 @@ public class Pipeline
 
     public CliExit Execute(ParseResult parseResult, string rawInput, ConsoleHack? consoleHack = null)
     {
-        var pipelineContext = new PipelineResult(parseResult, rawInput, this, consoleHack ?? new ConsoleHack());
-        ExecuteSubsystems(pipelineContext);
-        return new CliExit(pipelineContext);
+        var pipelineResult = new PipelineResult(parseResult, rawInput, this, consoleHack ?? new ConsoleHack());
+        ExecuteSubsystems(pipelineResult);
+        return new CliExit(pipelineResult);
     }
 
     // TODO: Consider whether this should be public. It would simplify testing, but would it do anything else
@@ -94,7 +94,7 @@ public class Pipeline
     /// <summary>
     /// Perform any cleanup operations
     /// </summary>
-    /// <param name="pipelineContext">The context of the current execution</param>
+    /// <param name="pipelineResult">The context of the current execution</param>
     protected virtual CliExit TearDownSubsystems(CliExit cliExit)
     {
         // TODO: Work on this design as the last cliExit wins and they may not all be well behaved
@@ -109,24 +109,24 @@ public class Pipeline
         return cliExit;
     }
 
-    protected virtual void ExecuteSubsystems(PipelineResult pipelineContext)
+    protected virtual void ExecuteSubsystems(PipelineResult pipelineResult)
     {
-        // TODO: Consider redesign where pipelineContext is not modifiable. 
+        // TODO: Consider redesign where pipelineResult is not modifiable. 
         // 
         foreach (var subsystem in Subsystems)
         {
             if (subsystem is not null)
             {
-                pipelineContext = subsystem.ExecuteIfNeeded(pipelineContext);
+                pipelineResult = subsystem.ExecuteIfNeeded(pipelineResult);
             }
         }
     }
 
-    protected static void ExecuteIfNeeded(CliSubsystem? subsystem, PipelineResult pipelineContext)
+    protected static void ExecuteIfNeeded(CliSubsystem? subsystem, PipelineResult pipelineResult)
     {
-        if (subsystem is not null && (!pipelineContext.AlreadyHandled || subsystem.RunsEvenIfAlreadyHandled))
+        if (subsystem is not null && (!pipelineResult.AlreadyHandled || subsystem.RunsEvenIfAlreadyHandled))
         {
-            subsystem.ExecuteIfNeeded(pipelineContext);
+            subsystem.ExecuteIfNeeded(pipelineResult);
         }
     }
 

--- a/src/System.CommandLine.Subsystems/Pipeline.cs
+++ b/src/System.CommandLine.Subsystems/Pipeline.cs
@@ -62,7 +62,7 @@ public class Pipeline
 
     public CliExit Execute(ParseResult parseResult, string rawInput, ConsoleHack? consoleHack = null)
     {
-        var pipelineContext = new PipelineContext(parseResult, rawInput, this, consoleHack ?? new ConsoleHack());
+        var pipelineContext = new PipelineResult(parseResult, rawInput, this, consoleHack ?? new ConsoleHack());
         ExecuteSubsystems(pipelineContext);
         return new CliExit(pipelineContext);
     }
@@ -109,7 +109,7 @@ public class Pipeline
         return cliExit;
     }
 
-    protected virtual void ExecuteSubsystems(PipelineContext pipelineContext)
+    protected virtual void ExecuteSubsystems(PipelineResult pipelineContext)
     {
         // TODO: Consider redesign where pipelineContext is not modifiable. 
         // 
@@ -122,7 +122,7 @@ public class Pipeline
         }
     }
 
-    protected static void ExecuteIfNeeded(CliSubsystem? subsystem, PipelineContext pipelineContext)
+    protected static void ExecuteIfNeeded(CliSubsystem? subsystem, PipelineResult pipelineContext)
     {
         if (subsystem is not null && (!pipelineContext.AlreadyHandled || subsystem.RunsEvenIfAlreadyHandled))
         {

--- a/src/System.CommandLine.Subsystems/Subsystems/CliSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/CliSubsystem.cs
@@ -67,13 +67,13 @@ public abstract class CliSubsystem
     /// </summary>
     /// <param name="pipelineContext">The context contains data like the ParseResult, and allows setting of values like whether execution was handled and the CLI should terminate </param>
     /// <returns>A CliExit object with information such as whether the CLI should terminate</returns>
-    protected internal virtual CliExit Execute(PipelineContext pipelineContext)
+    protected internal virtual CliExit Execute(PipelineResult pipelineContext)
         => CliExit.NotRun(pipelineContext.ParseResult);
 
-    internal PipelineContext ExecuteIfNeeded(PipelineContext pipelineContext)
+    internal PipelineResult ExecuteIfNeeded(PipelineResult pipelineContext)
         => ExecuteIfNeeded(pipelineContext.ParseResult, pipelineContext);
 
-    internal PipelineContext ExecuteIfNeeded(ParseResult? parseResult, PipelineContext pipelineContext)
+    internal PipelineResult ExecuteIfNeeded(ParseResult? parseResult, PipelineResult pipelineContext)
     {
         if (GetIsActivated(parseResult))
         {

--- a/src/System.CommandLine.Subsystems/Subsystems/CliSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/CliSubsystem.cs
@@ -65,21 +65,21 @@ public abstract class CliSubsystem
     /// <summary>
     /// Executes the behavior of the subsystem. For example, help would write information to the console.
     /// </summary>
-    /// <param name="pipelineContext">The context contains data like the ParseResult, and allows setting of values like whether execution was handled and the CLI should terminate </param>
+    /// <param name="pipelineResult">The context contains data like the ParseResult, and allows setting of values like whether execution was handled and the CLI should terminate </param>
     /// <returns>A CliExit object with information such as whether the CLI should terminate</returns>
-    protected internal virtual CliExit Execute(PipelineResult pipelineContext)
-        => CliExit.NotRun(pipelineContext.ParseResult);
+    protected internal virtual CliExit Execute(PipelineResult pipelineResult)
+        => CliExit.NotRun(pipelineResult.ParseResult);
 
-    internal PipelineResult ExecuteIfNeeded(PipelineResult pipelineContext)
-        => ExecuteIfNeeded(pipelineContext.ParseResult, pipelineContext);
+    internal PipelineResult ExecuteIfNeeded(PipelineResult pipelineResult)
+        => ExecuteIfNeeded(pipelineResult.ParseResult, pipelineResult);
 
-    internal PipelineResult ExecuteIfNeeded(ParseResult? parseResult, PipelineResult pipelineContext)
+    internal PipelineResult ExecuteIfNeeded(ParseResult? parseResult, PipelineResult pipelineResult)
     {
         if (GetIsActivated(parseResult))
         {
-            Execute(pipelineContext);
+            Execute(pipelineResult);
         }
-        return pipelineContext;
+        return pipelineResult;
     }
 
 

--- a/src/System.CommandLine.Subsystems/Subsystems/PipelineResult.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/PipelineResult.cs
@@ -3,7 +3,7 @@
 
 namespace System.CommandLine.Subsystems;
 
-public class PipelineContext(ParseResult? parseResult, string rawInput, Pipeline? pipeline, ConsoleHack? consoleHack = null)
+public class PipelineResult(ParseResult? parseResult, string rawInput, Pipeline? pipeline, ConsoleHack? consoleHack = null)
 {
     public ParseResult? ParseResult { get; } = parseResult;
     public string RawInput { get; } = rawInput;

--- a/src/System.CommandLine.Subsystems/Subsystems/Subsystem.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Subsystem.cs
@@ -8,8 +8,8 @@ public class Subsystem
     public static void Initialize(CliSubsystem subsystem, CliConfiguration configuration, IReadOnlyList<string> args)
         => subsystem.Initialize(new InitializationContext(configuration, args));
 
-    public static CliExit Execute(CliSubsystem subsystem, PipelineResult pipelineContext)
-        => subsystem.Execute(pipelineContext);
+    public static CliExit Execute(CliSubsystem subsystem, PipelineResult pipelineResult)
+        => subsystem.Execute(pipelineResult);
 
     public static bool GetIsActivated(CliSubsystem subsystem, ParseResult parseResult)
         => subsystem.GetIsActivated(parseResult);
@@ -21,9 +21,9 @@ public class Subsystem
         => subsystem.Execute(new PipelineResult(parseResult, rawInput, null, consoleHack));
 
 
-    internal static PipelineResult ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack, PipelineResult? pipelineContext = null)
-        => subsystem.ExecuteIfNeeded(pipelineContext ?? new PipelineResult(parseResult, rawInput, null, consoleHack));
+    internal static PipelineResult ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack, PipelineResult? pipelineResult = null)
+        => subsystem.ExecuteIfNeeded(pipelineResult ?? new PipelineResult(parseResult, rawInput, null, consoleHack));
 
-    internal static PipelineResult ExecuteIfNeeded(CliSubsystem subsystem, PipelineResult pipelineContext)
-        => subsystem.ExecuteIfNeeded(pipelineContext);
+    internal static PipelineResult ExecuteIfNeeded(CliSubsystem subsystem, PipelineResult pipelineResult)
+        => subsystem.ExecuteIfNeeded(pipelineResult);
 }

--- a/src/System.CommandLine.Subsystems/Subsystems/Subsystem.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Subsystem.cs
@@ -8,22 +8,22 @@ public class Subsystem
     public static void Initialize(CliSubsystem subsystem, CliConfiguration configuration, IReadOnlyList<string> args)
         => subsystem.Initialize(new InitializationContext(configuration, args));
 
-    public static CliExit Execute(CliSubsystem subsystem, PipelineContext pipelineContext)
+    public static CliExit Execute(CliSubsystem subsystem, PipelineResult pipelineContext)
         => subsystem.Execute(pipelineContext);
 
     public static bool GetIsActivated(CliSubsystem subsystem, ParseResult parseResult)
         => subsystem.GetIsActivated(parseResult);
 
     public static CliExit ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack = null)
-        => new(subsystem.ExecuteIfNeeded(new PipelineContext(parseResult, rawInput, null, consoleHack)));
+        => new(subsystem.ExecuteIfNeeded(new PipelineResult(parseResult, rawInput, null, consoleHack)));
 
     public static CliExit Execute(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack = null)
-        => subsystem.Execute(new PipelineContext(parseResult, rawInput, null, consoleHack));
+        => subsystem.Execute(new PipelineResult(parseResult, rawInput, null, consoleHack));
 
 
-    internal static PipelineContext ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack, PipelineContext? pipelineContext = null)
-        => subsystem.ExecuteIfNeeded(pipelineContext ?? new PipelineContext(parseResult, rawInput, null, consoleHack));
+    internal static PipelineResult ExecuteIfNeeded(CliSubsystem subsystem, ParseResult parseResult, string rawInput, ConsoleHack? consoleHack, PipelineResult? pipelineContext = null)
+        => subsystem.ExecuteIfNeeded(pipelineContext ?? new PipelineResult(parseResult, rawInput, null, consoleHack));
 
-    internal static PipelineContext ExecuteIfNeeded(CliSubsystem subsystem, PipelineContext pipelineContext)
+    internal static PipelineResult ExecuteIfNeeded(CliSubsystem subsystem, PipelineResult pipelineContext)
         => subsystem.ExecuteIfNeeded(pipelineContext);
 }

--- a/src/System.CommandLine.Subsystems/ValueSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/ValueSubsystem.cs
@@ -29,10 +29,10 @@ public class ValueSubsystem(IAnnotationProvider? annotationProvider = null)
     /// <remarks>
     /// Note to inheritors: Call base for all ValueSubsystem methods that you override to ensure correct behavior
     /// </remarks>
-    protected internal override CliExit Execute(PipelineResult pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineResult)
     {
-        parseResult ??= pipelineContext.ParseResult;
-        return base.Execute(pipelineContext);
+        parseResult ??= pipelineResult.ParseResult;
+        return base.Execute(pipelineResult);
     }
 
     private void SetValue<T>(CliSymbol symbol, object? value)

--- a/src/System.CommandLine.Subsystems/ValueSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/ValueSubsystem.cs
@@ -29,7 +29,7 @@ public class ValueSubsystem(IAnnotationProvider? annotationProvider = null)
     /// <remarks>
     /// Note to inheritors: Call base for all ValueSubsystem methods that you override to ensure correct behavior
     /// </remarks>
-    protected internal override CliExit Execute(PipelineContext pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineContext)
     {
         parseResult ??= pipelineContext.ParseResult;
         return base.Execute(pipelineContext);

--- a/src/System.CommandLine.Subsystems/VersionSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/VersionSubsystem.cs
@@ -49,7 +49,7 @@ public class VersionSubsystem : CliSubsystem
     protected internal override bool GetIsActivated(ParseResult? parseResult)
         => parseResult is not null && parseResult.GetValue<bool>("--version");
 
-    protected internal override CliExit Execute(PipelineContext pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineContext)
     {
         var subsystemVersion = SpecificVersion;
         var version = subsystemVersion is null

--- a/src/System.CommandLine.Subsystems/VersionSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/VersionSubsystem.cs
@@ -49,15 +49,15 @@ public class VersionSubsystem : CliSubsystem
     protected internal override bool GetIsActivated(ParseResult? parseResult)
         => parseResult is not null && parseResult.GetValue<bool>("--version");
 
-    protected internal override CliExit Execute(PipelineResult pipelineContext)
+    protected internal override CliExit Execute(PipelineResult pipelineResult)
     {
         var subsystemVersion = SpecificVersion;
         var version = subsystemVersion is null
             ? CliExecutable.ExecutableVersion
             : subsystemVersion;
-        pipelineContext.ConsoleHack.WriteLine(version);
-        pipelineContext.AlreadyHandled = true;
-        return CliExit.SuccessfullyHandled(pipelineContext.ParseResult);
+        pipelineResult.ConsoleHack.WriteLine(version);
+        pipelineResult.AlreadyHandled = true;
+        return CliExit.SuccessfullyHandled(pipelineResult.ParseResult);
     }
 }
 


### PR DESCRIPTION
Previously, `PipelineContext` was ephemeral, subsystems carried input specific caches (oops), was often recreated, and the return was `CliExit`.

Now, `PipelineResult` carries all three purposes and a single instance is used for the life of the pipeline run (per call to `Execute`)

~~_This is currently in draft state because it will have merge conflicts with #2413, includes all the commits from #2413, and because it needs a cleanup/my review pass_~~ Edit: Now up to date with those PRs