### PR TITLE
Dispose StreamReader reading from disk in XmlDocReader

### DIFF
--- a/src/System.CommandLine.DragonFruit/XmlDocReader.cs
+++ b/src/System.CommandLine.DragonFruit/XmlDocReader.cs
@@ -23,7 +23,8 @@ namespace System.CommandLine.DragonFruit
         {
             try
             {
-                return TryLoad(File.OpenText(filePath), out xmlDocReader);
+                using var fileStreamReader = File.OpenText(filePath);
+                return TryLoad(fileStreamReader, out xmlDocReader);
             }
             catch
             {


### PR DESCRIPTION
We create a `StreamReader` via `File.OpenText`, but never `Dispose()` it. Wrap it in a `using` statement to automatically `Dispose()` it when `TryLoad(TextReader, ...)` is done using it.