### PR TITLE
Added Calculated Symbols and improved ValueProvider

### DIFF
--- a/OpenQuestions.md
+++ b/OpenQuestions.md
@@ -42,7 +42,7 @@ The first probably means we pass around `PipelineResult`. The second means that 
 
 We started with `Validators` and then added the IValidator interface to allow conditions to do validation because they have the strong type. Checking for this first also avoids a dictionary lookup.
 
-Our default validations will be on the Condition for the shortcut. Users can offer alternatives by creaing custom validators. The dictionary for custom validators will be lazy, and lookups will be pay for play when the user has custom validators. (This is not yet implemented.)
+Our default validations will be on the Condition for the shortcut. Users can offer alternatives by creating custom validators. The dictionary for custom validators will be lazy, and lookups will be pay for play when the user has custom validators. (This is not yet implemented.)
 
 When present, custom validators have precedence. There is no cost when they are not present.
 
@@ -57,3 +57,28 @@ Suggestion: Use internal constructors and leave conditions public
 ## Should `ValueCondition` be called `Condition`?
 
 They may apply to commands.
+
+## Can we remove the "Annotations" in xxxxAnnotationExtensions
+
+We have other extensions, such as `AddCalculation`. Where should it go?
+
+They may shift to extension types in the future.
+
+It's a long in Solution Explorer
+
+## Calculated value design
+
+My first direction on the calculated value design was to derive from CliSymbol and treat them similarly to any other CliSymbol. This results in a technical challenge in the way the `Add` method works for CliSymbols - specifically it does not allow adding anything except options and arguments and the design results in infinite recursion if the exception is ignored. While we might be able to finesse this, it indicates just how thing the ice is if we try to "trick" things in the core parser layer. 
+
+Instead calculated values are a new thing. They can contribute symbols when asked - their internal components can be expressed as symbols for help, for example. However, they are not a CliSymbol and for all uses must be separately treated. 
+
+They are held on commands via annotations. Calculated values that should be are not logically located on a symbol should be on the root command.
+
+This will use collection annotations when they are available. For now they are List<CalculatedValue>.
+
+We have a naming challenge that may indicate an underlying need to refactor:
+
+- ValueSource: Knows how to get data from disparate sources - constants, other symbols, environment variables.
+- Calculation: Parameter/property on ValueSources allowing them to be relative to their source
+- CalculatedValue (possibly CliCalculatedValue): A new thing that can be declared by the CliAuthor for late interpretation and type conversions.
+- ValueCondition, ValueSymbol and other places where "Value" allows unification of Option and Argument (and is very, very helpful for that)

--- a/OpenQuestions.md
+++ b/OpenQuestions.md
@@ -82,3 +82,15 @@ We have a naming challenge that may indicate an underlying need to refactor:
 - Calculation: Parameter/property on ValueSources allowing them to be relative to their source
 - CalculatedValue (possibly CliCalculatedValue): A new thing that can be declared by the CliAuthor for late interpretation and type conversions.
 - ValueCondition, ValueSymbol and other places where "Value" allows unification of Option and Argument (and is very, very helpful for that)
+
+## Tests that do not have `InternalsVisibleTo`
+
+Currently all the code we have is in the `internal` scope within the logical layer. As a result, we are not testing how the libary works from the outside. We could take either of these two approaches or do something else, but I think we need to do something soon to validate our design:
+
+- Isolate the very small amount of code that actually needs IVT into an additional test assembly for each logical layer. 
+  - This would result in two new projects and IVT would be removed from the current test project.
+  - The benefit of this approach is that the largest amount of code would be running without IVT.
+- Create "example" projects:
+  - This would result in one or two new projects, two if the dependencies are those that you would use when accessing either the raw parsing behavior or subsystems. Current tests would remain under IVT.
+  - The benefit of this approach is that we will be creating functional tests in the form of "how do I do xxx". Since they are tests, they would not get out of date with the code base.
+  - Another potential benefit would be a bounded space where we could focus on how our APIs work in practice.

--- a/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
+++ b/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
@@ -34,7 +34,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="ValueSourceTests.cs" />
     <Compile Include="ValidationSubsystemTests.cs" />
-    <Compile Include="ValueSubsystemTests.cs" />
+    <Compile Include="ValueProviderTests.cs" />
     <Compile Include="ResponseSubsystemTests.cs" />
     <Compile Include="DirectiveSubsystemTests.cs" />
     <Compile Include="DiagramSubsystemTests.cs" />

--- a/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
+++ b/src/System.CommandLine.Subsystems.Tests/System.CommandLine.Subsystems.Tests.csproj
@@ -4,12 +4,8 @@
     <TargetFrameworks>$(TargetFrameworkForNETSDK)</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);TestApps\**</DefaultExcludesInProjectFolder>
-    <OutputType>Library</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>annotations</Nullable>
-    <!--   
-    <Nullable>enable</Nullable>
-    -->
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
   </PropertyGroup>
 

--- a/src/System.CommandLine.Subsystems.Tests/ValueSourceTests.cs
+++ b/src/System.CommandLine.Subsystems.Tests/ValueSourceTests.cs
@@ -108,7 +108,7 @@ public class ValueSourceTests
     public void RelativeToSymbolValueSource_produces_value_that_was_set()
     {
         var option = new CliOption<int>("-a");
-        var valueSource = new RelativeToSymbolValueSource<int>(option);
+        var valueSource = new SymbolValueSource<int>(option);
 
         var found = valueSource.TryGetTypedValue(EmptyPipelineResult("-a 42", option), out var value);
 
@@ -137,7 +137,7 @@ public class ValueSourceTests
     public void RelativeToSymbolValueSource_from_extension_produces_value_that_was_set()
     {
         var option = new CliOption<int>("-a");
-        var valueSource = new RelativeToSymbolValueSource<int>(option);
+        var valueSource = new SymbolValueSource<int>(option);
 
         var found = valueSource.TryGetTypedValue(EmptyPipelineResult("-a 42", option), out var value);
 
@@ -151,7 +151,7 @@ public class ValueSourceTests
     public void RelativeToEnvironmentVariableValueSource_produces_value_that_was_set()
     {
         var envName = "SYSTEM_COMMANDLINE_TESTING";
-        var valueSource = new RelativeToEnvironmentVariableValueSource<int>(envName);
+        var valueSource = new EnvironmentVariableValueSource<int>(envName);
 
         Environment.SetEnvironmentVariable(envName, "42");
         var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
@@ -184,7 +184,7 @@ public class ValueSourceTests
     public void RelativeToSymbolValueSource_false_if_other_symbol_has_no_default_and_is_missing()
     {
         var option = new CliOption<int>("-a");
-        var valueSource = new RelativeToSymbolValueSource<int>(option);
+        var valueSource = new SymbolValueSource<int>(option);
 
         var found = valueSource.TryGetTypedValue(EmptyPipelineResult("", option), out var value);
         found.Should()
@@ -197,7 +197,7 @@ public class ValueSourceTests
     public void RelativeToEnvironmentVariable_false_if_environment_variable_missing()
     {
         var envName = "SYSTEM_COMMANDLINE_TESTING";
-        var valueSource = new RelativeToEnvironmentVariableValueSource<int>(envName);
+        var valueSource = new EnvironmentVariableValueSource<int>(envName);
 
         var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
 

--- a/src/System.CommandLine.Subsystems.Tests/ValueSourceTests.cs
+++ b/src/System.CommandLine.Subsystems.Tests/ValueSourceTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using FluentAssertions;
+using Microsoft.VisualBasic.FileIO;
 using System.CommandLine.Parsing;
 using System.CommandLine.ValueSources;
 using Xunit;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace System.CommandLine.Subsystems.Tests;
 
@@ -26,13 +28,12 @@ public class ValueSourceTests
     {
         var valueSource = new SimpleValueSource<int>(42);
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
     }
 
     [Fact]
@@ -40,13 +41,12 @@ public class ValueSourceTests
     {
         ValueSource<int> valueSource = 42;
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
     }
 
     [Fact]
@@ -54,13 +54,13 @@ public class ValueSourceTests
     {
         var valueSource = ValueSource.Create(42);
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
+
     }
 
     [Fact]
@@ -68,13 +68,12 @@ public class ValueSourceTests
     {
         var valueSource = new CalculatedValueSource<int>(() => (true, 42));
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
     }
 
     [Fact]
@@ -84,13 +83,12 @@ public class ValueSourceTests
         // ValueSource<int> valueSource2 = (() => 42);
         ValueSource<int> valueSource = (ValueSource<int>)(() => (true, 42)); ;
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
     }
 
     [Fact]
@@ -98,13 +96,12 @@ public class ValueSourceTests
     {
         var valueSource = ValueSource.Create(() => (true, 42));
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
     }
 
     [Fact]
@@ -113,14 +110,13 @@ public class ValueSourceTests
         var option = new CliOption<int>("-a");
         var valueSource = new RelativeToSymbolValueSource<int>(option);
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult("-a 42", option), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
-    
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult("-a 42", option), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
+
     }
 
     [Fact]
@@ -129,13 +125,12 @@ public class ValueSourceTests
         var option = new CliOption<int>("-a");
         ValueSource<int> valueSource = option;
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult("-a 42", option), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult("-a 42", option), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
     }
 
     [Fact]
@@ -144,13 +139,12 @@ public class ValueSourceTests
         var option = new CliOption<int>("-a");
         var valueSource = new RelativeToSymbolValueSource<int>(option);
 
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult("-a 42", option), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
-        Assert.Fail("Typed value not retrieved");
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult("-a 42", option), out var value);
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
     }
 
     [Fact]
@@ -160,16 +154,14 @@ public class ValueSourceTests
         var valueSource = new RelativeToEnvironmentVariableValueSource<int>(envName);
 
         Environment.SetEnvironmentVariable(envName, "42");
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
         Environment.SetEnvironmentVariable(envName, null);
-        Assert.Fail("Typed value not retrieved");
-    }
 
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
+    }
 
     [Fact]
     public void RelativeToEnvironmentVariableValueSource_from_extension_produces_value_that_was_set()
@@ -178,13 +170,41 @@ public class ValueSourceTests
         var valueSource = ValueSource.CreateFromEnvironmentVariable<int>(envName);
 
         Environment.SetEnvironmentVariable(envName, "42");
-        if (valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value))
-        {
-            value.Should()
-               .Be(42);
-            return;
-        }
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
         Environment.SetEnvironmentVariable(envName, null);
-        Assert.Fail("Typed value not retrieved");
+
+        found.Should()
+           .BeTrue();
+        value.Should()
+           .Be(42);
     }
+
+
+    [Fact]
+    public void RelativeToSymbolValueSource_false_if_other_symbol_missing()
+    {
+        var option = new CliOption<int>("-a");
+        var valueSource = new RelativeToSymbolValueSource<int>(option);
+
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult("", option), out var value);
+        found.Should()
+            .BeFalse();
+        value.Should()
+            .Be(default);
+    }
+
+    [Fact]
+    public void RelativeToEnvironmentVariable_false_if_environment_variable_missing()
+    {
+        var envName = "SYSTEM_COMMANDLINE_TESTING";
+        var valueSource = new RelativeToEnvironmentVariableValueSource<int>(envName);
+
+        var found = valueSource.TryGetTypedValue(EmptyPipelineResult(), out var value);
+
+        found.Should()
+            .BeFalse();
+        value.Should()
+            .Be(default);
+    }
+
 }

--- a/src/System.CommandLine.Subsystems.Tests/ValueSourceTests.cs
+++ b/src/System.CommandLine.Subsystems.Tests/ValueSourceTests.cs
@@ -181,7 +181,7 @@ public class ValueSourceTests
 
 
     [Fact]
-    public void RelativeToSymbolValueSource_false_if_other_symbol_missing()
+    public void RelativeToSymbolValueSource_false_if_other_symbol_has_no_default_and_is_missing()
     {
         var option = new CliOption<int>("-a");
         var valueSource = new RelativeToSymbolValueSource<int>(option);

--- a/src/System.CommandLine.Subsystems/CalculatedValue.cs
+++ b/src/System.CommandLine.Subsystems/CalculatedValue.cs
@@ -1,0 +1,69 @@
+﻿using System.CommandLine.ValueSources;
+
+namespace System.CommandLine;
+
+/// <summary>
+/// CalculatedValueSymbol lets ValueSource contribute to the data space of the application
+/// with many standard features such as default values and the ability to participate in help.
+/// </summary>
+/// <remarks>
+/// Known scenarios:
+/// <list type=">">
+/// <item>`dotnet nuget why`: where for historic reasons the first argument is optional and the second is required.</item>
+/// <item>Completions: where the number of items to be displayed may come from an environment variable or a config file.</item>
+/// <item>Compound types: where multiple value symbols contribute to the creation of a type, like -x and -y creating a point.</item>
+/// <item>Reusing a value, for example to avoid multiple reads of a file</item>
+/// </list>
+/// CalculatedValueSymbol's should be available to subsystems, including invocation and conditions.
+/// </remarks>
+public abstract class CalculatedValue : CliValueSymbol
+{
+    protected CalculatedValue(string name, ValueSource valueSource)
+        :base(name)
+    {
+        //Name = name;
+        ValueSource = valueSource;
+    }
+
+    public static CalculatedValue<T> CreateCalculatedValue<T>(string name, ValueSource<T> valueSource)
+       => new(name, valueSource);
+
+    ///// <summary>
+    ///// Gets the name of the symbol.
+    ///// </summary>
+    //public string Name { get; }
+
+    ///// <summary>
+    ///// Gets or sets the <see cref="Type" /> that the argument's parsed tokens will be converted to.
+    ///// </summary>
+    //public abstract Type ValueType { get; }
+
+    public IEnumerable<CliValueSymbol>? AppearAs {  get; set; }
+
+    public ValueSource ValueSource { get; }
+
+    internal bool TryGetValue<T>(PipelineResult pipelineResult, out T? calculatedValue)
+    {
+        if (ValueSource.TryGetValue(pipelineResult, out object? objectValue))
+        {
+            calculatedValue = (T?)objectValue;
+            return true;
+        }
+        calculatedValue = default;
+        return false;
+    }
+}
+
+/// <summary>
+/// CalculatedValueSymbol lets ValueSource contribute to the data space of the application
+/// with many standard features such as default values and the ability to participate in help.
+/// </summary>
+/// <typeparam name="T">The value type of the symbol.</typeparam>
+public class CalculatedValue<T> : CalculatedValue
+{
+    internal CalculatedValue(string name, ValueSource<T> valueSource)
+        : base(name, valueSource)
+    { } 
+    
+    public override Type ValueType { get; } = typeof(T);
+}

--- a/src/System.CommandLine.Subsystems/CalculatedValue.cs
+++ b/src/System.CommandLine.Subsystems/CalculatedValue.cs
@@ -21,25 +21,27 @@ public abstract class CalculatedValue : CliValueSymbol
     protected CalculatedValue(string name, ValueSource valueSource)
         :base(name)
     {
-        //Name = name;
         ValueSource = valueSource;
     }
 
+    /// <summary>
+    /// Create a CalculatedValue.
+    /// </summary>
+    /// <typeparam name="T">The type of the value that can be retrieved via this calculated value.</typeparam>
+    // TODO: Provide name lookup of CalculatedValues
+    /// <param name="name">The name of the calculated value</param>
+    /// <param name="valueSource">The ValueSource used to retrieve the value. If there are defaults/fallbacks, this will be an aggregate value source.</param>
+    /// <returns></returns>
     public static CalculatedValue<T> CreateCalculatedValue<T>(string name, ValueSource<T> valueSource)
        => new(name, valueSource);
 
-    ///// <summary>
-    ///// Gets the name of the symbol.
-    ///// </summary>
-    //public string Name { get; }
-
-    ///// <summary>
-    ///// Gets or sets the <see cref="Type" /> that the argument's parsed tokens will be converted to.
-    ///// </summary>
-    //public abstract Type ValueType { get; }
-
+    // TODO: This feels backwards. Should probably appear on the string array used as the data source.
     public IEnumerable<CliValueSymbol>? AppearAs {  get; set; }
 
+    /// <summary>
+    /// The ValueSource used to retrieve the value. If there are defaults/fallbacks, this will be an
+    /// aggregate value source.
+    /// </summary>
     public ValueSource ValueSource { get; }
 
     internal bool TryGetValue<T>(PipelineResult pipelineResult, out T? calculatedValue)
@@ -65,5 +67,6 @@ public class CalculatedValue<T> : CalculatedValue
         : base(name, valueSource)
     { } 
     
+    /// <inheritdoc/>
     public override Type ValueType { get; } = typeof(T);
 }

--- a/src/System.CommandLine.Subsystems/PipelineResult.cs
+++ b/src/System.CommandLine.Subsystems/PipelineResult.cs
@@ -9,7 +9,7 @@ public class PipelineResult
 {
     // TODO: Try to build workflow so it is illegal to create this without a ParseResult
     private readonly List<ParseError> errors = [];
-    private ValueProvider valueProvider { get; } 
+    private readonly ValueProvider valueProvider;
 
     public PipelineResult(ParseResult parseResult, string rawInput, Pipeline? pipeline, ConsoleHack? consoleHack = null)
     {

--- a/src/System.CommandLine.Subsystems/PipelineResult.cs
+++ b/src/System.CommandLine.Subsystems/PipelineResult.cs
@@ -36,6 +36,14 @@ public class PipelineResult
     public object? GetValue(CliValueSymbol option)
         => valueProvider.GetValue<object>(option);
 
+    public bool TryGetValue<T>(CliValueSymbol valueSymbol, out T? value)
+        => valueProvider.TryGetValue(valueSymbol, out value);
+
+    public bool TryGetValue(CliValueSymbol option, out object? value)
+        => valueProvider.TryGetValue(option, out value);
+
+
+
     public CliValueResult? GetValueResult(CliValueSymbol valueSymbol)
      => ParseResult.GetValueResult(valueSymbol);
 

--- a/src/System.CommandLine.Subsystems/PipelineResult.cs
+++ b/src/System.CommandLine.Subsystems/PipelineResult.cs
@@ -42,11 +42,8 @@ public class PipelineResult
     public bool TryGetValue(CliValueSymbol option, out object? value)
         => valueProvider.TryGetValue(option, out value);
 
-
-
     public CliValueResult? GetValueResult(CliValueSymbol valueSymbol)
      => ParseResult.GetValueResult(valueSymbol);
-
 
     public void AddErrors(IEnumerable<ParseError> errors)
     {

--- a/src/System.CommandLine.Subsystems/Subsystems/Annotations/ValueAnnotations.cs
+++ b/src/System.CommandLine.Subsystems/Subsystems/Annotations/ValueAnnotations.cs
@@ -36,4 +36,9 @@ public static class ValueAnnotations
     /// </para>
     /// </remarks>
     public static AnnotationId DefaultValueCalculation { get; } = new(Prefix, nameof(DefaultValueCalculation));
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static AnnotationId CalculatedValues { get; } = new (Prefix, nameof(CalculatedValues));
 }

--- a/src/System.CommandLine.Subsystems/System.CommandLine.Subsystems.csproj
+++ b/src/System.CommandLine.Subsystems/System.CommandLine.Subsystems.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <RootNamespace>System.CommandLine</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- Enabling the following line identifies missing and malformed XML comments -->
+    <!--<DocumentationFile>path/to/file.xml</DocumentationFile>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.CommandLine.Subsystems/Validation/ValidationContext.cs
+++ b/src/System.CommandLine.Subsystems/Validation/ValidationContext.cs
@@ -3,7 +3,6 @@
 
 using System.CommandLine.Parsing;
 using System.CommandLine.ValueSources;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace System.CommandLine.Validation;
 

--- a/src/System.CommandLine.Subsystems/ValueAnnotationExtensions.cs
+++ b/src/System.CommandLine.Subsystems/ValueAnnotationExtensions.cs
@@ -21,8 +21,8 @@ public static class ValueAnnotationExtensions
     /// which calculates the actual default value, based on the default value annotation and default value calculation,
     /// whether directly stored on the symbol or from the subsystem's <see cref="IAnnotationProvider"/>.
     /// </remarks>
-    public static bool TryGetDefaultValueSource(this CliValueSymbol valueSymbol, [NotNullWhen(true)] out ValueSource? defaultValueSource)
-        => valueSymbol.TryGetAnnotation(ValueAnnotations.DefaultValueSource, out defaultValueSource);
+    public static bool TryGetDefault(this CliValueSymbol valueSymbol, out ValueSource? defaultValueSource)
+        => valueSymbol.TryGetAnnotation(ValueAnnotations.DefaultValue, out defaultValueSource);
 
     /// <summary>
     /// Sets the default value annotation on the <paramref name="option"/>
@@ -30,185 +30,15 @@ public static class ValueAnnotationExtensions
     /// <typeparam name="TValue">The type of the option value</typeparam>
     /// <param name="option">The option</param>
     /// <param name="defaultValue">The default value for the option</param>
-    public static void SetDefaultValueSource(this CliValueSymbol valueSymbol, ValueSource defaultValue)
+    public static void SetDefault<T>(this CliValueSymbol valueSymbol, ValueSource<T> defaultValue)
         => valueSymbol.SetAnnotation(ValueAnnotations.DefaultValue, defaultValue);
 
-
-    /// <summary>
-    /// Sets the default value annotation on the <paramref name="option"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the option value</typeparam>
-    /// <param name="option">The option</param>
-    /// <param name="defaultValue">The default value for the option</param>
-    /// <returns>The <paramref name="option">, to enable fluent construction of symbols with annotations.</returns>
-    public static CliOption<TValue> WithDefaultValue<TValue>(this CliOption<TValue> option, TValue defaultValue)
+    public static void AddCalculatedValue<T>(this CliCommand command, CalculatedValue<T> calculatedValue)
     {
-        option.SetDefaultValue(defaultValue);
-        return option;
-    }
-
-    /// <summary>
-    /// Sets the default value annotation on the <paramref name="option"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the option value</typeparam>
-    /// <param name="option">The option</param>
-    /// <param name="defaultValue">The default value for the option</param>
-    public static void SetDefaultValue<TValue>(this CliOption<TValue> option, TValue defaultValue)
-    {
-        option.SetAnnotation(ValueAnnotations.DefaultValue, defaultValue);
-    }
-
-    /// <summary>
-    /// Get the default value annotation for the <paramref name="option"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the option value</typeparam>
-    /// <param name="option">The option</param>
-    /// <returns>The option's default value annotation if any, otherwise <see langword="null"/></returns>
-    /// <remarks>
-    /// This is intended to be called by CLI authors. Subsystems should instead call <see cref="PipelineResult.GetValue{T}(CliOption)"/>,
-    /// which calculates the actual default value, based on the default value annotation and default value calculation,
-    /// whether directly stored on the symbol or from the subsystem's <see cref="IAnnotationProvider"/>.
-    /// </remarks>
-    public static TValue? GetDefaultValueAnnotation<TValue>(this CliOption<TValue> option)
-    {
-        if (option.TryGetAnnotation(ValueAnnotations.DefaultValue, out TValue? defaultValue))
+        if (!command.TryGetAnnotation<List<CalculatedValue>>(ValueAnnotations.CalculatedValues, out var currentList))
         {
-            return defaultValue;
+            currentList = new List<CalculatedValue>();
         }
-        return default;
-    }
-
-    /// <summary>
-    /// Sets the default value annotation on the <paramref name="argument"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the argument value</typeparam>
-    /// <param name="argument">The argument</param>
-    /// <param name="defaultValue">The default value for the argument</param>
-    /// <returns>The <paramref name="argument">, to enable fluent construction of symbols with annotations.</returns>
-    public static CliArgument<TValue> WithDefaultValue<TValue>(this CliArgument<TValue> argument, TValue defaultValue)
-    {
-        argument.SetDefaultValue(defaultValue);
-        return argument;
-    }
-
-    /// <summary>
-    /// Sets the default value annotation on the <paramref name="argument"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the argument value</typeparam>
-    /// <param name="argument">The argument</param>
-    /// <param name="defaultValue">The default value for the argument</param>
-    /// <returns>The <paramref name="argument">, to enable fluent construction of symbols with annotations.</returns>
-    public static void SetDefaultValue<TValue>(this CliArgument<TValue> argument, TValue defaultValue)
-    {
-        argument.SetAnnotation(ValueAnnotations.DefaultValue, defaultValue);
-    }
-
-    /// <summary>
-    /// Get the default value annotation for the <paramref name="argument"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the argument value</typeparam>
-    /// <param name="argument">The argument</param>
-    /// <returns>The argument's default value annotation if any, otherwise <see langword="null"/></returns>
-    /// <remarks>
-    /// This is intended to be called by CLI authors. Subsystems should instead call <see cref="PipelineResult.GetValue{T}(CliArgument)"/>,
-    /// which calculates the actual default value, based on the default value annotation and default value calculation,
-    /// whether directly stored on the symbol or from the subsystem's <see cref="IAnnotationProvider"/>.
-    /// </remarks>
-    public static TValue? GetDefaultValueAnnotation<TValue>(this CliArgument<TValue> argument)
-    {
-        if (argument.TryGetAnnotation(ValueAnnotations.DefaultValue, out TValue? defaultValue))
-        {
-            return (TValue?)defaultValue;
-        }
-        return default;
-    }
-
-    /// <summary>
-    /// Sets the default value calculation for the <paramref name="option"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the option value</typeparam>
-    /// <param name="option">The option</param>
-    /// <param name="defaultValueCalculation">The default value calculation for the option</param>
-    /// <returns>The <paramref name="option">, to enable fluent construction of symbols with annotations.</returns>
-    public static CliOption<TValue> WithDefaultValueCalculation<TValue>(this CliOption<TValue> option, Func<TValue?> defaultValueCalculation)
-    {
-        option.SetDefaultValueCalculation(defaultValueCalculation);
-        return option;
-    }
-
-    /// <summary>
-    /// Sets the default value calculation for the <paramref name="option"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the option value</typeparam>
-    /// <param name="option">The option</param>
-    /// <param name="defaultValueCalculation">The default value calculation for the option</param>
-    public static void SetDefaultValueCalculation<TValue>(this CliOption<TValue> option, Func<TValue?> defaultValueCalculation)
-    {
-        option.SetAnnotation(ValueAnnotations.DefaultValueCalculation, defaultValueCalculation);
-    }
-
-    /// <summary>
-    /// Get the default value calculation for the <paramref name="option"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the option value</typeparam>
-    /// <param name="option">The option</param>
-    /// <returns>The option's default value calculation if any, otherwise <see langword="null"/></returns>
-    /// <remarks>
-    /// This is intended to be called by CLI authors. Subsystems should instead call <see cref="PipelineResult.GetValue{T}(CliOption)"/>,
-    /// which calculates the actual default value, based on the default value annotation and default value calculation,
-    /// whether directly stored on the symbol or from the subsystem's <see cref="IAnnotationProvider"/>.
-    /// </remarks>
-    public static Func<TValue?>? GetDefaultValueCalculation<TValue>(this CliOption<TValue> option)
-    {
-        if (option.TryGetAnnotation(ValueAnnotations.DefaultValueCalculation, out Func<TValue?>? defaultValueCalculation))
-        {
-            return defaultValueCalculation;
-        }
-        return default;
-    }
-
-    /// <summary>
-    /// Sets the default value calculation for the <paramref name="argument"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the argument value</typeparam>
-    /// <param name="argument">The argument</param>
-    /// <param name="defaultValueCalculation">The default value calculation for the argument</param>
-    /// <returns>The <paramref name="option">, to enable fluent construction of symbols with annotations.</returns>
-    public static CliArgument<TValue> WithDefaultValueCalculation<TValue>(this CliArgument<TValue> argument, Func<TValue?> defaultValueCalculation)
-    {
-        argument.SetDefaultValueCalculation(defaultValueCalculation);
-        return argument;
-    }
-
-    /// <summary>
-    /// Sets the default value calculation for the <paramref name="argument"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the argument value</typeparam>
-    /// <param name="argument">The argument</param>
-    /// <param name="defaultValueCalculation">The default value calculation for the argument</param>
-    /// <returns>The <paramref name="option">, to enable fluent construction of symbols with annotations.</returns>
-    public static void SetDefaultValueCalculation<TValue>(this CliArgument<TValue> argument, Func<TValue?> defaultValueCalculation)
-    {
-        argument.SetAnnotation(ValueAnnotations.DefaultValueCalculation, defaultValueCalculation);
-    }
-
-    /// <summary>
-    /// Get the default value calculation for the <paramref name="argument"/>
-    /// </summary>
-    /// <typeparam name="TValue">The type of the argument value</typeparam>
-    /// <param name="argument">The argument</param>
-    /// <returns>The argument's default value calculation if any, otherwise <see langword="null"/></returns>
-    /// <remarks>
-    /// This is intended to be called by CLI authors. Subsystems should instead call <see cref="PipelineResult.GetValue{T}(CliArgument)"/>,
-    /// which calculates the actual default value, based on the default value annotation and default value calculation,
-    /// whether directly stored on the symbol or from the subsystem's <see cref="IAnnotationProvider"/>.
-    /// </remarks>
-    public static Func<TValue?>? GetDefaultValueCalculation<TValue>(this CliArgument<TValue> argument)
-    {
-        if (argument.TryGetAnnotation(ValueAnnotations.DefaultValueCalculation, out Func<TValue?>? defaultValueCalculation))
-        {
-            return defaultValueCalculation;
-        }
-        return default;
+        currentList.Add(calculatedValue);
     }
 }

--- a/src/System.CommandLine.Subsystems/ValueProvider.cs
+++ b/src/System.CommandLine.Subsystems/ValueProvider.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.ValueSources;
+using CacheItem = (bool found, object? value);
 
 namespace System.CommandLine;
 
 internal class ValueProvider
 {
-    private Dictionary<CliSymbol, object?> cachedValues = [];
+    private Dictionary<CliSymbol, CacheItem> cachedValues = [];
     private PipelineResult pipelineResult;
 
     public ValueProvider(PipelineResult pipelineResult)
@@ -15,66 +16,75 @@ internal class ValueProvider
         this.pipelineResult = pipelineResult;
     }
 
-    private void SetValue(CliSymbol symbol, object? value)
+    private void SetValue(CliSymbol symbol, object? value, bool found)
     {
-        cachedValues[symbol] = value;
+        cachedValues[symbol] = (found, value);
     }
 
-    private bool TryGetValue<T>(CliSymbol symbol, out T? value)
+    private bool TryGetFromCache<T>(CliSymbol symbol, out T? value)
     {
-        if (cachedValues.TryGetValue(symbol, out var objectValue))
+        if (cachedValues.TryGetValue(symbol, out var t))
         {
-            value = objectValue is null
-                ? default
-                : (T)objectValue;
-            return true;
+            if (t.found)
+            {
+                value = (T?)t.value;
+                return true;
+            }
         }
         value = default;
         return false;
     }
 
     public T? GetValue<T>(CliValueSymbol valueSymbol)
-        => GetValueInternal<T>(valueSymbol);
+    {
+        if (TryGetValueInternal<T>(valueSymbol, out var value))
+        {
+            return value;
+        }
+        return default;
+    }
 
-    private T? GetValueInternal<T>(CliValueSymbol valueSymbol)
+    public bool TryGetValue<T>(CliValueSymbol valueSymbol, out T? value)
+        => TryGetValueInternal<T>(valueSymbol, out value);
+
+    private bool TryGetValueInternal<T>(CliValueSymbol valueSymbol, out T? value)
     {
         // TODO: Add guard to prevent reentrancy for the same symbol via RelativeToSymbol of custom ValueSource
         var _ = valueSymbol ?? throw new ArgumentNullException(nameof(valueSymbol));
 
-        if (TryGetFromCache(valueSymbol, out var cachedValue))
+        if (TryGetFromCache(valueSymbol, out value))
         {
-            return cachedValue;
+            return true;
         }
         if (valueSymbol is CalculatedValue calculatedValueSymbol
-            && calculatedValueSymbol.TryGetValue<T>(pipelineResult, out T? calculatedValue))
+            && calculatedValueSymbol.TryGetValue(pipelineResult, out value))
         {
-            return UseValue(valueSymbol, calculatedValue);
+            return CacheAndReturnSuccess(valueSymbol, value, true);
         }
         if (valueSymbol is not CalculatedValue
             && pipelineResult.ParseResult?.GetValueResult(valueSymbol) is { } valueResult)
         {
-            return UseValue(valueSymbol, valueResult.GetValue<T>());
+            value = valueResult.GetValue<T>();
+            return CacheAndReturnSuccess(valueSymbol, value, true);
         }
         if (valueSymbol.TryGetDefault(out ValueSource? defaultValueSource))
         {
             if (defaultValueSource is not ValueSource<T> typedDefaultValueSource)
             {
-                throw new InvalidOperationException("Unexpected ValueSource type");
+                throw new InvalidOperationException("Unexpected ValueSource type for default value.");
             }
-            if (typedDefaultValueSource.TryGetTypedValue(pipelineResult, out T? defaultValue))
+            if (typedDefaultValueSource.TryGetTypedValue(pipelineResult, out value))
             {
-                return UseValue(valueSymbol, defaultValue);
+                return CacheAndReturnSuccess(valueSymbol, value, true);
             }
         }
-        return UseValue(valueSymbol, default(T));
+        // TODO: Determine if we should cache default. If so, additional design is needed to avoid first hit returning false, and remainder returning true
+        return CacheAndReturnSuccess(valueSymbol, default, false);
 
-        bool TryGetFromCache(CliValueSymbol valueSymbol, out T? cachedValue)
-        => TryGetValue<T>(valueSymbol, out cachedValue);
-
-        TValue UseValue<TValue>(CliSymbol symbol, TValue value)
+        bool CacheAndReturnSuccess(CliValueSymbol valueSymbol, T? valueToCache, bool valueFound)
         {
-            SetValue(symbol, value);
-            return value;
+            SetValue(valueSymbol, valueToCache, valueFound);
+            return valueFound;
         }
     }
 }

--- a/src/System.CommandLine.Subsystems/ValueProvider.cs
+++ b/src/System.CommandLine.Subsystems/ValueProvider.cs
@@ -72,8 +72,6 @@ internal class ValueProvider
             }
         }
         // !!! CRITICAL: All returns from this method should set the cache value to clear this pseudo-lock (use CacheAndReturn)
-        // TODO: Using the cache would only work if we gave up the cache returns being strongly typed. 
-        // Consider instead a 
         SetIsCalculating(valueSymbol);
 
         if (valueSymbol is CalculatedValue calculatedValueSymbol

--- a/src/System.CommandLine.Subsystems/ValueSources/CollectionValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/CollectionValueSource.cs
@@ -12,10 +12,10 @@ namespace System.CommandLine.ValueSources;
 /// <param name="calculation">A delegate that returns the requested type.</param>
 /// <param name="description">The description of this value, used to clarify the intent of the values that appear in error messages.</param>
     // TODO: Do we want this to be an aggregate, such that you could build a type from other symbols, calcs and env variables. Ooo aahh
-public sealed class RelativeToSymbolsValueSource<T>
+public sealed class CollectionValueSource<T>
     : ValueSource<T>
 {
-    internal RelativeToSymbolsValueSource(
+    internal CollectionValueSource(
        Func<IEnumerable<object?>, (bool success, T? value)> calculation,
        bool onlyUserEnteredValues = false,
        string? description = null,

--- a/src/System.CommandLine.Subsystems/ValueSources/CollectionValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/CollectionValueSource.cs
@@ -8,10 +8,9 @@ namespace System.CommandLine.ValueSources;
 /// If the calculation delegate is supplied, the returned value of the calculation is returned.
 /// </summary>
 /// <typeparam name="T">The type to be returned, which is almost always the type of the symbol the ValueSource will be used for.</typeparam>
-/// <param name="otherSymbol">The option or argument to return, with the calculation supplied if it is not null.</param>
-/// <param name="calculation">A delegate that returns the requested type.</param>
+/// <param name="otherSymbols">The <see cref="CliOption">, <see cref="CliArgument"/>, or <see cref="CalculatedValue"/> to include as sources.</param>
+/// <param name="calculation">A delegate that returns a value of the type of the collection source, which can be either a single value or a collection of values.</param>
 /// <param name="description">The description of this value, used to clarify the intent of the values that appear in error messages.</param>
-    // TODO: Do we want this to be an aggregate, such that you could build a type from other symbols, calcs and env variables. Ooo aahh
 public sealed class CollectionValueSource<T>
     : ValueSource<T>
 {

--- a/src/System.CommandLine.Subsystems/ValueSources/EnvironmentVariableValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/EnvironmentVariableValueSource.cs
@@ -11,10 +11,10 @@ namespace System.CommandLine.ValueSources;
 /// <param name="environmentVariableName">The name of then environment variable. Note that for some systems, this is case sensitive.</param>
 /// <param name="calculation">A delegate that returns the requested type. If it is not specified, standard type conversions are used.</param>
 /// <param name="description">The description of this value, used to clarify the intent of the values that appear in error messages.</param>
-public sealed class RelativeToEnvironmentVariableValueSource<T>
+public sealed class EnvironmentVariableValueSource<T>
     : ValueSource<T>
 {
-    internal RelativeToEnvironmentVariableValueSource(
+    internal EnvironmentVariableValueSource(
         string environmentVariableName,
         Func<string?, (bool success, T? value)>? calculation = null,
         string? description = null)

--- a/src/System.CommandLine.Subsystems/ValueSources/FallbackValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/FallbackValueSource.cs
@@ -3,11 +3,11 @@
 
 namespace System.CommandLine.ValueSources;
 
-public sealed class AggregateValueSource<T> : ValueSource<T>
+public sealed class FallbackValueSource<T> : ValueSource<T>
 {
     private List<ValueSource<T>> valueSources = [];
 
-    internal AggregateValueSource(ValueSource<T> firstSource,
+    internal FallbackValueSource(ValueSource<T> firstSource,
                                  ValueSource<T> secondSource,
                                  string? description = null,
                                  params ValueSource<T>[] otherSources)
@@ -45,10 +45,10 @@ public sealed class AggregateValueSource<T> : ValueSource<T>
         return source switch
         {
             SimpleValueSource<T> => 0,
-            RelativeToSymbolValueSource<T> => 1,
+            SymbolValueSource<T> => 1,
             CalculatedValueSource<T> => 2,
             //RelativeToConfigurationValueSource<T> => 3,
-            RelativeToEnvironmentVariableValueSource<T> => 4,
+            EnvironmentVariableValueSource<T> => 4,
             _ => 5
         };
     }

--- a/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolValueSource.cs
@@ -14,10 +14,11 @@ namespace System.CommandLine.ValueSources;
 public sealed class RelativeToSymbolValueSource<T>
     : ValueSource<T>
 {
+    // TODO: API differences between this adn RelativeToSymbols are very annoying
     internal RelativeToSymbolValueSource(
        CliValueSymbol otherSymbol,
-       bool onlyUserEnteredValues = false,
        Func<object?, (bool success, T? value)>? calculation = null,
+       bool onlyUserEnteredValues = false,
        string? description = null)
     {
         OtherSymbol = otherSymbol;

--- a/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolValueSource.cs
@@ -40,11 +40,11 @@ public sealed class RelativeToSymbolValueSource<T>
             return false;
         }
 
-        if (pipelineResult.TryGetValue<T>(OtherSymbol, out var otherSymbolValue))
+        if (pipelineResult.TryGetValue(OtherSymbol, out var otherSymbolValue))
         {
             if (Calculation is null)
             {
-                value = otherSymbolValue;
+                value = (T?)otherSymbolValue;
                 return true;
             }
             (var success, var newValue) = Calculation(otherSymbolValue);

--- a/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolValueSource.cs
@@ -40,19 +40,21 @@ public sealed class RelativeToSymbolValueSource<T>
             return false;
         }
 
-        var otherSymbolValue = pipelineResult.GetValue<T>(OtherSymbol);
+        if (pipelineResult.TryGetValue<T>(OtherSymbol, out var otherSymbolValue))
+        {
+            if (Calculation is null)
+            {
+                value = otherSymbolValue;
+                return true;
+            }
+            (var success, var newValue) = Calculation(otherSymbolValue);
+            if (success)
+            {
+                value = newValue;
+                return true;
+            }
+        }
 
-        if (Calculation is null)
-        {
-            value = otherSymbolValue;
-            return true;
-        }
-        (var success, var newValue) = Calculation(otherSymbolValue);
-        if (success)
-        {
-            value = newValue;
-            return true;
-        }
         value = default;
         return false;
     }

--- a/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolsValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolsValueSource.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.CommandLine.ValueSources;
+
+/// <summary>
+/// <see cref="ValueSource"/> that returns the value of the specified other symbol.
+/// If the calculation delegate is supplied, the returned value of the calculation is returned.
+/// </summary>
+/// <typeparam name="T">The type to be returned, which is almost always the type of the symbol the ValueSource will be used for.</typeparam>
+/// <param name="otherSymbol">The option or argument to return, with the calculation supplied if it is not null.</param>
+/// <param name="calculation">A delegate that returns the requested type.</param>
+/// <param name="description">The description of this value, used to clarify the intent of the values that appear in error messages.</param>
+    // TODO: Do we want this to be an aggregate, such that you could build a type from other symbols, calcs and env variables. Ooo aahh
+public sealed class RelativeToSymbolsValueSource<T>
+    : ValueSource<T>
+{
+    internal RelativeToSymbolsValueSource(
+       Func<IEnumerable<object?>, (bool success, T? value)> calculation,
+       bool onlyUserEnteredValues = false,
+       string? description = null,
+       params CliValueSymbol[] otherSymbols)
+    {
+        OtherSymbols = otherSymbols;
+        OnlyUserEnteredValues = onlyUserEnteredValues;
+        Calculation = calculation;
+        Description = description;
+    }
+
+    public override string? Description { get; }
+    public IEnumerable<CliValueSymbol> OtherSymbols { get; }
+    public bool OnlyUserEnteredValues { get; }
+    public Func<IEnumerable<object?>, (bool success, T? value)> Calculation { get; }
+
+    /// <inheritdoc/>
+    public override bool TryGetTypedValue(PipelineResult pipelineResult, out T? value)
+    {
+        // TODO: How do we test for only user values. (no defaults)
+        //if (OnlyUserEnteredValues && pipelineResult.GetValueResult(OtherSymbol) is null)
+        //{
+        //    value = default;
+        //    return false;
+        //}
+
+        var otherSymbolValues = OtherSymbols.Select(GetOtherSymbolValues).ToArray();
+        (var success, var newValue) = Calculation(otherSymbolValues);
+        if (success)
+        {
+            value = newValue;
+            return true;
+        }
+
+        value = default;
+        return false;
+
+        object? GetOtherSymbolValues(CliValueSymbol otherSymbol)
+        {
+            if (pipelineResult.TryGetValue(otherSymbol, out var otherSymbolValue))
+            {
+                return otherSymbolValue;
+            }
+            // TODO: I suspect we will need more data here, such as whether it exists and whether user entered
+            return null;
+        }
+    }
+}
+

--- a/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolsValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/RelativeToSymbolsValueSource.cs
@@ -27,9 +27,25 @@ public sealed class RelativeToSymbolsValueSource<T>
         Description = description;
     }
 
+    /// <summary>
+    /// The description that will be used in messages, such as value conditions
+    /// </summary>
     public override string? Description { get; }
+
+    /// <summary>
+    /// The other symbols that this ValueSource depends on.
+    /// </summary>
     public IEnumerable<CliValueSymbol> OtherSymbols { get; }
+
+    /// <summary>
+    /// If true, default values will not be used.
+    /// </summary>
+    // TODO: Find scenarios for good tests. This is based on intuition not a known scenario. Overall we are pretty aggressive about default values.
     public bool OnlyUserEnteredValues { get; }
+
+    /// <summary>
+    /// The calculation that determines a single value, which might an instance of a complex type, based on the values provided.
+    /// </summary>
     public Func<IEnumerable<object?>, (bool success, T? value)> Calculation { get; }
 
     /// <inheritdoc/>

--- a/src/System.CommandLine.Subsystems/ValueSources/SymbolValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/SymbolValueSource.cs
@@ -11,11 +11,11 @@ namespace System.CommandLine.ValueSources;
 /// <param name="otherSymbol">The option or argument to return, with the calculation supplied if it is not null.</param>
 /// <param name="calculation">A delegate that returns the requested type.</param>
 /// <param name="description">The description of this value, used to clarify the intent of the values that appear in error messages.</param>
-public sealed class RelativeToSymbolValueSource<T>
+public sealed class SymbolValueSource<T>
     : ValueSource<T>
 {
     // TODO: API differences between this adn RelativeToSymbols are very annoying
-    internal RelativeToSymbolValueSource(
+    internal SymbolValueSource(
        CliValueSymbol otherSymbol,
        Func<object?, (bool success, T? value)>? calculation = null,
        bool onlyUserEnteredValues = false,

--- a/src/System.CommandLine.Subsystems/ValueSources/ValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/ValueSource.cs
@@ -34,7 +34,14 @@ public abstract class ValueSource
                                            Func<object?, (bool success, T? value)>? calculation = null,
                                            bool userEnteredValueOnly = false,
                                            string? description = null)
-        => new RelativeToSymbolValueSource<T>(otherSymbol, userEnteredValueOnly, calculation, description);
+        => new RelativeToSymbolValueSource<T>(otherSymbol, calculation, userEnteredValueOnly, description);
+
+    public static ValueSource<T> Create<T>(
+                                       Func<IEnumerable<object?>, (bool success, T? value)> calculation,
+                                       bool userEnteredValueOnly = false,
+                                       string? description = null,
+                                       params CliValueSymbol[] otherSymbols)
+        => new RelativeToSymbolsValueSource<T>(calculation, userEnteredValueOnly, description, otherSymbols);
 
     public static ValueSource<T> Create<T>(ValueSource<T> firstSource,
                                            ValueSource<T> secondSource,

--- a/src/System.CommandLine.Subsystems/ValueSources/ValueSource.cs
+++ b/src/System.CommandLine.Subsystems/ValueSources/ValueSource.cs
@@ -34,25 +34,25 @@ public abstract class ValueSource
                                            Func<object?, (bool success, T? value)>? calculation = null,
                                            bool userEnteredValueOnly = false,
                                            string? description = null)
-        => new RelativeToSymbolValueSource<T>(otherSymbol, calculation, userEnteredValueOnly, description);
+        => new SymbolValueSource<T>(otherSymbol, calculation, userEnteredValueOnly, description);
 
     public static ValueSource<T> Create<T>(
                                        Func<IEnumerable<object?>, (bool success, T? value)> calculation,
                                        bool userEnteredValueOnly = false,
                                        string? description = null,
                                        params CliValueSymbol[] otherSymbols)
-        => new RelativeToSymbolsValueSource<T>(calculation, userEnteredValueOnly, description, otherSymbols);
+        => new CollectionValueSource<T>(calculation, userEnteredValueOnly, description, otherSymbols);
 
     public static ValueSource<T> Create<T>(ValueSource<T> firstSource,
                                            ValueSource<T> secondSource,
                                            string? description = null,
                                            params ValueSource<T>[] otherSources)
-        => new AggregateValueSource<T>(firstSource, secondSource, description, otherSources);
+        => new FallbackValueSource<T>(firstSource, secondSource, description, otherSources);
 
     public static ValueSource<T> CreateFromEnvironmentVariable<T>(string environmentVariableName,
                                                                   Func<string?, (bool success, T? value)>? calculation = null,
                                                                   string? description = null)
-        => new RelativeToEnvironmentVariableValueSource<T>(environmentVariableName, calculation, description);
+        => new EnvironmentVariableValueSource<T>(environmentVariableName, calculation, description);
 }
 
 // TODO: Determine philosophy for custom value sources and whether they can build on existing sources.
@@ -84,7 +84,7 @@ public abstract class ValueSource<T> : ValueSource
 
     public static implicit operator ValueSource<T>(T value) => new SimpleValueSource<T>(value);
     public static implicit operator ValueSource<T>(Func<(bool success, T? value)> calculated) => new CalculatedValueSource<T>(calculated);
-    public static implicit operator ValueSource<T>(CliValueSymbol symbol) => new RelativeToSymbolValueSource<T>(symbol);
+    public static implicit operator ValueSource<T>(CliValueSymbol symbol) => new SymbolValueSource<T>(symbol);
     // Environment variable does not have an explicit operator, because converting to string was too broad
 }
 

--- a/src/System.CommandLine/CliCommand.cs
+++ b/src/System.CommandLine/CliCommand.cs
@@ -27,8 +27,9 @@ namespace System.CommandLine
         internal AliasSet? _aliases;
         private ChildSymbolList<CliArgument>? _arguments;
         private ChildSymbolList<CliOption>? _options;
+        private ChildSymbolList<CliValueSymbol>? _otherValueSymbols;
         private ChildSymbolList<CliCommand>? _subcommands;
-// TODO: validators
+        // TODO: validators
         /*
         private List<Action<CliCommandResult>>? _validators;
 
@@ -78,6 +79,8 @@ namespace System.CommandLine
         // TODO: Consider value of lazy here. It sets up a desire to use awkward approach (HasOptions) for a perf win. Applies to Options and Subcommands also.
         public IList<CliOption> Options => _options ??= new (this);
 
+        public IList<CliValueSymbol> OtherSymbols => _otherValueSymbols ??= new(this);
+
         internal bool HasOptions => _options?.Count > 0;
 
         /// <summary>
@@ -86,7 +89,7 @@ namespace System.CommandLine
         public IList<CliCommand> Subcommands => _subcommands ??= new(this);
 
         internal bool HasSubcommands => _subcommands is not null && _subcommands.Count > 0;
-/*
+        /*
         /// <summary>
         /// Validators to the command. Validators can be used
         /// to create custom validation logic.
@@ -195,7 +198,7 @@ namespace System.CommandLine
 
         // Hide from IntelliSense as it's only to support initializing via C# collection expression
         // More specific efficient overloads are available for all supported symbol types.
-        [DebuggerStepThrough]
+        //[DebuggerStepThrough]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Add(CliSymbol symbol)
         {
@@ -211,9 +214,13 @@ namespace System.CommandLine
             {
                 Add(command);
             }
-            else
+            else if (symbol is CliValueSymbol valueSymbol)
             {
-// TODO: add a localized message here
+                OtherSymbols.Add(valueSymbol);
+            }
+            else 
+            {
+                // TODO: add a localized message here
                 throw new ArgumentException(null, nameof(symbol));
             }
         }


### PR DESCRIPTION
Creating `CalculatedSymbol` exposed flaws in the `ValueProvider` logic, so I went ahead and added the check for reentrancy. These can be severed if needed.

I also started an OpenQuestions document so we can scribble notes.

## Calculated values

The benefits of calculated values:

* Replacing custom parsers with a formal way to _get an array and process it after parsing_
  * Formalizes the pattern and allows us to solve the known and necessary case of `dotnet nuget why`
  * When an array is split at this point, we can apply validation, etc.
* Code reuse if the same concept is used in multiple ways along with the ability to name it
  * For example: "EndOfProbabtion" which is 90 days after hire date may be the first date for certain actions
* Performance if an expensive value is used more than once
  * For example: the current project file may be used both in a _must exist_ and a _default value_ context
* Compound values
  * For example, cases like `Point` where a value may be created from several `CliValueSymbols` just works
  * For example, this could be an easy way to handle things like the dotnet `nuget why` problem where backwards compatibility requires the use of a first argument being optional
* Subsystems that need to define values for the `Pipeline` instance would have a simple place to store them with all the support described here
  * Chet has mentioned this for the number of items returned in large or infinite completions
* Structuring these scenarios would allow documentation of calculated values and how they are calculated

This is a sufficiently small amount of work, that I would recommend it even if only because it solves the `nuget why` problem so elegantly.

## Other notes on the PR

There are also test for `dotnet nuget why` which in `ValueProviderTests`. In this case one array input is split into two values.

I think `CalculatedValues`, along with dependent value sources for validation, will accommodate the majority of current use of custom parsers (which we do not plan to support).

We should discuss the API for `CalculatedValue` with multiple input symbols. This is needed for the compositing problem, which is demonstrated by the Point2D test in `ValueProviderTests`. This is particularly ugly because RelativeToSymbolValueSource nad RelativeToSymbolsValueSource have a different order of parameters due to params and default values. However, there is first a deeper discussion on whether it should be multiple symbols, or an aggregate that can handle any ValueSource. For example, it is an easy hop from where we are in this PR to a value that relies on a combination of calculations with no dependency (such as offsets from today), values that are calculated relative to another symbol, and ones that are relative to an environment variable. It's all just how we allow people to use `ValueSource`


