### PR TITLE
Update source-build team references

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
 
 <Project>
 

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file or making other Source Build related changes, include @dotnet/source-build as a reviewer. -->
 <!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
 
 <UsageData>


### PR DESCRIPTION
The @dotnet/source-build-internal team is being deprecated. All references to it were updated.

Related to https://github.com/dotnet/source-build/issues/4645