### PR TITLE
Fix dotnet-suggest zsh completion shim

### DIFF
--- a/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh
+++ b/src/System.CommandLine.Suggest/dotnet-suggest-shim.zsh
@@ -14,7 +14,7 @@ _dotnet_zsh_complete()
     full_line="$words"
 
     # Get the completion results, will be newline-delimited
-    completions=$(dotnet suggest get --executable "$full_path" -- "$full_line")
+    completions=$(dotnet-suggest get --executable "$full_path" -- "$full_line")
     # explode the completions by linefeed instead of by spaces into the descriptions for the
     # _values helper function.
     


### PR DESCRIPTION
The zsh completion script has a subtle error in which it calls `dotnet suggest` instead of `dotnet-suggest`.
This error makes tab completion on zsh non-functional for me.

To trigger the error:
1. Install `dotnet-suggest` per the instructions here: https://learn.microsoft.com/en-us/dotnet/standard/commandline/tab-completion
2. Shim completions in zsh
3. Reload shell
4. Trigger completions with `% dotnet-suggest <tab>`
5. See the following output (`%` is the zsh prompt, `<tab>` indicates when to press the tab key):
```
% dotnet-suggest <tab>Could not execute because the specified command or file was not found.
        dotnet-suggest
  * You intended to execute a .NET program, but dotnet-get does not exist.^M
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
  * You misspelled a built-in dotnet command.^M
Possible reasons for this include
```

The output is from the `dotnet` tool itself:
```
% dotnet suggest get
Could not execute because the specified command or file was not found.
Possible reasons for this include:
  * You misspelled a built-in dotnet command.
  * You intended to execute a .NET program, but dotnet-get does not exist.
  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
```

If I fix the shim (i.e., `dotnet suggest -> dotnet-suggest`) and reload the shell, the completions work as-expected:
```
% dotnet-suggest <tab>
--help     -?         /?         get        register
--version  -h         /h         list       script
```

The bash and powershell scripts correctly use `dotnet-suggest`:
- Bash: https://github.com/dotnet/command-line-api/blob/803d8598f98fb4efd94604b32627ee9407f246db/src/System.CommandLine.Suggest/dotnet-suggest-shim.bash#L4
- Powershell: https://github.com/dotnet/command-line-api/blob/803d8598f98fb4efd94604b32627ee9407f246db/src/System.CommandLine.Suggest/dotnet-suggest-shim.ps1#L12
