### PR TITLE
Add support for 9.0 VMR controls

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -9,7 +9,7 @@
 
   <Target Name="ConfigureInnerBuildArg"
           BeforeTargets="GetSourceBuildCommandConfiguration"
-          Condition="'$(ArcadeBuildFromSource)' == 'true'">
+          Condition="'$(ArcadeBuildFromSource)' == 'true' or '$(DotNetBuild)' == 'true'">
     <PropertyGroup>
       <InnerBuildArgs>$(InnerBuildArgs) /p:Projects="$(InnerSourceBuildRepoRoot)sourcebuild.slnf"</InnerBuildArgs>
     </PropertyGroup>

--- a/src/System.CommandLine.Generator.Tests/System.CommandLine.Generator.Tests.csproj
+++ b/src/System.CommandLine.Generator.Tests/System.CommandLine.Generator.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>$(TargetFrameworkForNETSDK);$(NetFrameworkCurrent)</TargetFrameworks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj
+++ b/src/System.CommandLine.Hosting/System.CommandLine.Hosting.csproj
@@ -12,6 +12,7 @@
 
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These have an effect when building from the VMR and allow us to remove the old control schema (DotNetBuildFrom*, ExcludeFromSourceBuild, etc.) in 10.0 arcade.