### PR TITLE
Remove type from annotation ID

### DIFF
--- a/src/System.CommandLine.Subsystems/HelpAnnotationExtensions.cs
+++ b/src/System.CommandLine.Subsystems/HelpAnnotationExtensions.cs
@@ -45,6 +45,6 @@ public static class HelpAnnotationExtensions
     /// </remarks>
     public static string? GetDescription<TSymbol>(this TSymbol symbol) where TSymbol : CliSymbol
     {
-        return symbol.GetAnnotationOrDefault(HelpAnnotations.Description);
+        return symbol.GetAnnotationOrDefault<string>(HelpAnnotations.Description);
     }
 }

--- a/src/System.CommandLine.Subsystems/Subsystems/Annotations/AnnotationId.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Annotations/AnnotationId.cs
@@ -6,7 +6,7 @@ namespace System.CommandLine.Subsystems.Annotations;
 /// <summary>
 /// Describes the ID and type of an annotation.
 /// </summary>
-public record struct AnnotationId<TValue>(string Prefix, string Id)
+public record struct AnnotationId(string Prefix, string Id)
 {
     public override readonly string ToString() => $"{Prefix}.{Id}";
 }

--- a/src/System.CommandLine.Subsystems/Subsystems/Annotations/AnnotationStorageExtensions.AnnotationStorage.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Annotations/AnnotationStorageExtensions.AnnotationStorage.cs
@@ -11,25 +11,16 @@ partial class AnnotationStorageExtensions
     {
         record struct AnnotationKey(CliSymbol symbol, string prefix, string id)
         {
-            public static AnnotationKey Create<TAnnotation> (CliSymbol symbol, AnnotationId<TAnnotation> annotationId)
+            public static AnnotationKey Create (CliSymbol symbol, AnnotationId annotationId)
                 => new (symbol, annotationId.Prefix, annotationId.Id);
         }
 
         readonly Dictionary<AnnotationKey, object> annotations = [];
 
-        public bool TryGet<TValue>(CliSymbol symbol, AnnotationId<TValue> annotationId, [NotNullWhen(true)] out TValue? value)
-        {
-            if (annotations.TryGetValue(AnnotationKey.Create(symbol, annotationId), out var obj))
-            {
-                value = (TValue)obj;
-                return true;
-            }
+        public bool TryGet(CliSymbol symbol, AnnotationId annotationId, [NotNullWhen(true)] out object? value)
+            => annotations.TryGetValue(AnnotationKey.Create(symbol, annotationId), out value);
 
-            value = default;
-            return false;
-        }
-
-        public void Set<TValue>(CliSymbol symbol, AnnotationId<TValue> annotationId, TValue value)
+        public void Set(CliSymbol symbol, AnnotationId annotationId, object? value)
         {
             var key = AnnotationKey.Create(symbol, annotationId);
             if (value is not null)

--- a/src/System.CommandLine.Subsystems/Subsystems/Annotations/AnnotationTypeException.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Annotations/AnnotationTypeException.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine.Subsystems.Annotations;
+
+/// <summary>
+/// Thrown when an annotation value does not match the expected type for that <see cref="AnnotationId"/>.
+/// </summary>
+public class AnnotationTypeException(AnnotationId annotationId, Type expectedType, Type? actualType, IAnnotationProvider? provider = null) : Exception
+{
+    public AnnotationId AnnotationId { get; } = annotationId;
+    public Type ExpectedType { get; } = expectedType;
+    public Type? ActualType { get; } = actualType;
+    public IAnnotationProvider? Provider = provider;
+
+    public override string Message
+    {
+        get
+        {
+            if (Provider is not null)
+            {
+                return
+                    $"Typed accessor for annotation '${AnnotationId}' expected type '{ExpectedType}' but the annotation provider returned an annotation of type '{ActualType?.ToString() ?? "[null]"}'. " +
+                    $"This may be an authoring error in in the annotation provider '{Provider.GetType()}' or in a typed annotation accessor.";
+
+            }
+
+            return
+                $"Typed accessor for annotation '${AnnotationId}' expected type '{ExpectedType}' but the stored annotation is of type '{ActualType?.ToString() ?? "[null]"}'. " +
+                $"This may be an authoring error in a typed annotation accessor, or the annotation may have be stored directly with the incorrect type, bypassing the typed accessors.";
+        }
+    }
+}

--- a/src/System.CommandLine.Subsystems/Subsystems/Annotations/HelpAnnotations.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Annotations/HelpAnnotations.cs
@@ -10,5 +10,8 @@ public static class HelpAnnotations
 {
     public static string Prefix { get; } = nameof(SubsystemKind.Help);
 
-    public static AnnotationId<string> Description { get; } = new(Prefix, nameof(Description));
+    /// <summary>
+    /// The description of the symbol, as a plain text <see cref="string"/>.
+    /// </summary>
+    public static AnnotationId Description { get; } = new(Prefix, nameof(Description));
 }

--- a/src/System.CommandLine.Subsystems/Subsystems/Annotations/ValueAnnotations.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Annotations/ValueAnnotations.cs
@@ -14,18 +14,20 @@ public static class ValueAnnotations
     /// Default value for an option or argument
     /// </summary>
     /// <remarks>
-    /// Although the type is <see cref="object?"/>, it must actually be the same type as the type
-    /// parameter of the <see cref="CliArgument{T}"/> or <see cref="CliOption{T}"/>.
+    /// Must be actually the same type as the type parameter of
+    /// the <see cref="CliArgument{T}"/> or <see cref="CliOption{T}"/>.
     /// </remarks>
-    public static AnnotationId<object?> DefaultValue { get; } = new(Prefix, nameof(DefaultValue));
+    public static AnnotationId DefaultValue { get; } = new(Prefix, nameof(DefaultValue));
 
     /// <summary>
     /// Default value calculation for an option or argument
     /// </summary>
     /// <remarks>
-    /// Although the type is <see cref="object?"/>, it must actually be a <see cref="Func{TResult}">
-    /// with a type parameter matching the the type parameter type of the <see cref="CliArgument{T}"/>
-    /// or <see cref="CliOption{T}"/>
+    /// Please use the extension methods and do not call this directly.
+    /// <para>
+    /// Must return a <see cref="Func{TValue}"> with the same type parameter as
+    /// the <see cref="CliArgument{T}"/> or <see cref="CliOption{T}"/>.
+    /// </para>
     /// </remarks>
-    public static AnnotationId<object> DefaultValueCalculation { get; } = new(Prefix, nameof(DefaultValueCalculation));
+    public static AnnotationId DefaultValueCalculation { get; } = new(Prefix, nameof(DefaultValueCalculation));
 }

--- a/src/System.CommandLine.Subsystems/Subsystems/CliSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/CliSubsystem.cs
@@ -36,7 +36,11 @@ public abstract class CliSubsystem
     /// Attempt to retrieve the <paramref name="symbol"/>'s value for the annotation <paramref name="id"/>. This will check the
     /// annotation provider that was passed to the subsystem constructor, and the internal annotation storage.
     /// </summary>
-    /// <typeparam name="TValue">The value of the type to retrieve</typeparam>
+    /// <typeparam name="TValue">
+    /// The expected type of the annotation value. If the type does not match, a <see cref="AnnotationTypeException"/> will be thrown.
+    /// If the annotation allows multiple types for its values, and a type parameter cannot be determined statically,
+    /// use <see cref="TryGetAnnotation(CliSymbol, AnnotationId, out object?)"/> to access the annotation value without checking its type.
+    /// </typeparam>
     /// <param name="symbol">The symbol the value is attached to</param>
     /// <param name="id">
     /// The identifier for the annotation value to be retrieved.
@@ -45,10 +49,46 @@ public abstract class CliSubsystem
     /// <param name="value">An out parameter to contain the result</param>
     /// <returns>True if successful</returns>
     /// <remarks>
+    /// If the annotation value does not have a single expected type for this symbol, use the <see cref="TryGetAnnotation(CliSymbol, AnnotationId, out object?)"/> overload instead.
+    /// <para>
     /// Subsystem authors must use this to access annotation values, as it respects the subsystem's <see cref="IAnnotationProvider"/> if it has one.
     /// This value is protected because it is intended for use only by subsystem authors. It calls <see cref="AnnotationStorageExtensions"/>
+    /// </para>
     /// </remarks>
-    protected internal bool TryGetAnnotation<TValue>(CliSymbol symbol, AnnotationId<TValue> annotationId, [NotNullWhen(true)] out TValue? value)
+    protected internal bool TryGetAnnotation<TValue>(CliSymbol symbol, AnnotationId annotationId, [NotNullWhen(true)] out TValue? value)
+    {
+        if (_annotationProvider is not null && _annotationProvider.TryGet(symbol, annotationId, out object? rawValue))
+        {
+            if (rawValue is TValue expectedTypeValue)
+            {
+                value = expectedTypeValue;
+                return true;
+            }
+            throw new AnnotationTypeException(annotationId, typeof(TValue), rawValue?.GetType(), _annotationProvider);
+        }
+
+        return symbol.TryGetAnnotation(annotationId, out value);
+    }
+
+    /// <summary>
+    /// Attempt to retrieve the <paramref name="symbol"/>'s value for the annotation <paramref name="id"/>. This will check the
+    /// annotation provider that was passed to the subsystem constructor, and the internal annotation storage.
+    /// </summary>
+    /// <param name="symbol">The symbol the value is attached to</param>
+    /// <param name="id">
+    /// The identifier for the annotation value to be retrieved.
+    /// For example, the annotation identifier for the help description is <see cref="HelpAnnotations.Description">.
+    /// </param>
+    /// <param name="value">An out parameter to contain the result</param>
+    /// <returns>True if successful</returns>
+    /// <remarks>
+    /// If the expected type of the annotation value is known, use the <see cref="TryGetAnnotation{TValue}(CliSymbol, AnnotationId, out TValue?)"/> overload instead.
+    /// <para>
+    /// Subsystem authors must use this to access annotation values, as it respects the subsystem's <see cref="IAnnotationProvider"/> if it has one.
+    /// This value is protected because it is intended for use only by subsystem authors. It calls <see cref="AnnotationStorageExtensions"/>
+    /// </para>
+    /// </remarks>
+    protected internal bool TryGetAnnotation(CliSymbol symbol, AnnotationId annotationId, [NotNullWhen(true)] out object? value)
     {
         if (_annotationProvider is not null && _annotationProvider.TryGet(symbol, annotationId, out value))
         {

--- a/src/System.CommandLine.Subsystems/Subsystems/IAnnotationProvider.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/IAnnotationProvider.cs
@@ -11,5 +11,5 @@ namespace System.CommandLine.Subsystems;
 /// </summary>
 public interface IAnnotationProvider
 {
-    bool TryGet<TValue>(CliSymbol symbol, AnnotationId<TValue> id, [NotNullWhen(true)] out TValue? value);
+    bool TryGet(CliSymbol symbol, AnnotationId id, [NotNullWhen(true)] out object? value);
 }

--- a/src/System.CommandLine.Subsystems/ValueAnnotationExtensions.cs
+++ b/src/System.CommandLine.Subsystems/ValueAnnotationExtensions.cs
@@ -45,9 +45,9 @@ public static class ValueAnnotationExtensions
     /// </remarks>
     public static TValue? GetDefaultValueAnnotation<TValue>(this CliOption<TValue> option)
     {
-        if (option.TryGetAnnotation(ValueAnnotations.DefaultValue, out var defaultValue))
+        if (option.TryGetAnnotation(ValueAnnotations.DefaultValue, out TValue? defaultValue))
         {
-            return (TValue?)defaultValue;
+            return defaultValue;
         }
         return default;
     }
@@ -90,7 +90,7 @@ public static class ValueAnnotationExtensions
     /// </remarks>
     public static TValue? GetDefaultValueAnnotation<TValue>(this CliArgument<TValue> argument)
     {
-        if (argument.TryGetAnnotation(ValueAnnotations.DefaultValue, out var defaultValue))
+        if (argument.TryGetAnnotation(ValueAnnotations.DefaultValue, out TValue? defaultValue))
         {
             return (TValue?)defaultValue;
         }
@@ -134,9 +134,9 @@ public static class ValueAnnotationExtensions
     /// </remarks>
     public static Func<TValue?>? GetDefaultValueCalculation<TValue>(this CliOption<TValue> option)
     {
-        if (option.TryGetAnnotation(ValueAnnotations.DefaultValueCalculation, out var defaultValueCalculation))
+        if (option.TryGetAnnotation(ValueAnnotations.DefaultValueCalculation, out Func<TValue?>? defaultValueCalculation))
         {
-            return (Func<TValue?>)defaultValueCalculation;
+            return defaultValueCalculation;
         }
         return default;
     }
@@ -179,9 +179,9 @@ public static class ValueAnnotationExtensions
     /// </remarks>
     public static Func<TValue?>? GetDefaultValueCalculation<TValue>(this CliArgument<TValue> argument)
     {
-        if (argument.TryGetAnnotation(ValueAnnotations.DefaultValueCalculation, out var defaultValueCalculation))
+        if (argument.TryGetAnnotation(ValueAnnotations.DefaultValueCalculation, out Func<TValue?>? defaultValueCalculation))
         {
-            return (Func<TValue?>)defaultValueCalculation;
+            return defaultValueCalculation;
         }
         return default;
     }

--- a/src/System.CommandLine.Subsystems/ValueSubsystem.cs
+++ b/src/System.CommandLine.Subsystems/ValueSubsystem.cs
@@ -74,10 +74,10 @@ public class ValueSubsystem(IAnnotationProvider? annotationProvider = null)
             // configuration values go here in precedence
             //not null when GetDefaultFromEnvironmentVariable<T>(symbol, out var envName)
             //    => UseValue(symbol, GetEnvByName(envName)),
-            not null when TryGetAnnotation(symbol, ValueAnnotations.DefaultValueCalculation, out var defaultValueCalculation)
+            not null when TryGetAnnotation(symbol, ValueAnnotations.DefaultValueCalculation, out Func<T?>? defaultValueCalculation)
                 => UseValue(symbol, CalculatedDefault<T>(symbol, (Func<T?>)defaultValueCalculation)),
-            not null when TryGetAnnotation(symbol, ValueAnnotations.DefaultValue, out var explicitValue)
-                => UseValue<T>(symbol, (T)explicitValue),
+            not null when TryGetAnnotation(symbol, ValueAnnotations.DefaultValue, out T? explicitValue)
+                => UseValue(symbol, explicitValue),
             null => throw new ArgumentNullException(nameof(symbol)),
             _ => UseValue(symbol, default(T))
         };


### PR DESCRIPTION
The purpose of this was to ensure that accessors used the correct type for the annotation values. This originally applied to the `AnnotationAccessor<T>` helper for `symbol.With(help.Description, desc)` but also applied to later manually defined accessors.

This strong typing was not perfect, for example it was possible to (incorrectly) define two annotations with the same ID and different types, resulting in uninformative cast exceptions.

It also did not apply cleanly to more advanced cases, such as when the value was a `Func<T>` or where the annotation value type was based on the symbol value type. It is also not unreasonable to want to store more than one type in an annotation for other reasons. All these required removing the typing by using `AnnotationId<object?>`.

This makes things a bit cleaner by removing the strong typing from the annotation ID and instead adding `TryGetAnnotation` overloads that take a type and throw an informative exception on mismatch.

This only affects folks defining new annotations. It does not change anything for authors of CLIs or authors of subsystems, as they should to use the strongly typed accessors that should be defined along with every annotation ID.