### PR TITLE
Cli prefix changes

### DIFF
--- a/samples/HostingPlayground/Program.cs
+++ b/samples/HostingPlayground/Program.cs
@@ -22,15 +22,15 @@ namespace HostingPlayground
                 })
             .InvokeAsync(args);
 
-        private static CliConfiguration BuildCommandLine()
+        private static CommandLineConfiguration BuildCommandLine()
         {
-            var root = new CliRootCommand(@"$ dotnet run --name 'Joe'"){
-                new CliOption<string>("--name"){
+            var root = new RootCommand(@"$ dotnet run --name 'Joe'"){
+                new Option<string>("--name"){
                     Required = true
                 }
             };
             root.Action = CommandHandler.Create<GreeterOptions, IHost>(Run);
-            return new CliConfiguration(root);
+            return new CommandLineConfiguration(root);
         }
 
         private static void Run(GreeterOptions options, IHost host)

--- a/src/Common/ArgumentBuilder.cs
+++ b/src/Common/ArgumentBuilder.cs
@@ -9,12 +9,12 @@ internal static class ArgumentBuilder
 
     static ArgumentBuilder()
     {
-        _ctor = typeof(CliArgument<string>).GetConstructor(new[] { typeof(string) });
+        _ctor = typeof(Argument<string>).GetConstructor(new[] { typeof(string) });
     }
 
-    public static CliArgument CreateArgument(Type valueType, string name = "value")
+    public static Argument CreateArgument(Type valueType, string name = "value")
     {
-        var argumentType = typeof(CliArgument<>).MakeGenericType(valueType);
+        var argumentType = typeof(Argument<>).MakeGenericType(valueType);
 
 #if NET6_0_OR_GREATER
         var ctor = (ConstructorInfo)argumentType.GetMemberWithSameMetadataDefinitionAs(_ctor);
@@ -22,10 +22,10 @@ internal static class ArgumentBuilder
         var ctor = argumentType.GetConstructor(new[] { typeof(string) });
 #endif
 
-        return (CliArgument)ctor.Invoke(new object[] { name });
+        return (Argument)ctor.Invoke(new object[] { name });
     }
 
-    internal static CliArgument CreateArgument(ParameterInfo argsParam)
+    internal static Argument CreateArgument(ParameterInfo argsParam)
     {
         if (!argsParam.HasDefaultValue)
         {
@@ -36,10 +36,10 @@ internal static class ArgumentBuilder
 
         var ctor = argumentType.GetConstructor(new[] { typeof(string), argsParam.ParameterType });
 
-        return (CliArgument)ctor.Invoke(new object[] { argsParam.Name, argsParam.DefaultValue });
+        return (Argument)ctor.Invoke(new object[] { argsParam.Name, argsParam.DefaultValue });
     }
 
-    private sealed class Bridge<T> : CliArgument<T>
+    private sealed class Bridge<T> : Argument<T>
     {
         public Bridge(string name, T defaultValue)
             : base(name)

--- a/src/Common/OptionBuilder.cs
+++ b/src/Common/OptionBuilder.cs
@@ -11,12 +11,12 @@ internal static class OptionBuilder
 
     static OptionBuilder()
     {
-        _ctor = typeof(CliOption<string>).GetConstructor(new[] { typeof(string), typeof(string[]) });
+        _ctor = typeof(Option<string>).GetConstructor(new[] { typeof(string), typeof(string[]) });
     }
 
-    internal static CliOption CreateOption(string name, Type valueType, string description = null)
+    internal static Option CreateOption(string name, Type valueType, string description = null)
     {
-        var optionType = typeof(CliOption<>).MakeGenericType(valueType);
+        var optionType = typeof(Option<>).MakeGenericType(valueType);
 
 #if NET6_0_OR_GREATER
         var ctor = (ConstructorInfo)optionType.GetMemberWithSameMetadataDefinitionAs(_ctor);
@@ -24,14 +24,14 @@ internal static class OptionBuilder
         var ctor = optionType.GetConstructor(new[] { typeof(string), typeof(string[]) });
 #endif
 
-        var option = (CliOption)ctor.Invoke(new object[] { name, Array.Empty<string>() });
+        var option = (Option)ctor.Invoke(new object[] { name, Array.Empty<string>() });
 
         option.Description = description;
 
         return option;
     }
 
-    internal static CliOption CreateOption(string name, Type valueType, string description, Func<object> defaultValueFactory)
+    internal static Option CreateOption(string name, Type valueType, string description, Func<object> defaultValueFactory)
     {
         if (defaultValueFactory == null)
         {
@@ -42,12 +42,12 @@ internal static class OptionBuilder
 
         var ctor = optionType.GetConstructor(new[] { typeof(string), typeof(Func<object>), typeof(string) });
 
-        var option = (CliOption)ctor.Invoke(new object[] { name, defaultValueFactory, description });
+        var option = (Option)ctor.Invoke(new object[] { name, defaultValueFactory, description });
 
         return option;
     }
 
-    private sealed class Bridge<T> : CliOption<T>
+    private sealed class Bridge<T> : Option<T>
     {
         public Bridge(string name, Func<object> defaultValueFactory, string description)
             : base(name)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_Hosting_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_Hosting_api_is_not_changed.approved.txt
@@ -4,9 +4,9 @@ System.CommandLine.Hosting
     public static Microsoft.Extensions.Hosting.IHost GetHost(this System.CommandLine.ParseResult parseResult)
     public static System.CommandLine.ParseResult GetParseResult(this Microsoft.Extensions.Hosting.IHostBuilder hostBuilder)
     public static System.CommandLine.ParseResult GetParseResult(this Microsoft.Extensions.Hosting.HostBuilderContext context)
-    public static System.CommandLine.CliCommand UseCommandHandler<THandler>(this System.CommandLine.CliCommand command)
-    public static System.CommandLine.CliConfiguration UseHost(this System.CommandLine.CliConfiguration config, System.Action<Microsoft.Extensions.Hosting.IHostBuilder> configureHost = null)
-    public static System.CommandLine.CliConfiguration UseHost(this System.CommandLine.CliConfiguration config, System.Func<System.String[],Microsoft.Extensions.Hosting.IHostBuilder> hostBuilderFactory, System.Action<Microsoft.Extensions.Hosting.IHostBuilder> configureHost = null)
+    public static System.CommandLine.Command UseCommandHandler<THandler>(this System.CommandLine.Command command)
+    public static System.CommandLine.CommandLineConfiguration UseHost(this System.CommandLine.CommandLineConfiguration config, System.Action<Microsoft.Extensions.Hosting.IHostBuilder> configureHost = null)
+    public static System.CommandLine.CommandLineConfiguration UseHost(this System.CommandLine.CommandLineConfiguration config, System.Func<System.String[],Microsoft.Extensions.Hosting.IHostBuilder> hostBuilderFactory, System.Action<Microsoft.Extensions.Hosting.IHostBuilder> configureHost = null)
     public static Microsoft.Extensions.Hosting.IHostBuilder UseInvocationLifetime(this Microsoft.Extensions.Hosting.IHostBuilder host, System.Action<InvocationLifetimeOptions> configureOptions = null)
   public class InvocationLifetime, Microsoft.Extensions.Hosting.IHostLifetime
     .ctor(Microsoft.Extensions.Options.IOptions<InvocationLifetimeOptions> options, Microsoft.Extensions.Hosting.IHostEnvironment environment, Microsoft.Extensions.Hosting.IHostApplicationLifetime applicationLifetime, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory = null)

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_NamingConventionBinder_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_NamingConventionBinder_api_is_not_changed.approved.txt
@@ -21,7 +21,7 @@ System.CommandLine.NamingConventionBinder
     public static System.Void AddModelBinder(this System.CommandLine.Binding.BindingContext bindingContext, ModelBinder binder)
     public static System.CommandLine.Binding.BindingContext GetBindingContext(this System.CommandLine.ParseResult parseResult)
     public static ModelBinder GetOrCreateModelBinder(this System.CommandLine.Binding.BindingContext bindingContext, System.CommandLine.Binding.IValueDescriptor valueDescriptor)
-  public abstract class BindingHandler : System.CommandLine.Invocation.AsynchronousCliAction
+  public abstract class BindingHandler : System.CommandLine.Invocation.AsynchronousCommandLineAction
     public System.CommandLine.Binding.BindingContext GetBindingContext(System.CommandLine.ParseResult parseResult)
   public static class CommandHandler
     public static BindingHandler Create(System.Delegate delegate)
@@ -109,16 +109,16 @@ System.CommandLine.NamingConventionBinder
     public System.Boolean EnforceExplicitBinding { get; set; }
     public ModelDescriptor ModelDescriptor { get; }
     public System.CommandLine.Binding.IValueDescriptor ValueDescriptor { get; }
-    public System.Void BindMemberFromValue(System.Reflection.PropertyInfo property, System.CommandLine.CliSymbol symbol)
+    public System.Void BindMemberFromValue(System.Reflection.PropertyInfo property, System.CommandLine.Symbol symbol)
     public System.Object CreateInstance(System.CommandLine.Binding.BindingContext bindingContext)
     public System.Void UpdateInstance<T>(T instance, System.CommandLine.Binding.BindingContext bindingContext)
   public class ModelBinder<TModel> : ModelBinder
     .ctor()
-    public System.Void BindMemberFromValue<TValue>(Expression<Func<TModel,TValue>> property, System.CommandLine.CliSymbol symbol)
+    public System.Void BindMemberFromValue<TValue>(Expression<Func<TModel,TValue>> property, System.CommandLine.Symbol symbol)
     public System.Void BindMemberFromValue<TValue>(Expression<Func<TModel,TValue>> property, Func<System.CommandLine.Binding.BindingContext,TValue> getValue)
   public class ModelBindingCommandHandler : BindingHandler
-    public System.Void BindParameter(System.Reflection.ParameterInfo param, System.CommandLine.CliArgument argument)
-    public System.Void BindParameter(System.Reflection.ParameterInfo param, System.CommandLine.CliOption option)
+    public System.Void BindParameter(System.Reflection.ParameterInfo param, System.CommandLine.Argument argument)
+    public System.Void BindParameter(System.Reflection.ParameterInfo param, System.CommandLine.Option option)
     public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.CommandLine.ParseResult parseResult, System.Threading.CancellationToken cancellationToken = null)
   public class ModelDescriptor
     public static ModelDescriptor FromType<T>()

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -1,4 +1,23 @@
 System.CommandLine
+  public abstract class Argument : Symbol
+    public ArgumentArity Arity { get; set; }
+    public System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> CompletionSources { get; }
+    public System.Boolean HasDefaultValue { get; }
+    public System.String HelpName { get; set; }
+    public System.Collections.Generic.List<System.Action<System.CommandLine.Parsing.ArgumentResult>> Validators { get; }
+    public System.Type ValueType { get; }
+    public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
+    public System.Object GetDefaultValue()
+    public System.String ToString()
+  public class Argument<T> : Argument
+    .ctor(System.String name)
+    public Func<System.CommandLine.Parsing.ArgumentResult,T> CustomParser { get; set; }
+    public Func<System.CommandLine.Parsing.ArgumentResult,T> DefaultValueFactory { get; set; }
+    public System.Boolean HasDefaultValue { get; }
+    public System.Type ValueType { get; }
+    public System.Void AcceptLegalFileNamesOnly()
+    public System.Void AcceptLegalFilePathsOnly()
+    public System.Void AcceptOnlyFromAmong(System.String[] values)
   public struct ArgumentArity : System.ValueType, System.IEquatable<ArgumentArity>
     public static ArgumentArity ExactlyOne { get; }
     public static ArgumentArity OneOrMore { get; }
@@ -12,58 +31,39 @@ System.CommandLine
     public System.Boolean Equals(System.Object obj)
     public System.Int32 GetHashCode()
   public static class ArgumentValidation
-    public static CliArgument<System.IO.FileInfo> AcceptExistingOnly(this CliArgument<System.IO.FileInfo> argument)
-    public static CliArgument<System.IO.DirectoryInfo> AcceptExistingOnly(this CliArgument<System.IO.DirectoryInfo> argument)
-    public static CliArgument<System.IO.FileSystemInfo> AcceptExistingOnly(this CliArgument<System.IO.FileSystemInfo> argument)
-    public static CliArgument<T> AcceptExistingOnly<T>(this CliArgument<T> argument)
-  public abstract class CliArgument : CliSymbol
-    public ArgumentArity Arity { get; set; }
-    public System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> CompletionSources { get; }
-    public System.Boolean HasDefaultValue { get; }
-    public System.String HelpName { get; set; }
-    public System.Collections.Generic.List<System.Action<System.CommandLine.Parsing.ArgumentResult>> Validators { get; }
-    public System.Type ValueType { get; }
-    public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
-    public System.Object GetDefaultValue()
-    public System.String ToString()
-  public class CliArgument<T> : CliArgument
-    .ctor(System.String name)
-    public Func<System.CommandLine.Parsing.ArgumentResult,T> CustomParser { get; set; }
-    public Func<System.CommandLine.Parsing.ArgumentResult,T> DefaultValueFactory { get; set; }
-    public System.Boolean HasDefaultValue { get; }
-    public System.Type ValueType { get; }
-    public System.Void AcceptLegalFileNamesOnly()
-    public System.Void AcceptLegalFilePathsOnly()
-    public System.Void AcceptOnlyFromAmong(System.String[] values)
-  public class CliCommand : CliSymbol, System.Collections.IEnumerable
+    public static Argument<System.IO.FileInfo> AcceptExistingOnly(this Argument<System.IO.FileInfo> argument)
+    public static Argument<System.IO.DirectoryInfo> AcceptExistingOnly(this Argument<System.IO.DirectoryInfo> argument)
+    public static Argument<System.IO.FileSystemInfo> AcceptExistingOnly(this Argument<System.IO.FileSystemInfo> argument)
+    public static Argument<T> AcceptExistingOnly<T>(this Argument<T> argument)
+  public class Command : Symbol, System.Collections.IEnumerable
     .ctor(System.String name, System.String description = null)
-    public System.CommandLine.Invocation.CliAction Action { get; set; }
+    public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
     public System.Collections.Generic.ICollection<System.String> Aliases { get; }
-    public System.Collections.Generic.IList<CliArgument> Arguments { get; }
-    public System.Collections.Generic.IEnumerable<CliSymbol> Children { get; }
-    public System.Collections.Generic.IList<CliOption> Options { get; }
-    public System.Collections.Generic.IList<CliCommand> Subcommands { get; }
+    public System.Collections.Generic.IList<Argument> Arguments { get; }
+    public System.Collections.Generic.IEnumerable<Symbol> Children { get; }
+    public System.Collections.Generic.IList<Option> Options { get; }
+    public System.Collections.Generic.IList<Command> Subcommands { get; }
     public System.Boolean TreatUnmatchedTokensAsErrors { get; set; }
     public System.Collections.Generic.List<System.Action<System.CommandLine.Parsing.CommandResult>> Validators { get; }
-    public System.Void Add(CliArgument argument)
-    public System.Void Add(CliOption option)
-    public System.Void Add(CliCommand command)
+    public System.Void Add(Argument argument)
+    public System.Void Add(Option option)
+    public System.Void Add(Command command)
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
-    public ParseResult Parse(System.Collections.Generic.IReadOnlyList<System.String> args, CliConfiguration configuration = null)
-    public ParseResult Parse(System.String commandLine, CliConfiguration configuration = null)
+    public ParseResult Parse(System.Collections.Generic.IReadOnlyList<System.String> args, CommandLineConfiguration configuration = null)
+    public ParseResult Parse(System.String commandLine, CommandLineConfiguration configuration = null)
     public System.Void SetAction(System.Action<ParseResult> action)
     public System.Void SetAction(System.Func<ParseResult,System.Int32> action)
     public System.Void SetAction(System.Func<ParseResult,System.Threading.CancellationToken,System.Threading.Tasks.Task> action)
     public System.Void SetAction(System.Func<ParseResult,System.Threading.CancellationToken,System.Threading.Tasks.Task<System.Int32>> action)
-  public class CliConfiguration
-    .ctor(CliCommand rootCommand)
+  public class CommandLineConfiguration
+    .ctor(Command rootCommand)
     public System.Boolean EnableDefaultExceptionHandler { get; set; }
     public System.Boolean EnablePosixBundling { get; set; }
     public System.IO.TextWriter Error { get; set; }
     public System.IO.TextWriter Output { get; set; }
     public System.Nullable<System.TimeSpan> ProcessTerminationTimeout { get; set; }
     public System.CommandLine.Parsing.TryReplaceToken ResponseFileTokenReplacer { get; set; }
-    public CliCommand RootCommand { get; }
+    public Command RootCommand { get; }
     public System.Int32 Invoke(System.String commandLine)
     public System.Int32 Invoke(System.String[] args)
     public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.String commandLine, System.Threading.CancellationToken cancellationToken = null)
@@ -71,14 +71,24 @@ System.CommandLine
     public ParseResult Parse(System.Collections.Generic.IReadOnlyList<System.String> args)
     public ParseResult Parse(System.String commandLine)
     public System.Void ThrowIfInvalid()
-  public class CliConfigurationException : System.Exception, System.Runtime.Serialization.ISerializable
+  public class CommandLineConfigurationException : System.Exception, System.Runtime.Serialization.ISerializable
     .ctor(System.String message)
-  public class CliDirective : CliSymbol
+  public static class CompletionSourceExtensions
+    public static System.Void Add(this System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> completionSources, System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.String>> completionsDelegate)
+    public static System.Void Add(this System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> completionSources, System.String[] completions)
+  public class DiagramDirective : Directive
+    .ctor()
+    public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
+    public System.Int32 ParseErrorReturnValue { get; set; }
+  public class Directive : Symbol
     .ctor(System.String name)
-    public System.CommandLine.Invocation.CliAction Action { get; set; }
+    public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
-  public abstract class CliOption : CliSymbol
-    public System.CommandLine.Invocation.CliAction Action { get; set; }
+  public class EnvironmentVariablesDirective : Directive
+    .ctor()
+    public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
+  public abstract class Option : Symbol
+    public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
     public System.Collections.Generic.ICollection<System.String> Aliases { get; }
     public System.Boolean AllowMultipleArgumentsPerToken { get; set; }
     public ArgumentArity Arity { get; set; }
@@ -89,66 +99,56 @@ System.CommandLine
     public System.Boolean Required { get; set; }
     public System.Collections.Generic.List<System.Action<System.CommandLine.Parsing.OptionResult>> Validators { get; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
-  public class CliOption<T> : CliOption
+  public class Option<T> : Option
     .ctor(System.String name, System.String[] aliases)
     public Func<System.CommandLine.Parsing.ArgumentResult,T> CustomParser { get; set; }
     public Func<System.CommandLine.Parsing.ArgumentResult,T> DefaultValueFactory { get; set; }
     public System.Void AcceptLegalFileNamesOnly()
     public System.Void AcceptLegalFilePathsOnly()
     public System.Void AcceptOnlyFromAmong(System.String[] values)
-  public class CliRootCommand : CliCommand, System.Collections.IEnumerable
-    public static System.String ExecutableName { get; }
-    public static System.String ExecutablePath { get; }
-    .ctor(System.String description = )
-    public System.Collections.Generic.IList<CliDirective> Directives { get; }
-    public System.Void Add(CliDirective directive)
-  public abstract class CliSymbol
-    public System.String Description { get; set; }
-    public System.Boolean Hidden { get; set; }
-    public System.String Name { get; }
-    public System.Collections.Generic.IEnumerable<CliSymbol> Parents { get; }
-    public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
-    public System.String ToString()
-  public static class CompletionSourceExtensions
-    public static System.Void Add(this System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> completionSources, System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.String>> completionsDelegate)
-    public static System.Void Add(this System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> completionSources, System.String[] completions)
-  public class DiagramDirective : CliDirective
-    .ctor()
-    public System.CommandLine.Invocation.CliAction Action { get; set; }
-    public System.Int32 ParseErrorReturnValue { get; set; }
-  public class EnvironmentVariablesDirective : CliDirective
-    .ctor()
-    public System.CommandLine.Invocation.CliAction Action { get; set; }
   public static class OptionValidation
-    public static CliOption<System.IO.FileInfo> AcceptExistingOnly(this CliOption<System.IO.FileInfo> option)
-    public static CliOption<System.IO.DirectoryInfo> AcceptExistingOnly(this CliOption<System.IO.DirectoryInfo> option)
-    public static CliOption<System.IO.FileSystemInfo> AcceptExistingOnly(this CliOption<System.IO.FileSystemInfo> option)
-    public static CliOption<T> AcceptExistingOnly<T>(this CliOption<T> option)
+    public static Option<System.IO.FileInfo> AcceptExistingOnly(this Option<System.IO.FileInfo> option)
+    public static Option<System.IO.DirectoryInfo> AcceptExistingOnly(this Option<System.IO.DirectoryInfo> option)
+    public static Option<System.IO.FileSystemInfo> AcceptExistingOnly(this Option<System.IO.FileSystemInfo> option)
+    public static Option<T> AcceptExistingOnly<T>(this Option<T> option)
   public class ParseResult
-    public System.CommandLine.Invocation.CliAction Action { get; }
+    public System.CommandLine.Invocation.CommandLineAction Action { get; }
     public System.CommandLine.Parsing.CommandResult CommandResult { get; }
-    public CliConfiguration Configuration { get; }
+    public CommandLineConfiguration Configuration { get; }
     public System.Collections.Generic.IReadOnlyList<System.CommandLine.Parsing.ParseError> Errors { get; }
     public System.CommandLine.Parsing.CommandResult RootCommandResult { get; }
-    public System.Collections.Generic.IReadOnlyList<System.CommandLine.Parsing.CliToken> Tokens { get; }
+    public System.Collections.Generic.IReadOnlyList<System.CommandLine.Parsing.Token> Tokens { get; }
     public System.Collections.Generic.IReadOnlyList<System.String> UnmatchedTokens { get; }
     public System.CommandLine.Completions.CompletionContext GetCompletionContext()
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.Nullable<System.Int32> position = null)
-    public System.CommandLine.Parsing.ArgumentResult GetResult(CliArgument argument)
-    public System.CommandLine.Parsing.CommandResult GetResult(CliCommand command)
-    public System.CommandLine.Parsing.OptionResult GetResult(CliOption option)
-    public System.CommandLine.Parsing.DirectiveResult GetResult(CliDirective directive)
-    public System.CommandLine.Parsing.SymbolResult GetResult(CliSymbol symbol)
-    public T GetValue<T>(CliArgument<T> argument)
-    public T GetValue<T>(CliOption<T> option)
+    public System.CommandLine.Parsing.ArgumentResult GetResult(Argument argument)
+    public System.CommandLine.Parsing.CommandResult GetResult(Command command)
+    public System.CommandLine.Parsing.OptionResult GetResult(Option option)
+    public System.CommandLine.Parsing.DirectiveResult GetResult(Directive directive)
+    public System.CommandLine.Parsing.SymbolResult GetResult(Symbol symbol)
+    public T GetValue<T>(Argument<T> argument)
+    public T GetValue<T>(Option<T> option)
     public T GetValue<T>(System.String name)
     public System.Int32 Invoke()
     public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.Threading.CancellationToken cancellationToken = null)
     public System.String ToString()
-  public class VersionOption : CliOption<System.Boolean>
+  public class RootCommand : Command, System.Collections.IEnumerable
+    public static System.String ExecutableName { get; }
+    public static System.String ExecutablePath { get; }
+    .ctor(System.String description = )
+    public System.Collections.Generic.IList<Directive> Directives { get; }
+    public System.Void Add(Directive directive)
+  public abstract class Symbol
+    public System.String Description { get; set; }
+    public System.Boolean Hidden { get; set; }
+    public System.String Name { get; }
+    public System.Collections.Generic.IEnumerable<Symbol> Parents { get; }
+    public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
+    public System.String ToString()
+  public class VersionOption : Option<System.Boolean>
     .ctor()
     .ctor(System.String name, System.String[] aliases)
-    public System.CommandLine.Invocation.CliAction Action { get; set; }
+    public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
 System.CommandLine.Completions
   public class CompletionContext
     public static CompletionContext Empty { get; }
@@ -166,15 +166,15 @@ System.CommandLine.Completions
     public System.Boolean Equals(System.Object obj)
     public System.Int32 GetHashCode()
     public System.String ToString()
-  public class SuggestDirective : System.CommandLine.CliDirective
+  public class SuggestDirective : System.CommandLine.Directive
     .ctor()
-    public System.CommandLine.Invocation.CliAction Action { get; set; }
+    public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
   public class TextCompletionContext : CompletionContext
     public System.String CommandLineText { get; }
     public System.Int32 CursorPosition { get; }
     public TextCompletionContext AtCursorPosition(System.Int32 position)
 System.CommandLine.Help
-  public class HelpAction : System.CommandLine.Invocation.SynchronousCliAction
+  public class HelpAction : System.CommandLine.Invocation.SynchronousCommandLineAction
     .ctor()
     public HelpBuilder Builder { get; set; }
     public System.Int32 Invoke(System.CommandLine.ParseResult parseResult)
@@ -182,35 +182,35 @@ System.CommandLine.Help
     .ctor(System.Int32 maxWidth = 2147483647)
     public System.Int32 MaxWidth { get; }
     public System.Void CustomizeLayout(System.Func<HelpContext,System.Collections.Generic.IEnumerable<System.Func<HelpContext,System.Boolean>>> getLayout)
-    public System.Void CustomizeSymbol(System.CommandLine.CliSymbol symbol, System.Func<HelpContext,System.String> firstColumnText = null, System.Func<HelpContext,System.String> secondColumnText = null, System.Func<HelpContext,System.String> defaultValue = null)
-    public System.Void CustomizeSymbol(System.CommandLine.CliSymbol symbol, System.String firstColumnText = null, System.String secondColumnText = null, System.String defaultValue = null)
-    public TwoColumnHelpRow GetTwoColumnRow(System.CommandLine.CliSymbol symbol, HelpContext context)
+    public System.Void CustomizeSymbol(System.CommandLine.Symbol symbol, System.Func<HelpContext,System.String> firstColumnText = null, System.Func<HelpContext,System.String> secondColumnText = null, System.Func<HelpContext,System.String> defaultValue = null)
+    public System.Void CustomizeSymbol(System.CommandLine.Symbol symbol, System.String firstColumnText = null, System.String secondColumnText = null, System.String defaultValue = null)
+    public TwoColumnHelpRow GetTwoColumnRow(System.CommandLine.Symbol symbol, HelpContext context)
     public System.Void Write(HelpContext context)
-    public System.Void Write(System.CommandLine.CliCommand command, System.IO.TextWriter writer)
+    public System.Void Write(System.CommandLine.Command command, System.IO.TextWriter writer)
     public System.Void WriteColumns(System.Collections.Generic.IReadOnlyList<TwoColumnHelpRow> items, HelpContext context)
    static class Default
     public static System.Func<HelpContext,System.Boolean> AdditionalArgumentsSection()
     public static System.Func<HelpContext,System.Boolean> CommandArgumentsSection()
     public static System.Func<HelpContext,System.Boolean> CommandUsageSection()
-    public static System.String GetArgumentDefaultValue(System.CommandLine.CliArgument argument)
-    public static System.String GetArgumentDescription(System.CommandLine.CliArgument argument)
-    public static System.String GetArgumentUsageLabel(System.CommandLine.CliArgument argument)
-    public static System.String GetCommandUsageLabel(System.CommandLine.CliCommand symbol)
+    public static System.String GetArgumentDefaultValue(System.CommandLine.Argument argument)
+    public static System.String GetArgumentDescription(System.CommandLine.Argument argument)
+    public static System.String GetArgumentUsageLabel(System.CommandLine.Argument argument)
+    public static System.String GetCommandUsageLabel(System.CommandLine.Command symbol)
     public static System.Collections.Generic.IEnumerable<System.Func<HelpContext,System.Boolean>> GetLayout()
-    public static System.String GetOptionUsageLabel(System.CommandLine.CliOption symbol)
+    public static System.String GetOptionUsageLabel(System.CommandLine.Option symbol)
     public static System.Func<HelpContext,System.Boolean> OptionsSection()
     public static System.Func<HelpContext,System.Boolean> SubcommandsSection()
     public static System.Func<HelpContext,System.Boolean> SynopsisSection()
   public class HelpContext
-    .ctor(HelpBuilder helpBuilder, System.CommandLine.CliCommand command, System.IO.TextWriter output, System.CommandLine.ParseResult parseResult = null)
-    public System.CommandLine.CliCommand Command { get; }
+    .ctor(HelpBuilder helpBuilder, System.CommandLine.Command command, System.IO.TextWriter output, System.CommandLine.ParseResult parseResult = null)
+    public System.CommandLine.Command Command { get; }
     public HelpBuilder HelpBuilder { get; }
     public System.IO.TextWriter Output { get; }
     public System.CommandLine.ParseResult ParseResult { get; }
-  public class HelpOption : System.CommandLine.CliOption<System.Boolean>
+  public class HelpOption : System.CommandLine.Option<System.Boolean>
     .ctor()
     .ctor(System.String name, System.String[] aliases)
-    public System.CommandLine.Invocation.CliAction Action { get; set; }
+    public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
   public class TwoColumnHelpRow, System.IEquatable<TwoColumnHelpRow>
     .ctor(System.String firstColumnText, System.String secondColumnText)
     public System.String FirstColumnText { get; }
@@ -219,59 +219,43 @@ System.CommandLine.Help
     public System.Boolean Equals(TwoColumnHelpRow other)
     public System.Int32 GetHashCode()
 System.CommandLine.Invocation
-  public abstract class AsynchronousCliAction : CliAction
+  public abstract class AsynchronousCommandLineAction : CommandLineAction
     public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.CommandLine.ParseResult parseResult, System.Threading.CancellationToken cancellationToken = null)
-  public abstract class CliAction
+  public abstract class CommandLineAction
     public System.Boolean Terminating { get; }
     protected System.Void set_Terminating(System.Boolean value)
-  public class ParseErrorAction : SynchronousCliAction
+  public class ParseErrorAction : SynchronousCommandLineAction
     .ctor()
     public System.Boolean ShowHelp { get; set; }
     public System.Boolean ShowTypoCorrections { get; set; }
     public System.Int32 Invoke(System.CommandLine.ParseResult parseResult)
-  public abstract class SynchronousCliAction : CliAction
+  public abstract class SynchronousCommandLineAction : CommandLineAction
     public System.Int32 Invoke(System.CommandLine.ParseResult parseResult)
 System.CommandLine.Parsing
   public class ArgumentResult : SymbolResult
-    public System.CommandLine.CliArgument Argument { get; }
+    public System.CommandLine.Argument Argument { get; }
     public System.Void AddError(System.String errorMessage)
     public T GetValueOrDefault<T>()
     public System.Void OnlyTake(System.Int32 numberOfTokens)
     public System.String ToString()
-  public static class CliParser
-    public static System.CommandLine.ParseResult Parse(System.CommandLine.CliCommand command, System.Collections.Generic.IReadOnlyList<System.String> args, System.CommandLine.CliConfiguration configuration = null)
-    public static System.CommandLine.ParseResult Parse(System.CommandLine.CliCommand command, System.String commandLine, System.CommandLine.CliConfiguration configuration = null)
+  public static class CommandLineParser
+    public static System.CommandLine.ParseResult Parse(System.CommandLine.Command command, System.Collections.Generic.IReadOnlyList<System.String> args, System.CommandLine.CommandLineConfiguration configuration = null)
+    public static System.CommandLine.ParseResult Parse(System.CommandLine.Command command, System.String commandLine, System.CommandLine.CommandLineConfiguration configuration = null)
     public static System.Collections.Generic.IEnumerable<System.String> SplitCommandLine(System.String commandLine)
-  public class CliToken, System.IEquatable<CliToken>
-    public static System.Boolean op_Equality(CliToken left, CliToken right)
-    public static System.Boolean op_Inequality(CliToken left, CliToken right)
-    .ctor(System.String value, CliTokenType type, System.CommandLine.CliSymbol symbol)
-    public CliTokenType Type { get; }
-    public System.String Value { get; }
-    public System.Boolean Equals(System.Object obj)
-    public System.Boolean Equals(CliToken other)
-    public System.Int32 GetHashCode()
-    public System.String ToString()
-  public enum CliTokenType : System.Enum, System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
-    Argument=0
-    Command=1
-    Option=2
-    DoubleDash=3
-    Directive=4
   public class CommandResult : SymbolResult
     public System.Collections.Generic.IEnumerable<SymbolResult> Children { get; }
-    public System.CommandLine.CliCommand Command { get; }
-    public CliToken IdentifierToken { get; }
+    public System.CommandLine.Command Command { get; }
+    public Token IdentifierToken { get; }
     public System.String ToString()
   public class DirectiveResult : SymbolResult
-    public System.CommandLine.CliDirective Directive { get; }
-    public CliToken Token { get; }
+    public System.CommandLine.Directive Directive { get; }
+    public Token Token { get; }
     public System.Collections.Generic.IReadOnlyList<System.String> Values { get; }
   public class OptionResult : SymbolResult
-    public CliToken IdentifierToken { get; }
+    public Token IdentifierToken { get; }
     public System.Int32 IdentifierTokenCount { get; }
     public System.Boolean Implicit { get; }
-    public System.CommandLine.CliOption Option { get; }
+    public System.CommandLine.Option Option { get; }
     public T GetValueOrDefault<T>()
     public System.String ToString()
   public class ParseError
@@ -281,16 +265,32 @@ System.CommandLine.Parsing
   public abstract class SymbolResult
     public System.Collections.Generic.IEnumerable<ParseError> Errors { get; }
     public SymbolResult Parent { get; }
-    public System.Collections.Generic.IReadOnlyList<CliToken> Tokens { get; }
+    public System.Collections.Generic.IReadOnlyList<Token> Tokens { get; }
     public System.Void AddError(System.String errorMessage)
-    public ArgumentResult GetResult(System.CommandLine.CliArgument argument)
-    public CommandResult GetResult(System.CommandLine.CliCommand command)
-    public OptionResult GetResult(System.CommandLine.CliOption option)
-    public DirectiveResult GetResult(System.CommandLine.CliDirective directive)
+    public ArgumentResult GetResult(System.CommandLine.Argument argument)
+    public CommandResult GetResult(System.CommandLine.Command command)
+    public OptionResult GetResult(System.CommandLine.Option option)
+    public DirectiveResult GetResult(System.CommandLine.Directive directive)
     public SymbolResult GetResult(System.String name)
-    public T GetValue<T>(CliArgument<T> argument)
-    public T GetValue<T>(CliOption<T> option)
+    public T GetValue<T>(Argument<T> argument)
+    public T GetValue<T>(Option<T> option)
     public T GetValue<T>(System.String name)
+  public class Token, System.IEquatable<Token>
+    public static System.Boolean op_Equality(Token left, Token right)
+    public static System.Boolean op_Inequality(Token left, Token right)
+    .ctor(System.String value, TokenType type, System.CommandLine.Symbol symbol)
+    public TokenType Type { get; }
+    public System.String Value { get; }
+    public System.Boolean Equals(System.Object obj)
+    public System.Boolean Equals(Token other)
+    public System.Int32 GetHashCode()
+    public System.String ToString()
+  public enum TokenType : System.Enum, System.IComparable, System.IConvertible, System.IFormattable, System.ISpanFormattable
+    Argument=0
+    Command=1
+    Option=2
+    DoubleDash=3
+    Directive=4
   public delegate TryReplaceToken : System.MulticastDelegate, System.ICloneable, System.Runtime.Serialization.ISerializable
     .ctor(System.Object object, System.IntPtr method)
     public System.IAsyncResult BeginInvoke(System.String tokenToReplace, ref System.Collections.Generic.IReadOnlyList<System.String> replacementTokens, ref System.String& errorMessage, System.AsyncCallback callback, System.Object object)

--- a/src/System.CommandLine.ApiCompatibility.Tests/LocalizationTests.cs
+++ b/src/System.CommandLine.ApiCompatibility.Tests/LocalizationTests.cs
@@ -19,9 +19,9 @@ namespace System.CommandLine.ApiCompatibility.Tests
             {
                 CultureInfo.CurrentUICulture = new CultureInfo(cultureName);
 
-                CliCommand command = new(CommandName)
+                Command command = new(CommandName)
                 {
-                    new CliArgument<string>("arg")
+                    new Argument<string>("arg")
                 };
 
                 ParseResult parseResult = command.Parse(CommandName);

--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -21,12 +21,12 @@ namespace System.CommandLine.DragonFruit.Tests
         [Fact]
         public async Task Generated_boolean_parameters_will_accept_zero_arguments()
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(
                              GetMethodInfo(nameof(Method_taking_bool)), this);
             config.Output = TextWriter.Null;
 
-            await config.InvokeAsync($"{CliRootCommand.ExecutableName} --value");
+            await config.InvokeAsync($"{RootCommand.ExecutableName} --value");
 
             _receivedValues.Should().BeEquivalentTo(true);
         }
@@ -40,7 +40,7 @@ namespace System.CommandLine.DragonFruit.Tests
         [InlineData("--value=false", false)]
         public async Task Generated_boolean_parameters_will_accept_one_argument(string commandLine, bool expected)
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(
                              GetMethodInfo(nameof(Method_taking_bool)), this);
             config.Output = TextWriter.Null;
@@ -53,7 +53,7 @@ namespace System.CommandLine.DragonFruit.Tests
         [Fact]
         public async Task Single_character_parameters_generate_aliases_that_accept_a_single_dash_prefix()
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(
                              GetMethodInfo(nameof(Method_with_single_letter_parameters)), this);
             config.Output = TextWriter.Null;
@@ -78,7 +78,7 @@ namespace System.CommandLine.DragonFruit.Tests
             int minNumberOfValues,
             int maxNumberOfValues)
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(GetMethodInfo(methodName));
 
             var rootCommandArgument = config.RootCommand.Arguments.Single();
@@ -98,7 +98,7 @@ namespace System.CommandLine.DragonFruit.Tests
         [InlineData(nameof(Method_having_FileInfo_array_args), "args")]
         public void Parameters_named_arguments_generate_command_arguments_having_the_correct_name(string methodName, string expectedArgName)
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(GetMethodInfo(methodName));
 
             var rootCommandArgument = config.RootCommand.Arguments.Single();
@@ -118,7 +118,7 @@ namespace System.CommandLine.DragonFruit.Tests
         [InlineData(nameof(Method_having_FileInfo_array_args))]
         public void Options_are_not_generated_for_command_argument_parameters(string methodName)
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(GetMethodInfo(methodName));
 
             var rootCommand = config.RootCommand;
@@ -147,7 +147,7 @@ namespace System.CommandLine.DragonFruit.Tests
             string methodName,
             Type expectedType)
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(GetMethodInfo(methodName));
 
             var rootCommandArgument = config.RootCommand.Arguments.Single();
@@ -160,7 +160,7 @@ namespace System.CommandLine.DragonFruit.Tests
         [Fact]
         public async Task When_method_returns_void_then_return_code_is_0()
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(
                              GetMethodInfo(nameof(Method_returning_void)), this);
             config.Output = TextWriter.Null;
@@ -173,7 +173,7 @@ namespace System.CommandLine.DragonFruit.Tests
         [Fact]
         public async Task When_method_returns_int_then_return_code_is_set_to_return_value()
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(
                              GetMethodInfo(nameof(Method_returning_int)), this);
             config.Output = TextWriter.Null;
@@ -186,7 +186,7 @@ namespace System.CommandLine.DragonFruit.Tests
         [Fact]
         public async Task When_method_returns_Task_of_int_then_return_code_is_set_to_return_value()
         {
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                          .ConfigureRootCommandFromMethod(
                              GetMethodInfo(nameof(Method_returning_Task_of_int)), this);
             config.Output = TextWriter.Null;
@@ -209,13 +209,13 @@ namespace System.CommandLine.DragonFruit.Tests
             var options = handlerMethod.BuildOptions();
 
             options.Should()
-                   .NotContain(o => o.GetType().IsAssignableTo(typeof(CliOption<>).MakeGenericType(type)));
+                   .NotContain(o => o.GetType().IsAssignableTo(typeof(Option<>).MakeGenericType(type)));
         }
 
         [Fact]
         public async Task Method_parameters_on_the_invoked_member_method_are_bound_to_matching_option_names_by_MethodInfo_with_target()
         {
-            var command = new CliCommand("test");
+            var command = new Command("test");
             command.ConfigureFromMethod(GetMethodInfo(nameof(Method_taking_bool)), this);
 
             await command.Parse("--value").InvokeAsync();
@@ -226,7 +226,7 @@ namespace System.CommandLine.DragonFruit.Tests
         [Fact]
         public async Task Method_with_multiple_parameters_with_default_values_are_resolved_correctly()
         {
-            var command = new CliCommand("test");
+            var command = new Command("test");
             command.ConfigureFromMethod(GetMethodInfo(nameof(Method_with_multiple_default_values)), this);
 
             await command.Parse("").InvokeAsync();

--- a/src/System.CommandLine.DragonFruit/CommandLine.cs
+++ b/src/System.CommandLine.DragonFruit/CommandLine.cs
@@ -80,7 +80,7 @@ namespace System.CommandLine.DragonFruit
             TextWriter standardOutput = null,
             TextWriter standardError = null)
         {
-            CliConfiguration configuration = BuildConfiguration(method, xmlDocsFilePath, target);
+            CommandLineConfiguration configuration = BuildConfiguration(method, xmlDocsFilePath, target);
             configuration.Output = standardOutput ?? Console.Out;
             configuration.Error = standardError ?? Console.Error;
 
@@ -95,24 +95,24 @@ namespace System.CommandLine.DragonFruit
             TextWriter standardOutput = null,
             TextWriter standardError = null)
         {
-            CliConfiguration configuration = BuildConfiguration(method, xmlDocsFilePath, target);
+            CommandLineConfiguration configuration = BuildConfiguration(method, xmlDocsFilePath, target);
             configuration.Output = standardOutput ?? Console.Out;
             configuration.Error = standardError ?? Console.Error;
 
             return configuration.Parse(args).Invoke();
         }
 
-        private static CliConfiguration BuildConfiguration(MethodInfo method,
+        private static CommandLineConfiguration BuildConfiguration(MethodInfo method,
             string xmlDocsFilePath,
             object target)
         {
-            return new CliConfiguration(new CliRootCommand())
+            return new CommandLineConfiguration(new RootCommand())
                 .ConfigureRootCommandFromMethod(method, target)
                 .ConfigureHelpFromXmlComments(method, xmlDocsFilePath);
         }
 
-        public static CliConfiguration ConfigureRootCommandFromMethod(
-            this CliConfiguration builder,
+        public static CommandLineConfiguration ConfigureRootCommandFromMethod(
+            this CommandLineConfiguration builder,
             MethodInfo method,
             object target = null)
         {
@@ -139,7 +139,7 @@ namespace System.CommandLine.DragonFruit
         };
 
         public static void ConfigureFromMethod(
-            this CliCommand command,
+            this Command command,
             MethodInfo method,
             object target = null)
         {
@@ -166,8 +166,8 @@ namespace System.CommandLine.DragonFruit
             command.Action = CommandHandler.Create(method, target);
         }
 
-        public static CliConfiguration ConfigureHelpFromXmlComments(
-            this CliConfiguration builder,
+        public static CommandLineConfiguration ConfigureHelpFromXmlComments(
+            this CommandLineConfiguration builder,
             MethodInfo method,
             string xmlDocsFilePath)
         {
@@ -243,7 +243,7 @@ namespace System.CommandLine.DragonFruit
                        : $"-{parameterName.ToLowerInvariant()}";
         }
 
-        public static IEnumerable<CliOption> BuildOptions(this MethodInfo method)
+        public static IEnumerable<Option> BuildOptions(this MethodInfo method)
         {
             var descriptor = HandlerDescriptor.FromMethodInfo(method);
 
@@ -251,7 +251,7 @@ namespace System.CommandLine.DragonFruit
                                {
                                    typeof(BindingContext),
                                    typeof(ParseResult),
-                                   typeof(CliConfiguration),
+                                   typeof(CommandLineConfiguration),
                                    typeof(CancellationToken),
                                };
 
@@ -264,7 +264,7 @@ namespace System.CommandLine.DragonFruit
             }
         }
 
-        public static CliOption BuildOption(this ParameterDescriptor parameter)
+        public static Option BuildOption(this ParameterDescriptor parameter)
             => OptionBuilder.CreateOption(
                 parameter.BuildAlias(),
                 parameter.ValueType,
@@ -300,7 +300,7 @@ namespace System.CommandLine.DragonFruit
         /// </summary>
         /// <param name="alias">The alias, which can include a prefix.</param>
         /// <returns><see langword="true"/> if the alias exists; otherwise, <see langword="false"/>.</returns>
-        private static bool HasAliasIgnoringPrefix(CliOption option, string alias)
+        private static bool HasAliasIgnoringPrefix(Option option, string alias)
         {
             ReadOnlySpan<char> rawAlias = alias.AsSpan(GetPrefixLength(alias));
 

--- a/src/System.CommandLine.Generator.CommandHandler/CommandExtensions.cs
+++ b/src/System.CommandLine.Generator.CommandHandler/CommandExtensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.CommandLine;
 
 /// <summary>
-/// Provides extension methods for <see cref="CliCommand" />.
+/// Provides extension methods for <see cref="Command" />.
 /// </summary>
 public static class CommandExtensions
 {
@@ -16,9 +16,9 @@ public static class CommandExtensions
     /// <param name="delegate">A delegate implementing the handler for the command.</param>
     /// <param name="symbols">The symbols used to bind the handler's parameters.</param>
     public static void SetHandler<TDelegate>(
-        this CliCommand command,
+        this Command command,
         TDelegate @delegate,
-        params CliSymbol[] symbols)
+        params Symbol[] symbols)
     {
         throw new InvalidOperationException(_messageForWhenGeneratorIsNotInUse);
     }

--- a/src/System.CommandLine.Hosting.Tests/HostingHandlerTest.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingHandlerTest.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Hosting.Tests
         {
             var service = new MyService();
 
-            var config = new CliConfiguration(
+            var config = new CommandLineConfiguration(
                 new MyRootCommand().UseCommandHandler<MyHandler>()
                 )
                 .UseHost(builder => {
@@ -33,7 +33,7 @@ namespace System.CommandLine.Hosting.Tests
         [Fact]
         public static async Task Parameter_is_available_in_property()
         {
-            var config = new CliConfiguration(new MyRootCommand().UseCommandHandler<MyHandler>())
+            var config = new CommandLineConfiguration(new MyRootCommand().UseCommandHandler<MyHandler>())
                 .UseHost(host =>
                 {
                     host.ConfigureServices(services =>
@@ -50,11 +50,11 @@ namespace System.CommandLine.Hosting.Tests
         [Fact]
         public static async Task Can_have_different_handlers_based_on_command()
         {
-            var root = new CliRootCommand();
+            var root = new RootCommand();
 
             root.Subcommands.Add(new MyCommand().UseCommandHandler<MyHandler>());
             root.Subcommands.Add(new MyOtherCommand().UseCommandHandler<MyOtherCommand.MyHandler>());
-            var config = new CliConfiguration(root)
+            var config = new CommandLineConfiguration(root)
                 .UseHost(host =>
                 {
                     host.ConfigureServices(services =>
@@ -79,9 +79,9 @@ namespace System.CommandLine.Hosting.Tests
         public static async Task Can_bind_to_arguments_via_injection()
         {
             var service = new MyService();
-            var cmd = new CliRootCommand();
+            var cmd = new RootCommand();
             cmd.Subcommands.Add(new MyOtherCommand().UseCommandHandler<MyOtherCommand.MyHandler>());
-            var config = new CliConfiguration(cmd)
+            var config = new CommandLineConfiguration(cmd)
                 .UseHost(host =>
                 {
                     host.ConfigureServices(services =>
@@ -100,10 +100,10 @@ namespace System.CommandLine.Hosting.Tests
         {
             var service = new MyService();
 
-            var cmd = new CliRootCommand();
+            var cmd = new RootCommand();
             cmd.Subcommands.Add(new MyCommand().UseCommandHandler<MyDerivedCliAction>());
             cmd.Subcommands.Add(new MyOtherCommand().UseCommandHandler<MyOtherCommand.MyDerivedCliAction>());
-            var config = new CliConfiguration(cmd)
+            var config = new CommandLineConfiguration(cmd)
                          .UseHost((builder) => {
                              builder.ConfigureServices(services =>
                              {
@@ -118,7 +118,7 @@ namespace System.CommandLine.Hosting.Tests
             service.StringValue.Should().Be("TEST");
         }
 
-        public abstract class MyBaseCliAction : AsynchronousCliAction
+        public abstract class MyBaseCliAction : AsynchronousCommandLineAction
         {
             public int IntOption { get; set; } // bound from option
 
@@ -130,19 +130,19 @@ namespace System.CommandLine.Hosting.Tests
             protected abstract int Act();
         }
 
-        public class MyRootCommand : CliRootCommand
+        public class MyRootCommand : RootCommand
         {
             public MyRootCommand()
             {
-                Options.Add(new CliOption<int>("--int-option")); // or nameof(Handler.IntOption).ToKebabCase() if you don't like the string literal
+                Options.Add(new Option<int>("--int-option")); // or nameof(Handler.IntOption).ToKebabCase() if you don't like the string literal
             }
         }
 
-        public class MyCommand : CliCommand
+        public class MyCommand : Command
         {
             public MyCommand() : base(name: "mycommand")
             {
-                Options.Add(new CliOption<int>("--int-option")); // or nameof(Handler.IntOption).ToKebabCase() if you don't like the string literal
+                Options.Add(new Option<int>("--int-option")); // or nameof(Handler.IntOption).ToKebabCase() if you don't like the string literal
             }
         }
 
@@ -162,7 +162,7 @@ namespace System.CommandLine.Hosting.Tests
             }
         }
 
-        public class MyHandler : AsynchronousCliAction
+        public class MyHandler : AsynchronousCommandLineAction
         {
             private readonly MyService service;
 
@@ -180,15 +180,15 @@ namespace System.CommandLine.Hosting.Tests
             }
         }
 
-        public class MyOtherCommand : CliCommand
+        public class MyOtherCommand : Command
         {
             public MyOtherCommand() : base(name: "myothercommand")
             {
-                Options.Add(new CliOption<int>("--int-option")); // or nameof(Handler.IntOption).ToKebabCase() if you don't like the string literal
-                Arguments.Add(new CliArgument<string>("One") {  Arity = ArgumentArity.ZeroOrOne });
+                Options.Add(new Option<int>("--int-option")); // or nameof(Handler.IntOption).ToKebabCase() if you don't like the string literal
+                Arguments.Add(new Argument<string>("One") {  Arity = ArgumentArity.ZeroOrOne });
             }
 
-            public class MyHandler : AsynchronousCliAction
+            public class MyHandler : AsynchronousCommandLineAction
             {
                 private readonly MyService service;
 

--- a/src/System.CommandLine.Hosting.Tests/HostingTests.cs
+++ b/src/System.CommandLine.Hosting.Tests/HostingTests.cs
@@ -26,8 +26,8 @@ namespace System.CommandLine.Hosting.Tests
                 hostFromHandler = host;
             }
 
-            var config = new CliConfiguration(
-                new CliRootCommand { Action = CommandHandler.Create<IHost>(Execute) }
+            var config = new CommandLineConfiguration(
+                new RootCommand { Action = CommandHandler.Create<IHost>(Execute) }
                 )
                 .UseHost();
 
@@ -41,7 +41,7 @@ namespace System.CommandLine.Hosting.Tests
         {
             ParseResult parseResult = null;
 
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                 .UseHost(host =>
                 {
                     if (host.Properties.TryGetValue(typeof(ParseResult), out var ctx))
@@ -66,8 +66,8 @@ namespace System.CommandLine.Hosting.Tests
                 parseResult = services.GetRequiredService<ParseResult>();
             }
 
-            var config = new CliConfiguration(
-                new CliRootCommand { Action = CommandHandler.Create<IHost>(Execute) }
+            var config = new CommandLineConfiguration(
+                new RootCommand { Action = CommandHandler.Create<IHost>(Execute) }
                 )
                 .UseHost();
 
@@ -92,8 +92,8 @@ namespace System.CommandLine.Hosting.Tests
                 testConfigValue = config[testKey];
             }
 
-            var config = new CliConfiguration(
-                new CliRootCommand
+            var config = new CommandLineConfiguration(
+                new RootCommand
                 {
                     Action = CommandHandler.Create<IHost>(Execute),
                 })
@@ -127,8 +127,8 @@ namespace System.CommandLine.Hosting.Tests
                 testConfigValue = config[testKey];
             }
 
-            var config = new CliConfiguration(
-                new CliRootCommand
+            var config = new CommandLineConfiguration(
+                new RootCommand
                 {
                     Action = CommandHandler.Create<IHost>(Execute),
                 })
@@ -164,8 +164,8 @@ namespace System.CommandLine.Hosting.Tests
                 testConfigValue = config[testKey];
             }
 
-            var config = new CliConfiguration(
-                new CliRootCommand
+            var config = new CommandLineConfiguration(
+                new RootCommand
                 {
                     Action = CommandHandler.Create<IHost>(Execute)
                 })
@@ -183,8 +183,8 @@ namespace System.CommandLine.Hosting.Tests
             string commandLine = $"-{nameof(MyOptions.MyArgument)} {myValue}";
             MyOptions options = null;
 
-            var rootCmd = new CliRootCommand();
-            rootCmd.Options.Add(new CliOption<int>($"-{nameof(MyOptions.MyArgument)}"));
+            var rootCmd = new RootCommand();
+            rootCmd.Options.Add(new Option<int>($"-{nameof(MyOptions.MyArgument)}"));
             rootCmd.Action = CommandHandler.Create((IHost host) =>
             {
                 options = host.Services
@@ -192,7 +192,7 @@ namespace System.CommandLine.Hosting.Tests
                     .Value;
             });
 
-            int result = new CliConfiguration(rootCmd)
+            int result = new CommandLineConfiguration(rootCmd)
                 .UseHost(host =>
                 {
                     host.ConfigureServices(services =>
@@ -241,7 +241,7 @@ namespace System.CommandLine.Hosting.Tests
         public async static Task GetParseResult_returns_non_null_instance()
         {
             bool ctxAsserted = false;
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                 .UseHost(hostBuilder =>
                 {
                     ParseResult ctx = hostBuilder.GetParseResult();
@@ -257,7 +257,7 @@ namespace System.CommandLine.Hosting.Tests
         public async static Task GetParseResult_in_ConfigureServices_returns_non_null_instance()
         {
             bool ctxAsserted = false;
-            var config = new CliConfiguration(new CliRootCommand())
+            var config = new CommandLineConfiguration(new RootCommand())
                 .UseHost(hostBuilder =>
                 {
                     hostBuilder.ConfigureServices((hostingCtx, services) =>

--- a/src/System.CommandLine.Hosting/HostingAction.cs
+++ b/src/System.CommandLine.Hosting/HostingAction.cs
@@ -18,20 +18,20 @@ namespace System.CommandLine.Hosting
 
         private readonly Func<string[], IHostBuilder> _hostBuilderFactory;
         private readonly Action<IHostBuilder> _configureHost;
-        private readonly AsynchronousCliAction _actualAction;
+        private readonly AsynchronousCommandLineAction _actualAction;
 
-        internal static void SetHandlers(CliCommand command, Func<string[], IHostBuilder> hostBuilderFactory, Action<IHostBuilder> configureHost)
+        internal static void SetHandlers(Command command, Func<string[], IHostBuilder> hostBuilderFactory, Action<IHostBuilder> configureHost)
         {
-            command.Action = new HostingAction(hostBuilderFactory, configureHost, (AsynchronousCliAction)command.Action);
+            command.Action = new HostingAction(hostBuilderFactory, configureHost, (AsynchronousCommandLineAction)command.Action);
             command.TreatUnmatchedTokensAsErrors = false; // to pass unmatched Tokens to host builder factory
 
-            foreach (CliCommand subCommand in command.Subcommands)
+            foreach (Command subCommand in command.Subcommands)
             {
                 SetHandlers(subCommand, hostBuilderFactory, configureHost);
             }
         }
 
-        private HostingAction(Func<string[], IHostBuilder> hostBuilderFactory, Action<IHostBuilder> configureHost, AsynchronousCliAction actualAction)
+        private HostingAction(Func<string[], IHostBuilder> hostBuilderFactory, Action<IHostBuilder> configureHost, AsynchronousCommandLineAction actualAction)
         {
             _hostBuilderFactory = hostBuilderFactory;
             _configureHost = configureHost;
@@ -50,7 +50,7 @@ namespace System.CommandLine.Hosting
                               ?? new HostBuilder();
             hostBuilder.Properties[typeof(ParseResult)] = parseResult;
 
-            if (parseResult.Configuration.RootCommand is CliRootCommand root &&
+            if (parseResult.Configuration.RootCommand is RootCommand root &&
                 root.Directives.SingleOrDefault(d => d.Name == HostingDirectiveName) is { } directive)
             {
                 if (parseResult.GetResult(directive) is { } directiveResult)

--- a/src/System.CommandLine.Hosting/HostingExtensions.cs
+++ b/src/System.CommandLine.Hosting/HostingExtensions.cs
@@ -11,14 +11,14 @@ namespace System.CommandLine.Hosting
 {
     public static class HostingExtensions
     {
-        public static CliConfiguration UseHost(
-            this CliConfiguration config,
+        public static CommandLineConfiguration UseHost(
+            this CommandLineConfiguration config,
             Func<string[], IHostBuilder> hostBuilderFactory,
             Action<IHostBuilder> configureHost = null)
         {
-            if (config.RootCommand is CliRootCommand root)
+            if (config.RootCommand is RootCommand root)
             {
-                root.Add(new CliDirective(HostingAction.HostingDirectiveName));
+                root.Add(new Directive(HostingAction.HostingDirectiveName));
             }
 
             HostingAction.SetHandlers(config.RootCommand, hostBuilderFactory, configureHost);
@@ -26,8 +26,8 @@ namespace System.CommandLine.Hosting
             return config;
         }
 
-        public static CliConfiguration UseHost(
-            this CliConfiguration config,
+        public static CommandLineConfiguration UseHost(
+            this CommandLineConfiguration config,
             Action<IHostBuilder> configureHost = null
         ) => UseHost(config, null, configureHost);
 
@@ -57,10 +57,10 @@ namespace System.CommandLine.Hosting
             });
         }
 
-        public static CliCommand UseCommandHandler<THandler>(this CliCommand command)
-            where THandler : CliAction
+        public static Command UseCommandHandler<THandler>(this Command command)
+            where THandler : CommandLineAction
         {
-            command.Action = CommandHandler.Create(typeof(THandler).GetMethod(nameof(AsynchronousCliAction.InvokeAsync)));
+            command.Action = CommandHandler.Create(typeof(THandler).GetMethod(nameof(AsynchronousCommandLineAction.InvokeAsync)));
 
             return command;
         }

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ModelBinderTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ModelBinderTests.cs
@@ -27,7 +27,7 @@ public class ModelBinderTests
         var targetType = typeof(ClassWithCtorParameter<>).MakeGenericType(type);
         var binder = new ModelBinder(targetType);
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
             OptionBuilder.CreateOption("--value", type)
         };
@@ -54,7 +54,7 @@ public class ModelBinderTests
         var targetType = typeof(ClassWithCtorParameter<>).MakeGenericType(type);
         var binder = new ModelBinder(targetType);
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
             ArgumentBuilder.CreateArgument(type)
         };
@@ -77,7 +77,7 @@ public class ModelBinderTests
         var targetType = typeof(ClassWithCtorParameter<>).MakeGenericType(type);
         var binder = new ModelBinder(targetType);
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
             ArgumentBuilder.CreateArgument(type)
         };
@@ -97,16 +97,16 @@ public class ModelBinderTests
     [Fact]
     public void Explicitly_configured_default_values_can_be_bound_by_name_to_constructor_parameters()
     {
-        var option = new CliOption<string>("--string-option")
+        var option = new Option<string>("--string-option")
         {
             DefaultValueFactory = (_) => "the default",
         };
 
-        var command = new CliCommand("the-command");
+        var command = new Command("the-command");
         command.Options.Add(option);
         var binder = new ModelBinder(typeof(ClassWithMultiLetterCtorParameters));
 
-        var bindingContext = CliParser.Parse(command, "").GetBindingContext();
+        var bindingContext = CommandLineParser.Parse(command, "").GetBindingContext();
 
         var instance = (ClassWithMultiLetterCtorParameters)binder.CreateInstance(bindingContext);
 
@@ -126,7 +126,7 @@ public class ModelBinderTests
         var targetType = typeof(ClassWithSetter<>).MakeGenericType(type);
         var binder = new ModelBinder(targetType);
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
             OptionBuilder.CreateOption("--value", type)
         };
@@ -153,7 +153,7 @@ public class ModelBinderTests
         var targetType = typeof(ClassWithSetter<>).MakeGenericType(type);
         var binder = new ModelBinder(targetType);
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
             ArgumentBuilder.CreateArgument(type)
         };
@@ -172,9 +172,9 @@ public class ModelBinderTests
     {
         var tempPath = Path.GetTempPath();
 
-        var option = new CliOption<DirectoryInfo>("--value");
+        var option = new Option<DirectoryInfo>("--value");
 
-        var command = new CliCommand("the-command");
+        var command = new Command("the-command");
         command.Options.Add(option);
         var binder = new ModelBinder(typeof(ClassWithCtorParameter<DirectoryInfo>));
         var bindingContext = command.Parse($"--value \"{tempPath}\"").GetBindingContext();
@@ -187,9 +187,9 @@ public class ModelBinderTests
     [Fact]
     public void Explicitly_configured_default_values_can_be_bound_by_name_to_property_setters()
     {
-        var option = new CliOption<string>("--value") { DefaultValueFactory = (_) => "the default" };
+        var option = new Option<string>("--value") { DefaultValueFactory = (_) => "the default" };
 
-        var command = new CliCommand("the-command");
+        var command = new Command("the-command");
         command.Options.Add(option);
         var binder = new ModelBinder(typeof(ClassWithSetter<string>));
 
@@ -203,9 +203,9 @@ public class ModelBinderTests
     [Fact]
     public void Property_setters_with_no_default_value_and_no_matching_option_are_not_called()
     {
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
-            new CliOption<string>("--string-option")
+            new Option<string>("--string-option")
         };
 
         var binder = new ModelBinder(typeof(ClassWithSettersAndCtorParametersWithDifferentNames));
@@ -220,9 +220,9 @@ public class ModelBinderTests
     [Fact]
     public void Parse_result_can_be_used_to_create_an_instance_without_doing_handler_invocation()
     {
-        CliCommand command = new ("the-command")
+        Command command = new ("the-command")
         {
-            new CliOption<int>("--int-option")
+            new Option<int>("--int-option")
         };
         var bindingContext = command.Parse("the-command --int-option 123").GetBindingContext();
         var binder = new ModelBinder(typeof(ClassWithMultiLetterSetters));
@@ -235,9 +235,9 @@ public class ModelBinderTests
     [Fact]
     public void Parse_result_can_be_used_to_modify_an_existing_instance_without_doing_handler_invocation()
     {
-        CliCommand command = new("the-command")
+        Command command = new("the-command")
         {
-            new CliOption<int>("--int-option")
+            new Option<int>("--int-option")
         };
         var instance = new ClassWithMultiLetterSetters();
         var bindingContext = command.Parse("the-command --int-option 123").GetBindingContext();
@@ -251,7 +251,7 @@ public class ModelBinderTests
     [Fact]
     public void Modify_an_existing_instance_should_keep_all_default_values_if_no_argument_matches_option()
     {
-        CliCommand parser = new ("the-command");
+        Command parser = new ("the-command");
 
         var instance = new ClassWithComplexTypes();
         var bindingContext = parser.Parse("the-command").GetBindingContext();
@@ -265,10 +265,10 @@ public class ModelBinderTests
     [Fact]
     public void Values_from_options_on_parent_commands_are_bound_by_name_by_default()
     {
-        var parentCommand = new CliCommand("parent-command")
+        var parentCommand = new Command("parent-command")
         {
-            new CliOption<int>("--int-option"),
-            new CliCommand("child-command")
+            new Option<int>("--int-option"),
+            new Command("child-command")
         };
 
         var binder = new ModelBinder<ClassWithMultiLetterSetters>();
@@ -285,13 +285,13 @@ public class ModelBinderTests
     [Fact]
     public void Default_values_from_options_on_parent_commands_are_bound_by_name_by_default()
     {
-        var parentCommand = new CliCommand("parent-command")
+        var parentCommand = new Command("parent-command")
         {
-            new CliOption<int>("--int-option")
+            new Option<int>("--int-option")
             { 
                 DefaultValueFactory = (_) => 123,
             },
-            new CliCommand("child-command")
+            new Command("child-command")
         };
 
         var binder = new ModelBinder<ClassWithMultiLetterSetters>();
@@ -308,10 +308,10 @@ public class ModelBinderTests
     [Fact]
     public void Values_from_parent_command_arguments_are_bound_by_name_by_default()
     {
-        var parentCommand = new CliCommand("parent-command")
+        var parentCommand = new Command("parent-command")
         {
-            new CliArgument<int>(nameof(ClassWithMultiLetterSetters.IntOption)),
-            new CliCommand("child-command")
+            new Argument<int>(nameof(ClassWithMultiLetterSetters.IntOption)),
+            new Command("child-command")
         };
 
         var binder = new ModelBinder<ClassWithMultiLetterSetters>();
@@ -328,13 +328,13 @@ public class ModelBinderTests
     [Fact]
     public void Default_values_from_parent_command_arguments_are_bound_by_name_by_default()
     {
-        var parentCommand = new CliCommand("parent-command")
+        var parentCommand = new Command("parent-command")
         {
-            new CliArgument<int>(nameof(ClassWithMultiLetterSetters.IntOption))
+            new Argument<int>(nameof(ClassWithMultiLetterSetters.IntOption))
             {
                 DefaultValueFactory = (_) => 123
             },
-            new CliCommand("child-command")
+            new Command("child-command")
         };
 
         var binder = new ModelBinder<ClassWithMultiLetterSetters>();
@@ -351,9 +351,9 @@ public class ModelBinderTests
     [Fact]
     public void Values_from_options_on_parent_commands_can_be_bound_regardless_of_naming()
     {
-        var childCommand = new CliCommand("child-command");
-        var option = new CliOption<int>("-x");
-        var parentCommand = new CliCommand("parent-command")
+        var childCommand = new Command("child-command");
+        var option = new Option<int>("-x");
+        var parentCommand = new Command("parent-command")
         {
             option,
             childCommand
@@ -375,7 +375,7 @@ public class ModelBinderTests
     [Fact]
     public void Arbitrary_values_can_be_bound()
     {
-        var command = new CliCommand("the-command");
+        var command = new Command("the-command");
 
         var binder = new ModelBinder<ClassWithMultiLetterSetters>();
 
@@ -393,8 +393,8 @@ public class ModelBinderTests
     [Fact]
     public void PropertyInfo_can_be_bound_to_option()
     {
-        var command = new CliCommand("the-command");
-        var option = new CliOption<int>("--fred");
+        var command = new Command("the-command");
+        var option = new Option<int>("--fred");
         command.Add(option);
 
         var type = typeof(ClassWithMultiLetterSetters);
@@ -415,8 +415,8 @@ public class ModelBinderTests
     [Fact]
     public void PropertyInfo_can_be_bound_to_argument()
     {
-        var command = new CliCommand("the-command");
-        var argument = new CliArgument<int>("arg") { Arity = ArgumentArity.ExactlyOne };
+        var command = new Command("the-command");
+        var argument = new Argument<int>("arg") { Arity = ArgumentArity.ExactlyOne };
         command.Arguments.Add(argument);
 
         var type = typeof(ClassWithMultiLetterSetters);
@@ -435,8 +435,8 @@ public class ModelBinderTests
     [Fact]
     public void PropertyExpression_can_be_bound_to_option()
     {
-        var command = new CliCommand("the-command");
-        var option = new CliOption<int>("--fred");
+        var command = new Command("the-command");
+        var option = new Option<int>("--fred");
         command.Options.Add(option);
 
         var binder = new ModelBinder<ClassWithMultiLetterSetters>();
@@ -455,8 +455,8 @@ public class ModelBinderTests
     [Fact]
     public void PropertyExpression_can_be_bound_to_argument()
     {
-        var command = new CliCommand("the-command");
-        var argument = new CliArgument<int>("arg") { Arity = ArgumentArity.ExactlyOne };
+        var command = new Command("the-command");
+        var argument = new Argument<int>("arg") { Arity = ArgumentArity.ExactlyOne };
         command.Arguments.Add(argument);
 
         var binder = new ModelBinder<ClassWithMultiLetterSetters>();
@@ -475,9 +475,9 @@ public class ModelBinderTests
     [Fact]
     public void Option_argument_is_bound_to_longest_constructor()
     {
-        var option = new CliOption<int>("--int-property");
+        var option = new Option<int>("--int-property");
 
-        var bindingContext = new CliRootCommand { option }.Parse("--int-property 42").GetBindingContext();
+        var bindingContext = new RootCommand { option }.Parse("--int-property 42").GetBindingContext();
         var binder = new ModelBinder<ClassWithMultipleCtor>();
         var instance = binder.CreateInstance(bindingContext) as ClassWithMultipleCtor;
 
@@ -488,8 +488,8 @@ public class ModelBinderTests
     [Fact]
     public void Command_argument_is_bound_to_longest_constructor()
     {
-        var rootCommand = new CliRootCommand();
-        rootCommand.Arguments.Add(new CliArgument<int>(nameof(ClassWithMultipleCtor.IntProperty)));
+        var rootCommand = new RootCommand();
+        rootCommand.Arguments.Add(new Argument<int>(nameof(ClassWithMultipleCtor.IntProperty)));
 
         var bindingContext = rootCommand.Parse("42").GetBindingContext();
         var binder = new ModelBinder<ClassWithMultipleCtor>();
@@ -502,9 +502,9 @@ public class ModelBinderTests
     [Fact]
     public void Explicit_model_binder_binds_only_to_configured_properties()
     {
-        var intOption = new CliOption<int>("--int-property");
-        var stringOption = new CliOption<string>("--string-property");
-        CliRootCommand rootCommand = new CliRootCommand { intOption, stringOption };
+        var intOption = new Option<int>("--int-property");
+        var stringOption = new Option<string>("--string-property");
+        RootCommand rootCommand = new RootCommand { intOption, stringOption };
 
         var bindingContext = rootCommand.Parse("--int-property 42 --string-property Hello").GetBindingContext();
         var binder = new ModelBinder<ClassWithMultiLetterSetters>
@@ -522,9 +522,9 @@ public class ModelBinderTests
     [Fact]
     public async Task Bound_array_command_arguments_default_to_an_empty_array_when_not_specified()
     {
-        var rootCommand = new CliRootCommand("Command")
+        var rootCommand = new RootCommand("Command")
         {
-            new CliArgument<string[]>("names")
+            new Argument<string[]>("names")
         };
         rootCommand.Action = CommandHandler.Create<string[]>(Handler);
         string[] passedNames = null;
@@ -542,9 +542,9 @@ public class ModelBinderTests
     [Fact]
     public async Task Bound_enumerable_command_arguments_default_to_an_empty_array_when_not_specified()
     {
-        var rootCommand = new CliRootCommand("Command")
+        var rootCommand = new RootCommand("Command")
         {
-            new CliArgument<IEnumerable<string>>("names")
+            new Argument<IEnumerable<string>>("names")
         };
         rootCommand.Action = CommandHandler.Create<IEnumerable<string>>(Handler);
         IEnumerable<string> passedNames = null;
@@ -562,9 +562,9 @@ public class ModelBinderTests
     [Fact]
     public async Task Bound_array_options_default_to_an_empty_array_when_not_specified()
     {
-        var rootCommand = new CliRootCommand("Command")
+        var rootCommand = new RootCommand("Command")
         {
-            new CliOption<string[]>("--names")
+            new Option<string[]>("--names")
         };
         rootCommand.Action = CommandHandler.Create<string[]>(Handler);
         string[] passedNames = null;
@@ -582,9 +582,9 @@ public class ModelBinderTests
     [Fact]
     public async Task Bound_enumerable_options_default_to_an_empty_array_when_not_specified()
     {
-        var rootCommand = new CliRootCommand("Command")
+        var rootCommand = new RootCommand("Command")
         {
-            new CliOption<IEnumerable<string>>("--names"),
+            new Option<IEnumerable<string>>("--names"),
         };
         rootCommand.Action = CommandHandler.Create<IEnumerable<string>>(Handler);
         IEnumerable<string> passedNames = null;
@@ -604,10 +604,10 @@ public class ModelBinderTests
     {
         int first = 0, second = 0;
 
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
-            new CliOption<int>("one") { DefaultValueFactory = (_) => 1 },
-            new CliOption<int>("two") { DefaultValueFactory = (_) => 2 }
+            new Option<int>("one") { DefaultValueFactory = (_) => 1 },
+            new Option<int>("two") { DefaultValueFactory = (_) => 2 }
         };
         rootCommand.Action = CommandHandler.Create<int, int>((one, two) =>
         {
@@ -615,7 +615,7 @@ public class ModelBinderTests
             second = two;
         });
 
-        var config = new CliConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand);
 
         config.Invoke("");
 
@@ -626,9 +626,9 @@ public class ModelBinderTests
     [Fact]
     public void Binder_does_not_match_on_partial_name()
     {
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
-            new CliOption<List<string>>("--abc")
+            new Option<List<string>>("--abc")
         };
 
         ClassWithOnePropertyNameThatIsSubstringOfAnother boundValue = default;
@@ -652,7 +652,7 @@ public class ModelBinderTests
     {
         ClassWithListTypePropertiesAndDefaultCtor boundInstance = default;
 
-        var cmd = new CliRootCommand
+        var cmd = new RootCommand
         {
             Action = CommandHandler.Create((ClassWithListTypePropertiesAndDefaultCtor value) => { boundInstance = value; })
         };
@@ -669,9 +669,9 @@ public class ModelBinderTests
     {
         decimal? receivedValue = null;
 
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
-            new CliOption<decimal>("--opt-decimal")
+            new Option<decimal>("--opt-decimal")
         };
         rootCommand.Action = CommandHandler.Create((ComplexType options) => { receivedValue = options.OptDecimal; });
 
@@ -688,13 +688,13 @@ public class ModelBinderTests
     [Fact] // issue: https://github.com/dotnet/command-line-api/issues/1365
     public void Binder_does_not_match_by_substring()
     {
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
-            new CliOption<string>("--bundle", "-b")
+            new Option<string>("--bundle", "-b")
             { 
                 Description = "the path to the app bundle to be installed"
             },
-            new CliOption<string>("--bundle-id", "--bundle_id", "-1")
+            new Option<string>("--bundle-id", "--bundle_id", "-1")
             {
                 Description = "specify bundle id for list and upload"
             }
@@ -717,8 +717,8 @@ public class ModelBinderTests
     [Fact]
     public void ParseResult_GetValue_with_generic_option_returns_value()
     {
-        CliOption<int> option = new("--number");
-        CliCommand command = new("the-command")
+        Option<int> option = new("--number");
+        Command command = new("the-command")
         {
             option
         };
@@ -733,8 +733,8 @@ public class ModelBinderTests
     [Fact]
     public void ParseResult_GetValue_with_generic_argument_returns_value()
     {
-        CliArgument<int> argument = new("arg");
-        CliCommand command = new("the-command")
+        Argument<int> argument = new("arg");
+        Command command = new("the-command")
         {
             argument
         };
@@ -759,10 +759,10 @@ public class ModelBinderTests
     [InlineData("--int-value 1234")]
     public void When_only_available_constructor_is_span_then_null_is_passed(string commandLine)
     {
-        var root = new CliRootCommand
+        var root = new RootCommand
         {
-            new CliOption<ClassWithSpanConstructor>("--class-with-span-ctor"),
-            new CliOption<int>("--int-value"),
+            new Option<ClassWithSpanConstructor>("--class-with-span-ctor"),
+            new Option<int>("--int-value"),
         };
 
         var handlerWasCalled = false;

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.BindingByName.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.BindingByName.cs
@@ -32,12 +32,12 @@ public partial class ModelBindingCommandHandlerTests
             var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
                                            .GetCommandHandler();
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 OptionBuilder.CreateOption("--value", type)
             };
             command.Action = handler;
-            CliConfiguration configuration = new(command)
+            CommandLineConfiguration configuration = new(command)
             {
                 Output = new StringWriter()
             };
@@ -66,12 +66,12 @@ public partial class ModelBindingCommandHandlerTests
             var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
                                            .GetCommandHandler();
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 OptionBuilder.CreateOption("--value", type)
             };
             command.Action = handler;
-            CliConfiguration configuration = new(command)
+            CommandLineConfiguration configuration = new(command)
             {
                 Output = new StringWriter()
             };
@@ -100,12 +100,12 @@ public partial class ModelBindingCommandHandlerTests
             var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
                                            .GetCommandHandler();
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 OptionBuilder.CreateOption("--value", type)
             };
             command.Action = handler;
-            CliConfiguration configuration = new(command)
+            CommandLineConfiguration configuration = new(command)
             {
                 Output = new StringWriter()
             };
@@ -130,12 +130,12 @@ public partial class ModelBindingCommandHandlerTests
             var handler = HandlerDescriptor.FromMethodInfo(handlerMethod)
                                            .GetCommandHandler();
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 ArgumentBuilder.CreateArgument(type)
             };
             command.Action = handler;
-            CliConfiguration configuration = new(command)
+            CommandLineConfiguration configuration = new(command)
             {
                 Output = new StringWriter()
             };
@@ -150,9 +150,9 @@ public partial class ModelBindingCommandHandlerTests
         {
             FileSystemInfo received = null;
 
-            var root = new CliRootCommand
+            var root = new RootCommand
             {
-                new CliOption<DirectoryInfo>("-f")
+                new Option<DirectoryInfo>("-f")
             };
             root.Action = CommandHandler.Create<FileSystemInfo>(f => received = f);
             var path = $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}";

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ModelBindingCommandHandlerTests.cs
@@ -33,7 +33,7 @@ public partial class ModelBindingCommandHandlerTests
 
         var handler = CommandHandler.Create(captureMethod);
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
             OptionBuilder.CreateOption("-x", parameterType)
         };
@@ -88,7 +88,7 @@ public partial class ModelBindingCommandHandlerTests
     {
         var testCase = BindingCases[(type, variation)];
 
-        AsynchronousCliAction handler;
+        AsynchronousCommandLineAction handler;
         if (!useDelegate)
         {
             var captureMethod = GetType()
@@ -108,7 +108,7 @@ public partial class ModelBindingCommandHandlerTests
             handler = CommandHandler.Create((Delegate)@delegate);
         }
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
             OptionBuilder.CreateOption("--value", testCase.ParameterType)
         };
@@ -131,11 +131,11 @@ public partial class ModelBindingCommandHandlerTests
     {
         string[] received = { "this should get overwritten" };
 
-        var o = new CliOption<string[]>("-i") { Description = "Path to an image or directory of supported images" };
+        var o = new Option<string[]>("-i") { Description = "Path to an image or directory of supported images" };
 
-        var command = new CliCommand("command") { o };
+        var command = new Command("command") { o };
         command.Action = CommandHandler.Create<string[], ParseResult>((nameDoesNotMatch, c) => received = nameDoesNotMatch);
-        CliConfiguration config = new(command);
+        CommandLineConfiguration config = new(command);
         config.Error = new StringWriter();
 
         var commandLine = "command -i 1 -i 2 -i 3 ";
@@ -168,7 +168,7 @@ public partial class ModelBindingCommandHandlerTests
 
         var handler = CommandHandler.Create(captureMethod);
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
             ArgumentBuilder.CreateArgument(type)
         };
@@ -213,7 +213,7 @@ public partial class ModelBindingCommandHandlerTests
 
         var argument = ArgumentBuilder.CreateArgument(testCase.ParameterType, "value");
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
             argument
         };
@@ -264,7 +264,7 @@ public partial class ModelBindingCommandHandlerTests
 
         var option = OptionBuilder.CreateOption("--value", testCase.ParameterType);
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
             option
         };
@@ -298,7 +298,7 @@ public partial class ModelBindingCommandHandlerTests
             return true;
         };
 
-        var command = new CliCommand("wat")
+        var command = new Command("wat")
         {
             Action = CommandHandler.Create(@delegate)
         };

--- a/src/System.CommandLine.NamingConventionBinder.Tests/ParameterBindingTests.cs
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/ParameterBindingTests.cs
@@ -25,9 +25,9 @@ public class ParameterBindingTests
             boundAge = age;
         }
 
-        var command = new CliCommand("command");
-        command.Options.Add(new CliOption<string>("--name"));
-        command.Options.Add(new CliOption<int>("--age"));
+        var command = new Command("command");
+        command.Options.Add(new Option<string>("--name"));
+        command.Options.Add(new Option<int>("--age"));
         command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.Parse("command --age 425 --name Gandalf").InvokeAsync();
@@ -46,9 +46,9 @@ public class ParameterBindingTests
             boundFirstName = firstName;
         }
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<string>("--first-name")
+            new Option<string>("--first-name")
         };
         command.Action = CommandHandler.Create<string>(Execute);
 
@@ -69,9 +69,9 @@ public class ParameterBindingTests
             boundAge = AGE;
         }
 
-        var command = new CliCommand("command");
-        command.Options.Add(new CliOption<string>("--NAME"));
-        command.Options.Add(new CliOption<int>("--age"));
+        var command = new Command("command");
+        command.Options.Add(new Option<string>("--NAME"));
+        command.Options.Add(new Option<int>("--age"));
         command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.Parse("command --age 425 --NAME Gandalf").InvokeAsync();
@@ -92,10 +92,10 @@ public class ParameterBindingTests
             boundAge = age;
         }
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<string>("--name"),
-            new CliOption<int>("--age")
+            new Option<string>("--name"),
+            new Option<int>("--age")
         };
         command.Action = CommandHandler.Create<string, int>(Execute);
 
@@ -117,10 +117,10 @@ public class ParameterBindingTests
             boundAge = age;
         }
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<string>("--NAME", "-n"),
-            new CliOption<int>("--age", "-a")
+            new Option<string>("--NAME", "-n"),
+            new Option<int>("--age", "-a")
         };
         command.Action = CommandHandler.Create<string, int>(Execute);
 
@@ -136,10 +136,10 @@ public class ParameterBindingTests
         string boundName = default;
         int boundAge = default;
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<string>("--name"),
-            new CliOption<int>("--age")
+            new Option<string>("--name"),
+            new Option<int>("--age")
         };
         command.Action = CommandHandler.Create<string, int>((name, age) =>
         {
@@ -158,9 +158,9 @@ public class ParameterBindingTests
     {
         int? boundAge = default;
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<int?>("--age")
+            new Option<int?>("--age")
         };
         command.Action = CommandHandler.Create<int?>(age =>
         {
@@ -178,9 +178,9 @@ public class ParameterBindingTests
         var wasCalled = false;
         int? boundAge = default;
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<int?>("--age")
+            new Option<int?>("--age")
         };
         command.Action = CommandHandler.Create<int?>(age =>
         {
@@ -200,9 +200,9 @@ public class ParameterBindingTests
         DirectoryInfo boundDirectoryInfo = default;
         var tempPath = Path.GetTempPath();
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<DirectoryInfo>("--dir")
+            new Option<DirectoryInfo>("--dir")
         };
         command.Action = CommandHandler.Create<DirectoryInfo>(dir =>
         {
@@ -219,9 +219,9 @@ public class ParameterBindingTests
     {
         ParseResult boundParseResult = default;
 
-        var option = new CliOption<int>("-x");
+        var option = new Option<int>("-x");
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
             option
         };
@@ -237,8 +237,8 @@ public class ParameterBindingTests
     {
         BindingContext boundContext = default;
 
-        var option = new CliOption<int>("-x");
-        var command = new CliCommand("command")
+        var option = new Option<int>("-x");
+        var command = new Command("command")
         {
             option
         };
@@ -268,10 +268,10 @@ public class ParameterBindingTests
     {
         var testClass = new ExecuteTestClass();
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<string>("--name"),
-            new CliOption<int>("--age")
+            new Option<string>("--name"),
+            new Option<int>("--age")
         };
         command.Action = CommandHandler.Create((ExecuteTestDelegate)testClass.Execute);
 
@@ -286,10 +286,10 @@ public class ParameterBindingTests
     {
         var testClass = new ExecuteTestClass();
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliOption<string>("--name"),
-            new CliOption<int>("--age")
+            new Option<string>("--name"),
+            new Option<int>("--age")
         };
         command.Action = CommandHandler.Create(
             testClass.GetType().GetMethod(nameof(ExecuteTestClass.Execute)),
@@ -313,9 +313,9 @@ public class ParameterBindingTests
             boundAge = age;
         }
 
-        var command = new CliCommand("command");
-        command.Arguments.Add(new CliArgument<int>("age"));
-        command.Arguments.Add(new CliArgument<string>("name"));
+        var command = new Command("command");
+        command.Arguments.Add(new Argument<int>("age"));
+        command.Arguments.Add(new Argument<string>("name"));
         command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.Parse("command 425 Gandalf").InvokeAsync();
@@ -334,9 +334,9 @@ public class ParameterBindingTests
             boundFirstName = firstName;
         }
 
-        var command = new CliCommand("command")
+        var command = new Command("command")
         {
-            new CliArgument<string>("first-name")
+            new Argument<string>("first-name")
         };
         command.Action = CommandHandler.Create<string>(Execute);
 
@@ -357,9 +357,9 @@ public class ParameterBindingTests
             boundAge = AGE;
         }
 
-        var command = new CliCommand("command");
-        command.Arguments.Add(new CliArgument<int>("AGE"));
-        command.Arguments.Add(new CliArgument<string>("Name"));
+        var command = new Command("command");
+        command.Arguments.Add(new Argument<int>("AGE"));
+        command.Arguments.Add(new Argument<string>("Name"));
         command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.Parse("command 425 Gandalf").InvokeAsync();
@@ -380,9 +380,9 @@ public class ParameterBindingTests
             boundAge = age;
         }
 
-        var command = new CliCommand("command");
-        command.Arguments.Add(new CliArgument<int>("age"));
-        command.Arguments.Add(new CliArgument<string>("fullname|nickname"));
+        var command = new Command("command");
+        command.Arguments.Add(new Argument<int>("age"));
+        command.Arguments.Add(new Argument<string>("fullname|nickname"));
         command.Action = CommandHandler.Create<string, int>(Execute);
 
         await command.Parse("command 425 Gandalf").InvokeAsync();
@@ -397,15 +397,15 @@ public class ParameterBindingTests
     [InlineData(typeof(OverridenVirtualTestCommandHandler), 41)]
     public async Task Method_invoked_is_matching_to_the_interface_implementation(Type type, int expectedResult)
     {
-        var command = new CliCommand("command");
-        command.Action = CommandHandler.Create(type.GetMethod(nameof(AsynchronousCliAction.InvokeAsync)));
+        var command = new Command("command");
+        command.Action = CommandHandler.Create(type.GetMethod(nameof(AsynchronousCommandLineAction.InvokeAsync)));
 
         int result = await command.Parse("command").InvokeAsync();
 
         result.Should().Be(expectedResult);
     }
 
-    public abstract class AbstractTestCommandHandler : AsynchronousCliAction
+    public abstract class AbstractTestCommandHandler : AsynchronousCommandLineAction
     {
         public abstract Task<int> DoJobAsync();
         
@@ -419,7 +419,7 @@ public class ParameterBindingTests
             => Task.FromResult(42);
     }
 
-    public class VirtualTestCommandHandler : AsynchronousCliAction
+    public class VirtualTestCommandHandler : AsynchronousCommandLineAction
     {
         public override Task<int> InvokeAsync(ParseResult context, CancellationToken cancellationToken)
             => Task.FromResult(42);

--- a/src/System.CommandLine.NamingConventionBinder/BindingContext.cs
+++ b/src/System.CommandLine.NamingConventionBinder/BindingContext.cs
@@ -88,11 +88,11 @@ namespace System.CommandLine.Binding
                 }
                 else
                 {
-                    ArgumentResult argumentResult = valueDescriptor is CliArgument argument 
+                    ArgumentResult argumentResult = valueDescriptor is Argument argument 
                         ? parseResult.GetResult(argument) is ArgumentResult found
                             ? found
                             : new ArgumentResult(argument, parseResult.RootCommandResult.SymbolResultTree, null)
-                        : new ArgumentResult(new CliArgument<string>(valueDescriptor.ValueName), parseResult.RootCommandResult.SymbolResultTree, null);
+                        : new ArgumentResult(new Argument<string>(valueDescriptor.ValueName), parseResult.RootCommandResult.SymbolResultTree, null);
 
                     var parsed = ArgumentConverter.ConvertObject(
                         argumentResult,

--- a/src/System.CommandLine.NamingConventionBinder/BindingHandler.cs
+++ b/src/System.CommandLine.NamingConventionBinder/BindingHandler.cs
@@ -6,7 +6,7 @@ using System.CommandLine.Invocation;
 
 namespace System.CommandLine.NamingConventionBinder
 {
-    public abstract class BindingHandler : AsynchronousCliAction
+    public abstract class BindingHandler : AsynchronousCommandLineAction
     {
         private BindingContext? _bindingContext;
 

--- a/src/System.CommandLine.NamingConventionBinder/CommandResultExtensions.cs
+++ b/src/System.CommandLine.NamingConventionBinder/CommandResultExtensions.cs
@@ -46,7 +46,7 @@ internal static class CommandResultExtensions
 
         for (var i = 0; i < options.Count; i++)
         {
-            if (options[i] is CliOption option)
+            if (options[i] is Option option)
             {
                 var hasMatchingAlias =
                     HasMatchingAlias(valueDescriptor, option);
@@ -70,7 +70,7 @@ internal static class CommandResultExtensions
 
         static bool HasMatchingAlias(
             IValueDescriptor valueDescriptor,
-            CliOption option)
+            Option option)
         {
             string nameWithoutPrefix = RemovePrefix(option.Name);
             if (valueDescriptor.ValueName.Equals(nameWithoutPrefix, StringComparison.OrdinalIgnoreCase) || valueDescriptor.ValueName.IsMatch(nameWithoutPrefix))

--- a/src/System.CommandLine.NamingConventionBinder/ModelBinder.cs
+++ b/src/System.CommandLine.NamingConventionBinder/ModelBinder.cs
@@ -52,7 +52,7 @@ public class ModelBinder
     /// <param name="property">The property to bind.</param>
     /// <param name="symbol">A symbol to be used to set the property.</param>
     /// <exception cref="ArgumentException"></exception>
-    public void BindMemberFromValue(PropertyInfo property, CliSymbol symbol)
+    public void BindMemberFromValue(PropertyInfo property, Symbol symbol)
     {
         var propertyDescriptor = FindModelPropertyDescriptor(property.PropertyType, property.Name);
 

--- a/src/System.CommandLine.NamingConventionBinder/ModelBinder{T}.cs
+++ b/src/System.CommandLine.NamingConventionBinder/ModelBinder{T}.cs
@@ -22,7 +22,7 @@ public class ModelBinder<TModel> : ModelBinder
     /// <typeparam name="TValue">The type of the value to be bound.</typeparam>
     public void BindMemberFromValue<TValue>(
         Expression<Func<TModel, TValue>> property,
-        CliSymbol symbol)
+        Symbol symbol)
     {
         var (propertyType, propertyName) = property.MemberTypeAndName();
         var propertyDescriptor = FindModelPropertyDescriptor(propertyType, propertyName);

--- a/src/System.CommandLine.NamingConventionBinder/ModelBindingCommandHandler.cs
+++ b/src/System.CommandLine.NamingConventionBinder/ModelBindingCommandHandler.cs
@@ -92,22 +92,22 @@ public class ModelBindingCommandHandler : BindingHandler
     }
 
     /// <summary>
-    /// Binds a method or constructor parameter based on the specified <see cref="CliArgument"/>.
+    /// Binds a method or constructor parameter based on the specified <see cref="Argument"/>.
     /// </summary>
     /// <param name="param">The parameter to bind.</param>
     /// <param name="argument">The argument whose parsed result will be the source of the bound value.</param>
-    public void BindParameter(ParameterInfo param, CliArgument argument)
+    public void BindParameter(ParameterInfo param, Argument argument)
     {
         var _ = argument ?? throw new InvalidOperationException("You must specify an argument to bind");
         BindValueSource(param, new SpecificSymbolValueSource(argument));
     }
 
     /// <summary>
-    /// Binds a method or constructor parameter based on the specified <see cref="CliOption"/>.
+    /// Binds a method or constructor parameter based on the specified <see cref="Option"/>.
     /// </summary>
     /// <param name="param">The parameter to bind.</param>
     /// <param name="option">The option whose parsed result will be the source of the bound value.</param>
-    public void BindParameter(ParameterInfo param, CliOption option)
+    public void BindParameter(ParameterInfo param, Option option)
     {
         var _ = option ?? throw new InvalidOperationException("You must specify an option to bind");
         BindValueSource(param, new SpecificSymbolValueSource(option));

--- a/src/System.CommandLine.NamingConventionBinder/SpecificSymbolValueSource.cs
+++ b/src/System.CommandLine.NamingConventionBinder/SpecificSymbolValueSource.cs
@@ -7,9 +7,9 @@ namespace System.CommandLine.NamingConventionBinder;
 
 internal class SpecificSymbolValueSource : IValueSource
 {
-    private readonly CliSymbol _symbol;
+    private readonly Symbol _symbol;
 
-    public SpecificSymbolValueSource(CliSymbol symbol)
+    public SpecificSymbolValueSource(Symbol symbol)
     {
         _symbol = symbol ?? throw new ArgumentNullException(nameof(symbol));
     }
@@ -20,7 +20,7 @@ internal class SpecificSymbolValueSource : IValueSource
     {
         switch (_symbol)
         {
-            case CliOption option:
+            case Option option:
                 var optionResult = bindingContext?.ParseResult.GetResult(option);
                 if (optionResult is not null)
                 {
@@ -28,7 +28,7 @@ internal class SpecificSymbolValueSource : IValueSource
                     return true;
                 }
                 break;
-            case CliArgument argument:
+            case Argument argument:
                 var argumentResult = bindingContext?.ParseResult.GetResult(argument);
                 if (argumentResult is not null)
                 {

--- a/src/System.CommandLine.Rendering.Tests/TableRenderingTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/TableRenderingTests.cs
@@ -34,8 +34,8 @@ namespace System.CommandLine.Rendering.Tests
         public void A_row_is_written_for_each_item_and_a_header_for_each_column(OutputMode outputMode)
         {
             var options = new[] {
-                new CliOption<string>("-s") { Description = "a short option" },
-                new CliOption<string>("--very-long") { Description = "a long option" }
+                new Option<string>("-s") { Description = "a short option" },
+                new Option<string>("--very-long") { Description = "a long option" }
             };
 
             var view = new OptionsHelpView(options);
@@ -57,8 +57,8 @@ namespace System.CommandLine.Rendering.Tests
         {
             var options = new[]
             {
-                new CliOption<string>("-s") { Description = "a short option" },
-                new CliOption<string>("--very-long") { Description = "a long option" }
+                new Option<string>("-s") { Description = "a short option" },
+                new Option<string>("--very-long") { Description = "a long option" }
             };
 
             var view = new OptionsHelpView(options);
@@ -80,8 +80,8 @@ namespace System.CommandLine.Rendering.Tests
         public void Column_widths_are_aligned_to_the_longest_cell(OutputMode outputMode)
         {
             var options = new[] {
-                new CliOption<string>("-s") { Description = "an option" },
-                new CliOption<string>("--very-long") { Description = "an option" },
+                new Option<string>("-s") { Description = "an option" },
+                new Option<string>("--very-long") { Description = "an option" },
             };
 
             var view = new OptionsHelpView(options);
@@ -101,8 +101,8 @@ namespace System.CommandLine.Rendering.Tests
         public void Column_widths_are_aligned_to_the_longest_cell_in_file_mode()
         {
             var options = new[] {
-                new CliOption<string>("-s") { Description = "an option" },
-                new CliOption<string>("--very-long") { Description = "an option" },
+                new Option<string>("-s") { Description = "an option" },
+                new Option<string>("--very-long") { Description = "an option" },
             };
 
             var view = new OptionsHelpView(options);
@@ -121,9 +121,9 @@ namespace System.CommandLine.Rendering.Tests
         private TextRendered Cell(string text, int left, int top) => new(text, new Point(left, top));
     }
 
-    public class OptionsHelpView : TableView<CliOption>
+    public class OptionsHelpView : TableView<Option>
     {
-        public OptionsHelpView(IEnumerable<CliOption> options)
+        public OptionsHelpView(IEnumerable<Option> options)
         {
             Items = options.ToList();
 

--- a/src/System.CommandLine.Rendering.Tests/ViewRenderingTests.cs
+++ b/src/System.CommandLine.Rendering.Tests/ViewRenderingTests.cs
@@ -22,14 +22,14 @@ namespace System.CommandLine.Rendering.Tests
                 IsAnsiTerminal = false
             };
 
-            var command = new CliRootCommand();
+            var command = new RootCommand();
             command.SetAction(ctx =>
             {
                 parseResult = ctx;
                 terminal.Append(new ParseResultView(parseResult));
             });
 
-            var config = new CliConfiguration(command);
+            var config = new CommandLineConfiguration(command);
 
             config.Invoke("");
 

--- a/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/Program.cs
+++ b/src/System.CommandLine.Suggest.Tests/EndToEndTestApp/Program.cs
@@ -10,16 +10,16 @@ namespace EndToEndTestApp
     {
         static async Task Main(string[] args)
         {
-            CliOption<string> appleOption = new ("--apple" );
-            CliOption<string> bananaOption = new ("--banana");
-            CliOption<string> cherryOption = new ("--cherry");
-            CliOption<string> durianOption = new ("--durian");
+            Option<string> appleOption = new ("--apple" );
+            Option<string> bananaOption = new ("--banana");
+            Option<string> cherryOption = new ("--cherry");
+            Option<string> durianOption = new ("--durian");
 
-            CliRootCommand rootCommand = new ()
+            RootCommand rootCommand = new ()
             {
-                appleOption,          
-                bananaOption,          
-                cherryOption,          
+                appleOption,
+                bananaOption,
+                cherryOption,
                 durianOption,
             };
 
@@ -33,7 +33,7 @@ namespace EndToEndTestApp
                 return Task.CompletedTask;
             });
 
-            CliConfiguration commandLine = new (rootCommand);
+            CommandLineConfiguration commandLine = new (rootCommand);
 
             await commandLine.InvokeAsync(args);
         }

--- a/src/System.CommandLine.Suggest.Tests/SuggestionDispatcherTests.cs
+++ b/src/System.CommandLine.Suggest.Tests/SuggestionDispatcherTests.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine.Suggest.Tests
 {
     public class SuggestionDispatcherTests
     {
-        private static readonly string _currentExeName = CliRootCommand.ExecutableName;
+        private static readonly string _currentExeName = RootCommand.ExecutableName;
         
         private static readonly string _dotnetExeFullPath = 
             DotnetMuxer.Path.FullName;
@@ -38,7 +38,7 @@ namespace System.CommandLine.Suggest.Tests
         {
             string receivedTargetExeName = null;
 
-            string[] args = CliParser.SplitCommandLine($@"get -p 12 -e ""{CurrentExeFullPath()}"" -- ""{_currentExeName} add""").ToArray();
+            string[] args = CommandLineParser.SplitCommandLine($@"get -p 12 -e ""{CurrentExeFullPath()}"" -- ""{_currentExeName} add""").ToArray();
 
             await InvokeAsync(
                 args,
@@ -111,13 +111,13 @@ namespace System.CommandLine.Suggest.Tests
         private static string[] PrepareArgs(string args)
         {
             var formattableString = args.Replace("$", "");
-            return CliParser.SplitCommandLine(formattableString).ToArray();
+            return CommandLineParser.SplitCommandLine(formattableString).ToArray();
         }
 
         [Fact]
         public async Task InvokeAsync_with_unknown_suggestion_provider_returns_empty_string()
         {
-            string[] args = Enumerable.ToArray(CliParser.SplitCommandLine(@"get -p 10 -e ""testcli.exe"" -- command op"));
+            string[] args = Enumerable.ToArray(CommandLineParser.SplitCommandLine(@"get -p 10 -e ""testcli.exe"" -- command op"));
             (await InvokeAsync(args, new TestSuggestionRegistration()))
                 .Should()
                 .BeEmpty();
@@ -131,7 +131,7 @@ namespace System.CommandLine.Suggest.Tests
             dispatcher.Timeout = TimeSpan.FromMilliseconds(1);
             dispatcher.Configuration.Output = new StringWriter();
 
-            var args = CliParser.SplitCommandLine($@"get -p 0 -e ""{_currentExeName}"" -- {_currentExeName} add").ToArray();
+            var args = CommandLineParser.SplitCommandLine($@"get -p 0 -e ""{_currentExeName}"" -- {_currentExeName} add").ToArray();
 
             await dispatcher.InvokeAsync(args);
 
@@ -167,7 +167,7 @@ namespace System.CommandLine.Suggest.Tests
             var provider = new TestSuggestionRegistration();
             var dispatcher = new SuggestionDispatcher(provider);
 
-            var args = CliParser.SplitCommandLine($"register --command-path \"{_netExeFullPath}\"").ToArray();
+            var args = CommandLineParser.SplitCommandLine($"register --command-path \"{_netExeFullPath}\"").ToArray();
 
             await dispatcher.InvokeAsync(args);
 
@@ -181,7 +181,7 @@ namespace System.CommandLine.Suggest.Tests
             var provider = new TestSuggestionRegistration();
             var dispatcher = new SuggestionDispatcher(provider);
 
-            var args = CliParser.SplitCommandLine($"register --command-path \"{_netExeFullPath}\"").ToArray();
+            var args = CommandLineParser.SplitCommandLine($"register --command-path \"{_netExeFullPath}\"").ToArray();
 
             await dispatcher.InvokeAsync(args);
             await dispatcher.InvokeAsync(args);

--- a/src/System.CommandLine.Suggest.Tests/SuggestionShellScriptHandlerTest.cs
+++ b/src/System.CommandLine.Suggest.Tests/SuggestionShellScriptHandlerTest.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Suggest.Tests
 {
     public class SuggestionShellScriptHandlerTest
     {
-        private readonly CliConfiguration _configuration;
+        private readonly CommandLineConfiguration _configuration;
 
         public SuggestionShellScriptHandlerTest()
         {

--- a/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
+++ b/src/System.CommandLine.Suggest/SuggestionDispatcher.cs
@@ -21,9 +21,9 @@ namespace System.CommandLine.Suggest
 
             _suggestionStore = suggestionStore ?? new SuggestionStore();
 
-            var shellTypeArgument = new CliArgument<ShellType>(nameof(ShellType));
+            var shellTypeArgument = new Argument<ShellType>(nameof(ShellType));
 
-            CompleteScriptCommand = new CliCommand("script", "Print complete script for specific shell")
+            CompleteScriptCommand = new Command("script", "Print complete script for specific shell")
             {
                 shellTypeArgument
             };
@@ -32,7 +32,7 @@ namespace System.CommandLine.Suggest
                 SuggestionShellScriptHandler.Handle(context.Configuration.Output, context.GetValue(shellTypeArgument));
             });
 
-            ListCommand = new CliCommand("list")
+            ListCommand = new Command("list")
             {
                 Description = "Lists apps registered for suggestions",
             };
@@ -42,19 +42,19 @@ namespace System.CommandLine.Suggest
                 return Task.CompletedTask;
             });
 
-            GetCommand = new CliCommand("get", "Gets suggestions from the specified executable")
+            GetCommand = new Command("get", "Gets suggestions from the specified executable")
             {
                 ExecutableOption,
                 PositionOption
             };
             GetCommand.SetAction(Get);
 
-            var commandPathOption = new CliOption<string>("--command-path") { Description = "The path to the command for which to register suggestions" };
+            var commandPathOption = new Option<string>("--command-path") { Description = "The path to the command for which to register suggestions" };
 
-            RegisterCommand = new CliCommand("register", "Registers an app for suggestions")
+            RegisterCommand = new Command("register", "Registers an app for suggestions")
             {
                 commandPathOption,
-                new CliOption<string>("--suggestion-command") { Description = "The command to invoke to retrieve suggestions" }
+                new Option<string>("--suggestion-command") { Description = "The command to invoke to retrieve suggestions" }
             };
 
             RegisterCommand.SetAction((context, cancellationToken) =>
@@ -63,7 +63,7 @@ namespace System.CommandLine.Suggest
                 return Task.CompletedTask;
             });
 
-            var root = new CliRootCommand
+            var root = new RootCommand
             {
                 ListCommand,
                 GetCommand,
@@ -71,34 +71,34 @@ namespace System.CommandLine.Suggest
                 CompleteScriptCommand,
             };
             root.TreatUnmatchedTokensAsErrors = false;
-            Configuration = new CliConfiguration(root);
+            Configuration = new CommandLineConfiguration(root);
         }
 
-        private CliCommand CompleteScriptCommand { get; }
+        private Command CompleteScriptCommand { get; }
 
-        private CliCommand GetCommand { get; }
+        private Command GetCommand { get; }
 
-        private CliOption<FileInfo> ExecutableOption { get; } = GetExecutableOption();
+        private Option<FileInfo> ExecutableOption { get; } = GetExecutableOption();
 
-        private static CliOption<FileInfo> GetExecutableOption()
+        private static Option<FileInfo> GetExecutableOption()
         {
-            var option = new CliOption<FileInfo>("--executable", "-e") { Description = "The executable to call for suggestions" };
+            var option = new Option<FileInfo>("--executable", "-e") { Description = "The executable to call for suggestions" };
             option.AcceptLegalFilePathsOnly();
 
             return option;
         }
 
-        private CliCommand ListCommand { get; }
+        private Command ListCommand { get; }
 
-        private CliOption<int> PositionOption { get; } = new("--position", "-p")
+        private Option<int> PositionOption { get; } = new("--position", "-p")
         {
             Description = "The current character position on the command line",
             DefaultValueFactory = (_) => short.MaxValue
         };
 
-        private CliCommand RegisterCommand { get; }
+        private Command RegisterCommand { get; }
 
-        public CliConfiguration Configuration { get; }
+        public CommandLineConfiguration Configuration { get; }
 
         public TimeSpan Timeout { get; set; } = TimeSpan.FromMilliseconds(5000);
 

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -12,7 +12,7 @@ public class ArgumentTests
     [Fact]
     public void By_default_there_is_no_default_value()
     {
-        var argument = new CliArgument<string>("arg");
+        var argument = new Argument<string>("arg");
 
         argument.HasDefaultValue.Should().BeFalse();
     }
@@ -20,7 +20,7 @@ public class ArgumentTests
     [Fact]
     public void When_default_value_factory_is_set_then_HasDefaultValue_is_true()
     {
-        var argument = new CliArgument<string[]>("arg");
+        var argument = new Argument<string[]>("arg");
 
         argument.DefaultValueFactory = _ => null;
 
@@ -30,7 +30,7 @@ public class ArgumentTests
     [Fact]
     public void When_there_is_no_default_value_then_GetDefaultValue_throws()
     {
-        var argument = new CliArgument<string>("the-arg");
+        var argument = new Argument<string>("the-arg");
 
         argument.Invoking(a => a.GetDefaultValue())
                 .Should()
@@ -44,10 +44,10 @@ public class ArgumentTests
     [Fact]
     public void Argument_of_enum_can_limit_enum_members_as_valid_values()
     {
-        var argument = new CliArgument<ConsoleColor>("color");
+        var argument = new Argument<ConsoleColor>("color");
         argument.AcceptOnlyFromAmong(ConsoleColor.Red.ToString(), ConsoleColor.Green.ToString());
 
-        CliCommand command = new("set-color")
+        Command command = new("set-color")
         {
             argument
         };

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -14,22 +14,22 @@ namespace System.CommandLine.Tests.Binding
 {
     public class TypeConversionTests
     {
-        protected T GetValue<T>(CliOption<T> option, string commandLine)
+        protected T GetValue<T>(Option<T> option, string commandLine)
         {
-            var result = new CliRootCommand { option }.Parse(commandLine);
+            var result = new RootCommand { option }.Parse(commandLine);
             return result.GetValue(option);
         }
 
-        protected T GetValue<T>(CliArgument<T> argument, string commandLine)
+        protected T GetValue<T>(Argument<T> argument, string commandLine)
         {
-            var result = new CliRootCommand { argument }.Parse(commandLine);
+            var result = new RootCommand { argument }.Parse(commandLine);
             return result.GetValue(argument);
         }
 
         [Fact]
         public void Option_argument_of_FileInfo_can_be_bound_without_custom_conversion_logic()
         {
-            var option = new CliOption<FileInfo>("--file");
+            var option = new Option<FileInfo>("--file");
 
             var file = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "the-file.txt"));
 
@@ -42,9 +42,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Command_argument_of_FileInfo_can_be_bound_without_custom_conversion_logic()
         {
-            var argument = new CliArgument<FileInfo>("the-arg");
+            var argument = new Argument<FileInfo>("the-arg");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 argument
             };
@@ -61,11 +61,11 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Command_argument_of_FileInfo_returns_null_when_argument_is_not_provided()
         {
-            var argument = new CliArgument<FileInfo>("the-arg")
+            var argument = new Argument<FileInfo>("the-arg")
             {
                 Arity = ArgumentArity.ZeroOrOne
             };
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 argument
             };
@@ -80,8 +80,8 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Argument_of_FileInfo_that_is_empty_results_in_an_informative_error()
         {
-            var option = new CliOption<FileInfo>("--file");
-            var result = new CliRootCommand { option }.Parse(new string[] { "--file", "" });
+            var option = new Option<FileInfo>("--file");
+            var result = new RootCommand { option }.Parse(new string[] { "--file", "" });
 
             result.Errors
                   .Should()
@@ -95,7 +95,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Argument_of_array_of_FileInfo_can_be_called_without_custom_conversion_logic()
         {
-            var option = new CliOption<FileInfo[]>("--file");
+            var option = new Option<FileInfo[]>("--file");
 
             var file1 = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "file1.txt"));
             var file2 = new FileInfo(Path.Combine(new DirectoryInfo("temp").FullName, "file2.txt"));
@@ -109,7 +109,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Argument_defaults_arity_to_One_for_non_IEnumerable_types()
         {
-            var argument = new CliArgument<int>("arg");
+            var argument = new Argument<int>("arg");
 
             argument.Arity.Should().BeEquivalentTo(ArgumentArity.ExactlyOne);
         }
@@ -117,7 +117,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Argument_defaults_arity_to_ExactlyOne_for_string()
         {
-            var argument = new CliArgument<string>("arg");
+            var argument = new Argument<string>("arg");
 
             argument.Arity.Should().BeEquivalentTo(ArgumentArity.ExactlyOne);
         }
@@ -125,9 +125,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Command_Argument_defaults_arity_to_ZeroOrOne_for_nullable_types()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<int?>("arg")
+                new Argument<int?>("arg")
             };
 
             command.Arguments.Single().Arity.Should().BeEquivalentTo(ArgumentArity.ZeroOrOne);
@@ -147,9 +147,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Argument_parses_as_the_default_value_when_the_option_has_not_been_applied()
         {
-            var option = new CliOption<int>("-x") { DefaultValueFactory = (_) => 123 };
+            var option = new Option<int>("-x") { DefaultValueFactory = (_) => 123 };
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 option
             };
@@ -162,9 +162,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Option_does_not_parse_as_the_default_value_when_the_option_has_been_applied()
         {
-            var option = new CliOption<int>("-x") { DefaultValueFactory = (_) => 123 };
+            var option = new Option<int>("-x") { DefaultValueFactory = (_) => 123 };
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 option
             };
@@ -181,9 +181,9 @@ namespace System.CommandLine.Tests.Binding
         [InlineData("the-command -x=true")]
         public void Bool_parses_as_true_when_the_option_has_been_applied(string commandLine)
         {
-            var option = new CliOption<bool>("-x");
+            var option = new Option<bool>("-x");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -198,8 +198,8 @@ namespace System.CommandLine.Tests.Binding
         [Fact] // https://github.com/dotnet/command-line-api/issues/2210
         public void Nullable_bool_with_unparseable_argument_does_not_throw()
         {
-            CliRootCommand rootCommand = new();
-            CliOption<bool?> option = new("--test");
+            RootCommand rootCommand = new();
+            Option<bool?> option = new("--test");
             rootCommand.Options.Add(option);
             var result = rootCommand.Parse("--test ouch");
 
@@ -210,8 +210,8 @@ namespace System.CommandLine.Tests.Binding
         [Fact] // https://github.com/dotnet/command-line-api/issues/2210
         public void Bool_with_unparseable_argument_does_not_throw()
         {
-            CliRootCommand rootCommand = new();
-            CliOption<bool> option = new("--test");
+            RootCommand rootCommand = new();
+            Option<bool> option = new("--test");
             rootCommand.Options.Add(option);
             var result = rootCommand.Parse("--test ouch");
 
@@ -226,9 +226,9 @@ namespace System.CommandLine.Tests.Binding
         [InlineData("the-command -x=true")]
         public void Nullable_bool_parses_as_true_when_the_option_has_been_applied(string commandLine)
         {
-            var option = new CliOption<bool?>("-x");
+            var option = new Option<bool?>("-x");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -246,9 +246,9 @@ namespace System.CommandLine.Tests.Binding
         [InlineData("the-command -x=false")]
         public void Nullable_bool_parses_as_false_when_the_option_has_been_applied(string commandLine)
         {
-            var option = new CliOption<bool?>("-x");
+            var option = new Option<bool?>("-x");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -263,7 +263,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Nullable_bool_parses_as_null_when_the_option_has_not_been_applied()
         {
-            var option = new CliOption<bool?>("-x");
+            var option = new Option<bool?>("-x");
 
             GetValue(option, "")
                 .Should()
@@ -273,9 +273,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void When_exactly_one_argument_is_expected_and_none_are_provided_then_getting_value_throws()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -298,14 +298,14 @@ namespace System.CommandLine.Tests.Binding
         [InlineData("c c c")]
         public void When_command_argument_has_arity_greater_than_one_it_captures_arguments_before_and_after_option(string commandLine)
         {
-            var argument = new CliArgument<string[]>("the-arg")
+            var argument = new Argument<string[]>("the-arg")
             {
                 Arity = ArgumentArity.ZeroOrMore
             };
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("-a"),
+                new Option<string>("-a"),
                 argument
             };
 
@@ -319,10 +319,10 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void The_default_value_of_a_bool_option_with_no_arguments_is_true()
         {
-            var option = new CliOption<bool>("-x");
+            var option = new Option<bool>("-x");
 
             var command =
-                new CliCommand("the-command")
+                new Command("the-command")
                 {
                     option
                 };
@@ -337,9 +337,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void By_default_a_bool_option_without_arguments_parses_as_false_when_it_is_not_applied()
         {
-            var option = new CliOption<bool>("-x");
+            var option = new Option<bool>("-x");
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 option
             };
@@ -354,9 +354,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void An_option_with_a_default_value_parses_as_the_default_value_when_the_option_has_not_been_applied()
         {
-            var option = new CliOption<string>("-x") { DefaultValueFactory = (_) => "123" };
+            var option = new Option<string>("-x") { DefaultValueFactory = (_) => "123" };
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 option
             };
@@ -371,9 +371,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void An_option_with_a_default_value_of_null_parses_as_null_when_the_option_has_not_been_applied()
         {
-            var option = new CliOption<string>("-x") { DefaultValueFactory = (_) => null };
+            var option = new Option<string>("-x") { DefaultValueFactory = (_) => null };
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 option
             };
@@ -388,9 +388,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void A_default_value_of_a_non_string_type_can_be_specified()
         {
-            var option = new CliOption<int>("-x") { DefaultValueFactory = (_) => 123 };
+            var option = new Option<int>("-x") { DefaultValueFactory = (_) => 123 };
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 option
             };
@@ -406,9 +406,9 @@ namespace System.CommandLine.Tests.Binding
         {
             var directoryInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
 
-            var option = new CliOption<DirectoryInfo>("-x") { DefaultValueFactory = (_) => directoryInfo };
+            var option = new Option<DirectoryInfo>("-x") { DefaultValueFactory = (_) => directoryInfo };
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 option
             };
@@ -423,9 +423,9 @@ namespace System.CommandLine.Tests.Binding
         {
             var directoryInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
 
-            var argument = new CliArgument<DirectoryInfo>("the-arg") { DefaultValueFactory = (_) => directoryInfo };
+            var argument = new Argument<DirectoryInfo>("the-arg") { DefaultValueFactory = (_) => directoryInfo };
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 argument
             };
@@ -442,9 +442,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Specifying_an_option_argument_overrides_the_default_value()
         {
-            var option = new CliOption<int>("-x") { DefaultValueFactory = (_) => 123 };
+            var option = new Option<int>("-x") { DefaultValueFactory = (_) => 123 };
 
-            var command = new CliCommand("something")
+            var command = new Command("something")
             {
                 option
             };
@@ -460,7 +460,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Values_can_be_correctly_converted_to_DateTime_without_the_parser_specifying_a_custom_converter()
         {
-            var option = new CliOption<DateTime>("-x");
+            var option = new Option<DateTime>("-x");
 
             var dateString = "2022-02-06T01:46:03.0000000-08:00";
 
@@ -471,7 +471,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_DateTime_without_the_parser_specifying_a_custom_converter()
         {
-            var option = new CliOption<DateTime?>("-x");
+            var option = new Option<DateTime?>("-x");
 
             var dateString = "2022-02-06T01:46:03.0000000-08:00";
 
@@ -481,7 +481,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Values_can_be_correctly_converted_to_DateTimeOffset_without_the_parser_specifying_a_custom_converter()
         {
-            var option = new CliOption<DateTimeOffset>("-x");
+            var option = new Option<DateTimeOffset>("-x");
 
             var dateString = "2022-02-06T09:52:54.5275055-08:00";
 
@@ -491,7 +491,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_DateTimeOffset_without_the_parser_specifying_a_custom_converter()
         {
-            var option = new CliOption<DateTimeOffset?>("-x");
+            var option = new Option<DateTimeOffset?>("-x");
 
             var dateString = "2022-02-06T09:52:54.5275055-08:00";
 
@@ -500,34 +500,34 @@ namespace System.CommandLine.Tests.Binding
 
         [Fact]
         public void Values_can_be_correctly_converted_to_decimal_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<decimal>("-x"), "-x 123.456").Should().Be(123.456m);
+            => GetValue(new Option<decimal>("-x"), "-x 123.456").Should().Be(123.456m);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_decimal_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<decimal?>("-x"), "-x 123.456").Should().Be(123.456m);
+            => GetValue(new Option<decimal?>("-x"), "-x 123.456").Should().Be(123.456m);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_double_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<double>("-x"), "-x 123.456").Should().Be(123.456d);
+            => GetValue(new Option<double>("-x"), "-x 123.456").Should().Be(123.456d);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_double_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<double?>("-x"), "-x 123.456").Should().Be(123.456d);
+            => GetValue(new Option<double?>("-x"), "-x 123.456").Should().Be(123.456d);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_float_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<float>("-x"), "-x 123.456").Should().Be(123.456f);
+            => GetValue(new Option<float>("-x"), "-x 123.456").Should().Be(123.456f);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_float_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<float?>("-x"), "-x 123.456").Should().Be(123.456f);
+            => GetValue(new Option<float?>("-x"), "-x 123.456").Should().Be(123.456f);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_Guid_without_the_parser_specifying_a_custom_converter()
         {
             const string guidString = "75517282-018F-46BB-B15F-1D8DBFE23F6E";
 
-            GetValue(new CliOption<Guid>("-x"), $"-x {guidString}").Should().Be(Guid.Parse(guidString));
+            GetValue(new Option<Guid>("-x"), $"-x {guidString}").Should().Be(Guid.Parse(guidString));
         }
 
         [Fact]
@@ -535,7 +535,7 @@ namespace System.CommandLine.Tests.Binding
         {
             const string guidString = "75517282-018F-46BB-B15F-1D8DBFE23F6E";
 
-            GetValue(new CliOption<Guid?>("-x"), $"-x {guidString}").Should().Be(Guid.Parse(guidString));
+            GetValue(new Option<Guid?>("-x"), $"-x {guidString}").Should().Be(Guid.Parse(guidString));
         }
 
         [Fact]
@@ -543,7 +543,7 @@ namespace System.CommandLine.Tests.Binding
         {
             const string timeSpanString = "30";
 
-            GetValue(new CliOption<TimeSpan>("-x"), $"-x {timeSpanString}").Should().Be(TimeSpan.Parse(timeSpanString));
+            GetValue(new Option<TimeSpan>("-x"), $"-x {timeSpanString}").Should().Be(TimeSpan.Parse(timeSpanString));
         }
 
         [Fact]
@@ -551,13 +551,13 @@ namespace System.CommandLine.Tests.Binding
         {
             const string timeSpanString = "30";
 
-            GetValue(new CliOption<TimeSpan?>("-x"), $"-x {timeSpanString}").Should().Be(TimeSpan.Parse(timeSpanString));
+            GetValue(new Option<TimeSpan?>("-x"), $"-x {timeSpanString}").Should().Be(TimeSpan.Parse(timeSpanString));
         }
 
         [Fact]
         public void Values_can_be_correctly_converted_to_Uri_when_custom_parser_is_provided()
         {
-            CliOption<Uri> option = new ("-x")
+            Option<Uri> option = new ("-x")
             {
                 CustomParser = (argumentResult) => Uri.TryCreate(argumentResult.Tokens.Last().Value, UriKind.RelativeOrAbsolute, out var uri) ? uri : null
             };
@@ -568,54 +568,54 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Options_with_arguments_specified_can_be_correctly_converted_to_bool_without_the_parser_specifying_a_custom_converter()
         {
-            GetValue(new CliOption<bool>("-x"), "-x false").Should().BeFalse();
-            GetValue(new CliOption<bool>("-x"), "-x true").Should().BeTrue();
+            GetValue(new Option<bool>("-x"), "-x false").Should().BeFalse();
+            GetValue(new Option<bool>("-x"), "-x true").Should().BeTrue();
         }
 
         [Fact]
         public void Values_can_be_correctly_converted_to_long_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<long>("-x"), "-x 123456790").Should().Be(123456790L);
+            => GetValue(new Option<long>("-x"), "-x 123456790").Should().Be(123456790L);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_long_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<long?>("-x"), "-x 123456790").Should().Be(123456790L);
+            => GetValue(new Option<long?>("-x"), "-x 123456790").Should().Be(123456790L);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_short_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<short>("-s"), "-s 1234").Should().Be(1234);
+            => GetValue(new Option<short>("-s"), "-s 1234").Should().Be(1234);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_short_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<short?>("-s"), "-s 1234").Should().Be(1234);
+            => GetValue(new Option<short?>("-s"), "-s 1234").Should().Be(1234);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_ulong_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<ulong>("-x"), "-x 1234").Should().Be(1234);
+            => GetValue(new Option<ulong>("-x"), "-x 1234").Should().Be(1234);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_ulong_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<ulong?>("-x"), "-x 1234").Should().Be(1234);
+            => GetValue(new Option<ulong?>("-x"), "-x 1234").Should().Be(1234);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_ushort_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<ushort>("-s"), "-s 1234").Should().Be(1234);
+            => GetValue(new Option<ushort>("-s"), "-s 1234").Should().Be(1234);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_ushort_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<ushort?>("-s"), "-s 1234").Should().Be(1234);
+            => GetValue(new Option<ushort?>("-s"), "-s 1234").Should().Be(1234);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_sbyte_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<sbyte>("-us"), "-us 123").Should().Be(123);
+            => GetValue(new Option<sbyte>("-us"), "-us 123").Should().Be(123);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_sbyte_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<sbyte?>("-us"), "-us 123").Should().Be(123);
+            => GetValue(new Option<sbyte?>("-us"), "-us 123").Should().Be(123);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_ipaddress_when_custom_parser_is_provided()
         {
-            CliOption<IPAddress> option = new ("-us")
+            Option<IPAddress> option = new ("-us")
             { 
                 CustomParser = (argumentResult) => IPAddress.Parse(argumentResult.Tokens.Last().Value)
             };
@@ -627,7 +627,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Values_can_be_correctly_converted_to_ipendpoint_when_custom_parser_is_provided()
         {
-            CliOption<IPEndPoint> option = new("-us")
+            Option<IPEndPoint> option = new("-us")
             {
                 CustomParser = (argumentResult) => IPEndPoint.Parse(argumentResult.Tokens.Last().Value)
             };
@@ -639,40 +639,40 @@ namespace System.CommandLine.Tests.Binding
 #if NET6_0_OR_GREATER
         [Fact]
         public void Values_can_be_correctly_converted_to_dateonly_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<DateOnly>("-us"), "-us 2022-03-02").Should().Be(DateOnly.Parse("2022-03-02"));
+            => GetValue(new Option<DateOnly>("-us"), "-us 2022-03-02").Should().Be(DateOnly.Parse("2022-03-02"));
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_dateonly_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<DateOnly?>("-x"), "-x 2022-03-02").Should().Be(DateOnly.Parse("2022-03-02"));
+            => GetValue(new Option<DateOnly?>("-x"), "-x 2022-03-02").Should().Be(DateOnly.Parse("2022-03-02"));
 
         [Fact]
         public void Values_can_be_correctly_converted_to_timeonly_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<TimeOnly>("-us"), "-us 12:34:56").Should().Be(TimeOnly.Parse("12:34:56"));
+            => GetValue(new Option<TimeOnly>("-us"), "-us 12:34:56").Should().Be(TimeOnly.Parse("12:34:56"));
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_timeonly_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<TimeOnly?>("-x"), "-x 12:34:56").Should().Be(TimeOnly.Parse("12:34:56"));
+            => GetValue(new Option<TimeOnly?>("-x"), "-x 12:34:56").Should().Be(TimeOnly.Parse("12:34:56"));
 #endif
 
         [Fact]
         public void Values_can_be_correctly_converted_to_byte_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<byte>("-us"), "-us 123").Should().Be(123);
+            => GetValue(new Option<byte>("-us"), "-us 123").Should().Be(123);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_byte_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<byte?>("-us"), "-us 123").Should().Be(123);
+            => GetValue(new Option<byte?>("-us"), "-us 123").Should().Be(123);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_uint_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<uint>("-us"), "-us 1234").Should().Be(1234);
+            => GetValue(new Option<uint>("-us"), "-us 1234").Should().Be(1234);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_nullable_uint_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<uint?>("-us"), "-us 1234").Should().Be(1234);
+            => GetValue(new Option<uint?>("-us"), "-us 1234").Should().Be(1234);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_array_of_int_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<int[]>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
+            => GetValue(new Option<int[]>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
 
         [Theory]
         [InlineData(0, 100_000, typeof(string[]))]
@@ -704,7 +704,7 @@ namespace System.CommandLine.Tests.Binding
             var option = OptionBuilder.CreateOption("--items", valueType: argumentType);
             option.Arity = new ArgumentArity(minArity, maxArity);
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 option
             };
@@ -717,26 +717,26 @@ namespace System.CommandLine.Tests.Binding
 
         [Fact]
         public void Values_can_be_correctly_converted_to_List_of_int_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<List<int>>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
+            => GetValue(new Option<List<int>>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
 
         [Fact]
         public void Values_can_be_correctly_converted_to_IEnumerable_of_int_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<IEnumerable<int>>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
+            => GetValue(new Option<IEnumerable<int>>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
 
         [Fact]
         public void Enum_values_can_be_correctly_converted_based_on_enum_value_name_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<DayOfWeek>("-x"), "-x Monday").Should().Be(DayOfWeek.Monday);
+            => GetValue(new Option<DayOfWeek>("-x"), "-x Monday").Should().Be(DayOfWeek.Monday);
 
         [Fact]
         public void Nullable_enum_values_can_be_correctly_converted_based_on_enum_value_name_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new CliOption<DayOfWeek?>("-x"), "-x Monday").Should().Be(DayOfWeek.Monday);
+            => GetValue(new Option<DayOfWeek?>("-x"), "-x Monday").Should().Be(DayOfWeek.Monday);
 
         [Fact]
         public void Enum_values_that_cannot_be_parsed_result_in_an_informative_error()
         {
-            var option = new CliOption<DayOfWeek>("-x");
+            var option = new Option<DayOfWeek>("-x");
 
-            var value = new CliRootCommand { option }.Parse("-x Notaday");
+            var value = new RootCommand { option }.Parse("-x Notaday");
 
             value.Errors
                  .Should()
@@ -750,9 +750,9 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void When_getting_a_single_value_and_specifying_a_conversion_type_that_is_not_supported_then_it_throws()
         {
-            var option = new CliOption<int>("-x");
+            var option = new Option<int>("-x");
 
-            var result = new CliRootCommand { option }.Parse("-x not-an-int");
+            var result = new RootCommand { option }.Parse("-x not-an-int");
 
             Action getValue = () => result.GetValue(option);
 
@@ -767,7 +767,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void When_getting_an_array_of_values_and_specifying_a_conversion_type_that_is_not_supported_then_it_throws()
         {
-            Action getValue = () => GetValue(new CliOption<int[]>("-x"), "-x not-an-int -x 2");
+            Action getValue = () => GetValue(new Option<int[]>("-x"), "-x not-an-int -x 2");
 
             getValue.Should()
                     .Throw<InvalidOperationException>()
@@ -780,7 +780,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void String_defaults_to_null_when_not_specified_only_for_not_required_arguments()
             => GetValue(
-                new CliArgument<string>("arg")
+                new Argument<string>("arg")
                 { 
                     Arity = ArgumentArity.ZeroOrMore
                 }, "").Should().BeNull();
@@ -803,12 +803,12 @@ namespace System.CommandLine.Tests.Binding
         [InlineData(typeof(FileAccess[]))]
         public void Sequence_type_defaults_to_empty_when_not_specified(Type sequenceType)
         {
-            var argument = Activator.CreateInstance(typeof(CliArgument<>).MakeGenericType(sequenceType), new object[] { "argName" });
+            var argument = Activator.CreateInstance(typeof(Argument<>).MakeGenericType(sequenceType), new object[] { "argName" });
 
             AssertParsedValueIsEmpty((dynamic)argument);
         }
 
-        private void AssertParsedValueIsEmpty<T>(CliArgument<T> argument) where T : IEnumerable
+        private void AssertParsedValueIsEmpty<T>(Argument<T> argument) where T : IEnumerable
             => GetValue(argument, "").Should().BeEmpty();
     }
 }

--- a/src/System.CommandLine.Tests/CommandLineConfigurationTests.cs
+++ b/src/System.CommandLine.Tests/CommandLineConfigurationTests.cs
@@ -6,27 +6,27 @@ using Xunit;
 
 namespace System.CommandLine.Tests;
 
-public class CliConfigurationTests
+public class CommandLineConfigurationTests
 {
     [Fact]
     public void ThrowIfInvalid_throws_if_there_are_duplicate_sibling_option_aliases_on_the_root_command()
     {
-        var option1 = new CliOption<string>("--dupe");
-        var option2 = new CliOption<string>("-y");
+        var option1 = new Option<string>("--dupe");
+        var option2 = new Option<string>("-y");
         option2.Aliases.Add("--dupe");
 
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
             option1,
             option2
         };
 
-        var config = new CliConfiguration(command);
+        var config = new CommandLineConfiguration(command);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -36,25 +36,25 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_there_are_duplicate_sibling_option_aliases_on_a_subcommand()
     {
-        var option1 = new CliOption<string>("--dupe");
-        var option2 = new CliOption<string>("--ok");
+        var option1 = new Option<string>("--dupe");
+        var option2 = new Option<string>("--ok");
         option2.Aliases.Add("--dupe");
 
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
-            new CliCommand("subcommand")
+            new Command("subcommand")
             {
                 option1,
                 option2
             }
         };
 
-        var config = new CliConfiguration(command);
+        var config = new CommandLineConfiguration(command);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -64,22 +64,22 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_there_are_duplicate_sibling_subcommand_aliases_on_the_root_command()
     {
-        var command1 = new CliCommand("dupe");
-        var command2 = new CliCommand("not-a-dupe");
+        var command1 = new Command("dupe");
+        var command2 = new Command("not-a-dupe");
         command2.Aliases.Add("dupe");
 
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
             command1,
             command2
         };
 
-        var config = new CliConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -89,21 +89,21 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_there_are_duplicate_sibling_subcommand_aliases_on_a_subcommand()
     {
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
-            new CliCommand("subcommand")
+            new Command("subcommand")
             {
-                new CliCommand("dupe"),
-                new CliCommand("not-a-dupe") { Aliases = { "dupe" } }
+                new Command("dupe"),
+                new Command("not-a-dupe") { Aliases = { "dupe" } }
             }
         };
 
-        var config = new CliConfiguration(command);
+        var config = new CommandLineConfiguration(command);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -113,22 +113,22 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_sibling_command_and_option_aliases_collide_on_the_root_command()
     {
-        var option = new CliOption<string>("dupe");
-        var command = new CliCommand("not-a-dupe");
+        var option = new Option<string>("dupe");
+        var command = new Command("not-a-dupe");
         command.Aliases.Add("dupe");
 
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
             option,
             command
         };
 
-        var config = new CliConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -138,25 +138,25 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_sibling_command_and_option_aliases_collide_on_a_subcommand()
     {
-        var option = new CliOption<string>("dupe");
-        var command = new CliCommand("not-a-dupe");
+        var option = new Option<string>("dupe");
+        var command = new Command("not-a-dupe");
         command.Aliases.Add("dupe");
 
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
-            new CliCommand("subcommand")
+            new Command("subcommand")
             {
                 option,
                 command
             }
         };
 
-        var config = new CliConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -166,20 +166,20 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_there_are_duplicate_sibling_global_option_aliases_on_the_root_command()
     {
-        var option1 = new CliOption<string>("--dupe") { Recursive = true };
-        var option2 = new CliOption<string>("-y") { Recursive = true };
+        var option1 = new Option<string>("--dupe") { Recursive = true };
+        var option2 = new Option<string>("-y") { Recursive = true };
         option2.Aliases.Add("--dupe");
 
-        var command = new CliRootCommand();
+        var command = new RootCommand();
         command.Options.Add(option1);
         command.Options.Add(option2);
 
-        var config = new CliConfiguration(command);
+        var config = new CommandLineConfiguration(command);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -189,16 +189,16 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_does_not_throw_if_global_option_alias_is_the_same_as_local_option_alias()
     {
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
-            new CliCommand("subcommand")
+            new Command("subcommand")
             {
-                new CliOption<string>("--dupe")
+                new Option<string>("--dupe")
             }
         };
-        rootCommand.Options.Add(new CliOption<string>("--dupe") { Recursive = true });
+        rootCommand.Options.Add(new Option<string>("--dupe") { Recursive = true });
 
-        var config = new CliConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand);
 
         var validate = () => config.ThrowIfInvalid();
 
@@ -208,16 +208,16 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_does_not_throw_if_global_option_alias_is_the_same_as_subcommand_alias()
     {
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
-            new CliCommand("subcommand")
+            new Command("subcommand")
             {
-                new CliCommand("--dupe")
+                new Command("--dupe")
             }
         };
-        rootCommand.Options.Add(new CliOption<string>("--dupe") { Recursive = true });
+        rootCommand.Options.Add(new Option<string>("--dupe") { Recursive = true });
 
-        var config = new CliConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand);
 
         var validate = () => config.ThrowIfInvalid();
 
@@ -227,15 +227,15 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_a_command_is_its_own_parent()
     {
-        var command = new CliRootCommand();
+        var command = new RootCommand();
         command.Add(command);
 
-        var config = new CliConfiguration(command);
+        var config = new CommandLineConfiguration(command);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -245,16 +245,16 @@ public class CliConfigurationTests
     [Fact]
     public void ThrowIfInvalid_throws_if_a_parentage_cycle_is_detected()
     {
-        var command = new CliCommand("command");
-        var rootCommand = new CliRootCommand { command };
+        var command = new Command("command");
+        var rootCommand = new RootCommand { command };
         command.Add(rootCommand);
 
-        var config = new CliConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand);
 
         var validate = () => config.ThrowIfInvalid();
 
         validate.Should()
-                .Throw<CliConfigurationException>()
+                .Throw<CommandLineConfigurationException>()
                 .Which
                 .Message
                 .Should()
@@ -264,7 +264,7 @@ public class CliConfigurationTests
     [Fact]
     public void It_can_be_subclassed_to_provide_additional_context()
     {
-        var command = new CliRootCommand();
+        var command = new RootCommand();
         var commandWasInvoked = false;
         command.SetAction(parseResult =>
         {
@@ -285,9 +285,9 @@ public class CliConfigurationTests
     }
 }
 
-public class CustomAppConfiguration : CliConfiguration
+public class CustomAppConfiguration : CommandLineConfiguration
 {
-    public CustomAppConfiguration(CliRootCommand command) : base(command)
+    public CustomAppConfiguration(RootCommand command) : base(command)
     {
         EnableDefaultExceptionHandler = false;
     }

--- a/src/System.CommandLine.Tests/CommandTests.cs
+++ b/src/System.CommandLine.Tests/CommandTests.cs
@@ -10,15 +10,15 @@ namespace System.CommandLine.Tests
 {
     public class CommandTests
     {
-        private readonly CliCommand _outerCommand;
+        private readonly Command _outerCommand;
 
         public CommandTests()
         {
-            _outerCommand = new CliCommand("outer")
+            _outerCommand = new Command("outer")
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliOption<string>("--option")
+                    new Option<string>("--option")
                 }
             };
         }
@@ -102,14 +102,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Commands_at_multiple_levels_can_have_their_own_arguments()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
-                new CliArgument<string>("outer_arg")
+                new Argument<string>("outer_arg")
             };
             outer.Subcommands.Add(
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliArgument<string[]>("inner_arg")
+                    new Argument<string[]>("inner_arg")
                 });
 
             var result = outer.Parse("outer arg1 inner arg2 arg3");
@@ -131,7 +131,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Aliases_is_aware_of_added_alias()
         {
-            var command = new CliCommand("original");
+            var command = new Command("original");
 
             command.Aliases.Add("added");
 
@@ -146,7 +146,7 @@ namespace System.CommandLine.Tests
         public void When_a_command_is_created_with_an_alias_that_contains_whitespace_then_an_informative_error_is_returned(
             string alias)
         {
-            Action create = () => new CliCommand(alias);
+            Action create = () => new Command(alias);
 
             create.Should()
                   .Throw<ArgumentException>()
@@ -163,7 +163,7 @@ namespace System.CommandLine.Tests
         public void When_a_command_alias_is_added_and_contains_whitespace_then_an_informative_error_is_returned(
             string alias)
         {
-            var command = new CliCommand("-x");
+            var command = new Command("-x");
 
             Action addAlias = () => command.Aliases.Add(alias);
 
@@ -189,13 +189,13 @@ namespace System.CommandLine.Tests
         [InlineData("outer arg inner arg inner-er arg", "inner-er")]
         public void ParseResult_Command_identifies_innermost_command(string input, string expectedCommand)
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliCommand("inner-er")
+                    new Command("inner-er")
                 },
-                new CliCommand("sibling")
+                new Command("sibling")
             };
 
             var result = outer.Parse(input);
@@ -206,7 +206,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Commands_can_have_aliases()
         {
-            var command = new CliCommand("this");
+            var command = new Command("this");
             command.Aliases.Add("that");
             command.Name.Should().Be("this");
             command.Aliases.Should().BeEquivalentTo("that");
@@ -221,7 +221,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void RootCommand_can_have_aliases()
         {
-            var command = new CliRootCommand();
+            var command = new RootCommand();
             command.Aliases.Add("that");
             command.Aliases.Should().BeEquivalentTo("that");
             command.Aliases.Should().BeEquivalentTo("that");
@@ -235,10 +235,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Subcommands_can_have_aliases()
         {
-            var subcommand = new CliCommand("this");
+            var subcommand = new Command("this");
             subcommand.Aliases.Add("that");
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 subcommand
             };
@@ -252,9 +252,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void It_retains_argument_name_when_it_is_provided()
         {
-            var command = new CliCommand("-alias")
+            var command = new Command("-alias")
             {
-                new CliArgument<bool>("arg")
+                new Argument<bool>("arg")
             };
 
             command.Arguments.Single().Name.Should().Be("arg");
@@ -263,8 +263,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void AddGlobalOption_updates_Options_property()
         {
-            var option = new CliOption<string>("-x") { Recursive = true };
-            var command = new CliCommand("mycommand");
+            var option = new Option<string>("-x") { Recursive = true };
+            var command = new Command("mycommand");
             command.Options.Add(option);
 
             command.Options
@@ -276,8 +276,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_Options_is_referenced_before_a_global_option_is_added_then_adding_a_global_option_updates_the_Options_collection()
         {
-            var option = new CliOption<string>("-x");
-            var command = new CliCommand("mycommand");
+            var option = new Option<string>("-x");
+            var command = new Command("mycommand");
 
             // referencing command.Options here would reproduce the above bug before the fix
             // keeping it ensures the fix works and doesn't regress

--- a/src/System.CommandLine.Tests/CompilationTests.cs
+++ b/src/System.CommandLine.Tests/CompilationTests.cs
@@ -23,7 +23,7 @@ public class CompilationTests
     {
         _output = output;
 
-        _systemCommandLineDllPath = typeof(CliCommand).Assembly.Location;
+        _systemCommandLineDllPath = typeof(Command).Assembly.Location;
     }
 
     [ReleaseBuildOnlyTheory]

--- a/src/System.CommandLine.Tests/CompletionContextTests.cs
+++ b/src/System.CommandLine.Tests/CompletionContextTests.cs
@@ -12,11 +12,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void CommandLineText_preserves_command_line_prior_to_splitting_when_complete_command_line_is_parsed()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliCommand("verb")
+                new Command("verb")
                 {
-                    new CliOption<int>("-x")
+                    new Option<int>("-x")
                 }
             };
 
@@ -36,11 +36,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void CommandLineText_is_preserved_when_adjusting_position()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliCommand("verb")
+                new Command("verb")
                 {
-                    new CliOption<int>("-x")
+                    new Option<int>("-x")
                 }
             };
 
@@ -56,11 +56,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void CommandLineText_is_unavailable_when_string_array_is_parsed()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliCommand("verb")
+                new Command("verb")
                 {
-                    new CliOption<int>("-x")
+                    new Option<int>("-x")
                 }
             };
 
@@ -74,10 +74,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_unspecified_in_string_command_line_not_ending_with_a_space_then_it_returns_final_token()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("--option1"),
-                new CliOption<string>("--option2")
+                new Option<string>("--option1"),
+                new Option<string>("--option2")
             };
 
             string textToMatch = command.Parse("the-command t")
@@ -90,10 +90,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_unspecified_in_string_command_line_ending_with_a_space_then_it_returns_empty()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("--option1"),
-                new CliOption<string>("--option2")
+                new Option<string>("--option1"),
+                new Option<string>("--option2")
             };
 
             var commandLine = "the-command t";
@@ -109,14 +109,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_greater_than_input_length_in_a_string_command_line_then_it_returns_empty()
         {
-            CliOption<string> option1 = new ("--option1");
+            Option<string> option1 = new ("--option1");
             option1.AcceptOnlyFromAmong("apple", "banana", "cherry", "durian");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<string>("arg"),
+                new Argument<string>("arg"),
                 option1,
-                new CliOption<string>("--option2")
+                new Option<string>("--option2")
             };
 
             var textToMatch = command.Parse("the-command --option1 a")
@@ -131,10 +131,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_unspecified_in_array_command_line_and_final_token_is_unmatched_then_it_returns_final_token()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("--option1"),
-                new CliOption<string>("--option2")
+                new Option<string>("--option1"),
+                new Option<string>("--option2")
             };
 
             string textToMatch = command.Parse(new[] { "the-command", "opt" })
@@ -147,10 +147,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_unspecified_in_array_command_line_and_final_token_matches_an_command_then_it_returns_empty()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("--option1"),
-                new CliOption<string>("--option2")
+                new Option<string>("--option1"),
+                new Option<string>("--option2")
             };
 
             string textToMatch = command.Parse(new[] { "the-command" })
@@ -163,10 +163,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_unspecified_in_array_command_line_and_final_token_matches_an_option_then_it_returns_empty()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("--option1"),
-                new CliOption<string>("--option2")
+                new Option<string>("--option1"),
+                new Option<string>("--option2")
             };
 
             string textToMatch = command.Parse(new[] { "the-command", "--option1" })
@@ -179,14 +179,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_position_is_unspecified_in_array_command_line_and_final_token_matches_an_argument_then_it_returns_the_argument_value()
         {
-            CliOption<string> option1 = new("--option1");
+            Option<string> option1 = new("--option1");
             option1.AcceptOnlyFromAmong("apple", "banana", "cherry", "durian");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option1,
-                new CliOption<string>("--option2"),
-                new CliArgument<string>("arg")
+                new Option<string>("--option2"),
+                new Argument<string>("arg")
             };
 
             string textToMatch = command.Parse(new[] { "the-command", "--option1", "a" })
@@ -208,9 +208,9 @@ namespace System.CommandLine.Tests
             string expected)
         {
             var command =
-                new CliCommand("the-command")
+                new Command("the-command")
                 {
-                    new CliArgument<string[]>("arg")
+                    new Argument<string[]>("arg")
                 };
 
             var position = commandLine.IndexOf("$", StringComparison.Ordinal);

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -24,7 +24,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_GetCompletions_returns_argument_completions_if_configured()
         {
-            var option = new CliOption<string>("--hello");
+            var option = new Option<string>("--hello");
             option.CompletionSources.Add("one", "two", "three");
 
             var completions = option.GetCompletions(CompletionContext.Empty);
@@ -38,11 +38,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_returns_available_option_aliases()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliOption<string>("--one") { Description = "option one" },
-                new CliOption<string>("--two") { Description = "option two" },
-                new CliOption<string>("--three") { Description = "option three" },
+                new Option<string>("--one") { Description = "option one" },
+                new Option<string>("--two") { Description = "option two" },
+                new Option<string>("--three") { Description = "option three" },
             };
 
             var completions = command.GetCompletions(CompletionContext.Empty);
@@ -56,23 +56,23 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1563
         public void Command_GetCompletions_returns_available_option_aliases_for_global_options()
         {
-            var subcommand2 = new CliCommand("command2")
+            var subcommand2 = new Command("command2")
             {
-                new CliOption<string>("--one") { Description = "option one" },
-                new CliOption<string>("--two") { Description = "option two" }
+                new Option<string>("--one") { Description = "option one" },
+                new Option<string>("--two") { Description = "option two" }
             };
 
-            var subcommand1 = new CliCommand("command1")
+            var subcommand1 = new Command("command1")
             {
                 subcommand2
             };
 
-            var rootCommand = new CliCommand("root")
+            var rootCommand = new Command("root")
             {
                 subcommand1
             };
 
-            rootCommand.Options.Add(new CliOption<string>("--three") 
+            rootCommand.Options.Add(new Option<string>("--three") 
             { 
                 Description = "option three",
                 Recursive = true
@@ -89,11 +89,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_returns_available_subcommands()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliCommand("one"),
-                new CliCommand("two"),
-                new CliCommand("three")
+                new Command("one"),
+                new Command("two"),
+                new Command("three")
             };
 
             var completions = command.GetCompletions(CompletionContext.Empty);
@@ -107,10 +107,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_returns_available_subcommands_and_option_aliases()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliCommand("subcommand"),
-                new CliOption<string>("--option")
+                new Command("subcommand"),
+                new Option<string>("--option")
             };
 
             var completions = command.GetCompletions(CompletionContext.Empty);
@@ -123,11 +123,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_returns_available_subcommands_and_option_aliases_and_configured_arguments()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliCommand("subcommand", "subcommand"),
-                new CliOption<bool>("--option") { Description = "option" },
-                new CliArgument<string[]>("args")
+                new Command("subcommand", "subcommand"),
+                new Option<bool>("--option") { Description = "option" },
+                new Argument<string[]>("args")
                 {
                     Arity = ArgumentArity.OneOrMore,
                     CompletionSources = { "command-argument" }
@@ -144,11 +144,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_without_text_to_match_orders_alphabetically()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliCommand("andmythirdsubcommand"),
-                new CliCommand("mysubcommand"),
-                new CliCommand("andmyothersubcommand"),
+                new Command("andmythirdsubcommand"),
+                new Command("mysubcommand"),
+                new Command("andmyothersubcommand"),
             };
 
             var completions = command.GetCompletions(CompletionContext.Empty);
@@ -162,9 +162,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_does_not_return_argument_names()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliArgument<string>("the-argument")
+                new Argument<string>("the-argument")
             };
 
             var completions = command.GetCompletions(CompletionContext.Empty);
@@ -178,14 +178,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_with_text_to_match_orders_by_match_position_then_alphabetically()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliCommand("andmythirdsubcommand"),
-                new CliCommand("mysubcommand"),
-                new CliCommand("andmyothersubcommand"),
+                new Command("andmythirdsubcommand"),
+                new Command("mysubcommand"),
+                new Command("andmyothersubcommand"),
             };
 
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var completions = command.Parse("my", simpleConfig).GetCompletions();
 
             completions
@@ -197,14 +197,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_a_default_value_it_will_still_be_suggested()
         {
-            var command = new CliCommand("test")
+            var command = new Command("test")
             {
-                new CliOption<string>("--apple") { DefaultValueFactory = (_) => "cortland" },
-                new CliOption<string>("--banana"),
-                new CliOption<string>("--cherry")
+                new Option<string>("--apple") { DefaultValueFactory = (_) => "cortland" },
+                new Option<string>("--banana"),
+                new Option<string>("--cherry")
             };
 
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var result = command.Parse("", simpleConfig);
 
             _output.WriteLine(result.ToString());
@@ -220,8 +220,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_can_access_ParseResult()
         {
-            var originOption = new CliOption<string>("--origin");
-            var cloneOption = new CliOption<string>("--clone");
+            var originOption = new Option<string>("--origin");
+            var cloneOption = new Option<string>("--clone");
 
             cloneOption.CompletionSources.Add(ctx =>
             {
@@ -229,13 +229,13 @@ namespace System.CommandLine.Tests
                 return !string.IsNullOrWhiteSpace(opt1Value) ? new[] { opt1Value } : Array.Empty<string>();
             });
 
-            CliRootCommand rootCommand = new CliRootCommand
+            RootCommand rootCommand = new RootCommand
             {
                 originOption,
                 cloneOption
             };
 
-            CliConfiguration simpleConfig = new (rootCommand);
+            CommandLineConfiguration simpleConfig = new (rootCommand);
             var result = rootCommand.Parse("--origin test --clone ", simpleConfig);
 
             _output.WriteLine(result.ToString());
@@ -249,11 +249,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_GetCompletions_include_recursive_options_of_root_command()
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
-                new CliCommand("sub")
+                new Command("sub")
                 {
-                    new CliOption<int>("--option")
+                    new Option<int>("--option")
                 }
             };
 
@@ -270,15 +270,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_one_option_has_been_specified_then_it_and_its_siblings_will_still_be_suggested()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliOption<string>("--apple"),
-                new CliOption<string>("--banana"),
-                new CliOption<string>("--cherry")
+                new Option<string>("--apple"),
+                new Option<string>("--banana"),
+                new Option<string>("--cherry")
             };
 
             var commandLine = "--apple grannysmith";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var result = command.Parse(commandLine, simpleConfig);
 
             result.GetCompletions(commandLine.Length + 1)
@@ -291,22 +291,22 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_subcommand_has_been_specified_then_its_sibling_commands_will_not_be_suggested()
         {
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
-                new CliCommand("apple")
+                new Command("apple")
                 {
-                    new CliOption<string>("--cortland")
+                    new Option<string>("--cortland")
                 },
-                new CliCommand("banana")
+                new Command("banana")
                 {
-                    new CliOption<string>("--cavendish")
+                    new Option<string>("--cavendish")
                 },
-                new CliCommand("cherry")
+                new Command("cherry")
                 {
-                    new CliOption<string>("--rainier")
+                    new Option<string>("--rainier")
                 }
             };
-            CliConfiguration simpleConfig = new (rootCommand);
+            CommandLineConfiguration simpleConfig = new (rootCommand);
 
             var result = rootCommand.Parse("cherry ", simpleConfig);
 
@@ -318,24 +318,24 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_subcommand_has_been_specified_then_its_sibling_commands_aliases_will_not_be_suggested()
         {
-            var apple = new CliCommand("apple")
+            var apple = new Command("apple")
             {
-                new CliOption<string>("--cortland")
+                new Option<string>("--cortland")
             };
             apple.Aliases.Add("apl");
 
-            var banana = new CliCommand("banana")
+            var banana = new Command("banana")
             {
-                new CliOption<string>("--cavendish")
+                new Option<string>("--cavendish")
             };
             banana.Aliases.Add("bnn");
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 apple,
                 banana
             };
-            CliConfiguration simpleConfig = new (rootCommand);
+            CommandLineConfiguration simpleConfig = new (rootCommand);
 
             var result = rootCommand.Parse("banana ", simpleConfig);
 
@@ -348,14 +348,14 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1494
         public void When_a_subcommand_has_been_specified_then_its_sibling_options_will_not_be_suggested()
         {
-            var command = new CliRootCommand("parent")
+            var command = new RootCommand("parent")
             {
-                new CliCommand("child"), 
-                new CliOption<string>("--parent-option")
+                new Command("child"), 
+                new Option<string>("--parent-option")
             };
 
             var commandLine = "child";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var parseResult = command.Parse(commandLine, simpleConfig);
 
             parseResult
@@ -368,15 +368,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_subcommand_has_been_specified_then_its_sibling_options_with_argument_limit_reached_will_be_not_be_suggested()
         {
-            var command = new CliRootCommand("parent")
+            var command = new RootCommand("parent")
             {
-                new CliCommand("child"),
-                new CliOption<string>("--parent-option"),
-                new CliArgument<string>("arg")
+                new Command("child"),
+                new Option<string>("--parent-option"),
+                new Argument<string>("arg")
             };
 
             var commandLine = "--parent-option 123 child";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var parseResult = command.Parse(commandLine, simpleConfig);
 
             parseResult
@@ -388,17 +388,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_subcommand_has_been_specified_then_its_child_options_will_be_suggested()
         {
-            var command = new CliRootCommand("parent")
+            var command = new RootCommand("parent")
             {
-                new CliArgument<string>("arg"),
-                new CliCommand("child")
+                new Argument<string>("arg"),
+                new Command("child")
                 {
-                    new CliOption<string>("--child-option")
+                    new Option<string>("--child-option")
                 }
             };
 
             var commandLine = "child ";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var parseResult = command.Parse(commandLine, simpleConfig);
 
             parseResult
@@ -411,24 +411,24 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_subcommand_with_subcommands_has_been_specified_then_its_sibling_commands_will_not_be_suggested()
         {
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
-                new CliCommand("apple")
+                new Command("apple")
                 {
-                    new CliCommand("cortland")
+                    new Command("cortland")
                 },
-                new CliCommand("banana")
+                new Command("banana")
                 {
-                    new CliCommand("cavendish")
+                    new Command("cavendish")
                 },
-                new CliCommand("cherry")
+                new Command("cherry")
                 {
-                    new CliCommand("rainier")
+                    new Command("rainier")
                 }
             };
 
             var commandLine = "cherry";
-            CliConfiguration simpleConfig = new (rootCommand);
+            CommandLineConfiguration simpleConfig = new (rootCommand);
             var result = rootCommand.Parse(commandLine, simpleConfig);
 
             result.GetCompletions(commandLine.Length + 1)
@@ -440,15 +440,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_one_option_has_been_partially_specified_then_nonmatching_siblings_will_not_be_suggested()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("--apple"),
-                new CliOption<string>("--banana"),
-                new CliOption<string>("--cherry")
+                new Option<string>("--apple"),
+                new Option<string>("--banana"),
+                new Option<string>("--cherry")
             };
 
             var input = "a";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var result = command.Parse(input, simpleConfig);
 
             result.GetCompletions(input.Length)
@@ -461,16 +461,16 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_can_be_hidden_from_completions_by_setting_IsHidden_to_true()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("--hide-me")
+                new Option<string>("--hide-me")
                 {
                     Hidden = true
                 },
-                new CliOption<string>("-n") { Description = "Not hidden" }
+                new Option<string>("-n") { Description = "Not hidden" }
             };
 
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var completions = command.Parse("the-command ", simpleConfig).GetCompletions();
 
             completions.Select(item => item.Label).Should().NotContain("--hide-me");
@@ -479,14 +479,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parser_options_can_supply_context_sensitive_matches()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 CreateOptionWithAcceptOnlyFromAmong(name: "--bread", "wheat", "sourdough", "rye"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "--cheese", "provolone", "cheddar", "cream cheese")
             };
 
             var commandLine = "--bread";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var result = command.Parse(commandLine, simpleConfig);
 
             result.GetCompletions(commandLine.Length + 1)
@@ -506,15 +506,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Subcommand_names_are_available_as_suggestions()
         {
-            var command = new CliCommand("test")
+            var command = new Command("test")
             {
-                new CliCommand("one", "Command one"),
-                new CliCommand("two", "Command two"),
-                new CliArgument<string>("arg")
+                new Command("one", "Command one"),
+                new Command("two", "Command two"),
+                new Argument<string>("arg")
             };
 
             var commandLine = "test";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             command.Parse(commandLine, simpleConfig)
                    .GetCompletions(commandLine.Length + 1)
                    .Select(item => item.Label)
@@ -525,15 +525,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Both_subcommands_and_options_are_available_as_suggestions()
         {
-            var command = new CliCommand("test")
+            var command = new Command("test")
             {
-                new CliCommand("one"),
-                new CliOption<string>("--one"),
-                new CliArgument<string>("arg")
+                new Command("one"),
+                new Option<string>("--one"),
+                new Argument<string>("arg")
             };
 
             var commandLine = "test";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             command.Parse(commandLine, simpleConfig)
                    .GetCompletions(commandLine.Length + 1)
                    .Select(item => item.Label)
@@ -546,14 +546,14 @@ namespace System.CommandLine.Tests
         [InlineData("outer -")]
         public void Option_GetCompletions_are_not_provided_without_matching_prefix(string input)
         {
-            var command = new CliCommand("outer")
+            var command = new Command("outer")
             {
-                new CliOption<string>("--one"),
-                new CliOption<string>("--two"),
-                new CliOption<string>("--three")
+                new Option<string>("--one"),
+                new Option<string>("--two"),
+                new Option<string>("--three")
             };
 
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             ParseResult result = command.Parse(input, simpleConfig);
             result.GetCompletions()
                   .Select(item => item.Label)
@@ -564,15 +564,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_GetCompletions_can_be_based_on_the_proximate_option()
         {
-            CliCommand outer = new CliCommand("outer")
+            Command outer = new Command("outer")
             {
-                new CliOption<string>("--one"),
-                new CliOption<string>("--two"),
-                new CliOption<string>("--three")
+                new Option<string>("--one"),
+                new Option<string>("--two"),
+                new Option<string>("--three")
             };
 
             var commandLine = "outer";
-            CliConfiguration simpleConfig = new (outer);
+            CommandLineConfiguration simpleConfig = new (outer);
             ParseResult result = outer.Parse(commandLine, simpleConfig);
 
             result.GetCompletions(commandLine.Length + 1)
@@ -584,14 +584,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Argument_completions_can_be_based_on_the_proximate_option()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
                 CreateOptionWithAcceptOnlyFromAmong(name: "--one", "one-a", "one-b"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "--two", "two-a", "two-b")
             };
 
             var commandLine = "outer --two";
-            CliConfiguration simpleConfig = new (outer);
+            CommandLineConfiguration simpleConfig = new (outer);
             ParseResult result = outer.Parse(commandLine, simpleConfig);
 
             result.GetCompletions(commandLine.Length + 1)
@@ -603,14 +603,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_GetCompletions_can_be_based_on_the_proximate_option_and_partial_input()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
-                new CliCommand("one", "Command one"),
-                new CliCommand("two", "Command two"),
-                new CliCommand("three", "Command three")
+                new Command("one", "Command one"),
+                new Command("two", "Command two"),
+                new Command("three", "Command three")
             };
 
-            CliConfiguration simpleConfig = new (outer);
+            CommandLineConfiguration simpleConfig = new (outer);
             ParseResult result = outer.Parse("outer o", simpleConfig);
 
             result.GetCompletions()
@@ -622,15 +622,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Completions_can_be_provided_in_the_absence_of_validation()
         {
-            CliOption<string> option = new ("-t");
+            Option<string> option = new ("-t");
             option.CompletionSources.Add("vegetable", "mineral", "animal");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
 
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             command.Parse("the-command -t m", simpleConfig)
                    .GetCompletions()
                    .Select(item => item.Label)
@@ -647,11 +647,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_argument_completions_can_be_provided_using_a_delegate()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliCommand("one")
+                new Command("one")
                 {
-                    new CliArgument<string>("arg")
+                    new Argument<string>("arg")
                         {
                             CompletionSources = { _ => new[] { "vegetable", "mineral", "animal" } }
                         }
@@ -668,10 +668,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_argument_completions_can_be_provided_using_a_delegate()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
             option.CompletionSources.Add(_ => new[] { "vegetable", "mineral", "animal" });
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -688,14 +688,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_caller_does_the_tokenizing_then_argument_completions_are_based_on_the_proximate_option()
         {
-            var command = new CliCommand("outer")
+            var command = new Command("outer")
             {
                 CreateOptionWithAcceptOnlyFromAmong(name: "one", "one-a", "one-b", "one-c"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "two", "two-a", "two-b", "two-c"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "three", "three-a", "three-b", "three-c")
             };
 
-            var configuration = new CliConfiguration(command);
+            var configuration = new CommandLineConfiguration(command);
 
             var result = command.Parse("outer two b", configuration);
 
@@ -708,7 +708,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_parsing_from_array_then_argument_completions_are_based_on_the_proximate_option()
         {
-            var command = new CliCommand("outer")
+            var command = new Command("outer")
             {
                 CreateOptionWithAcceptOnlyFromAmong(name: "one", "one-a", "one-b", "one-c"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "two", "two-a", "two-b", "two-c"),
@@ -726,17 +726,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_parsing_from_text_then_argument_completions_are_based_on_the_proximate_command()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
-                new CliCommand("one")
+                new Command("one")
                 {
                     CreateArgumentWithAcceptOnlyFromAmong("one-a", "one-b", "one-c")
                 },
-                new CliCommand("two")
+                new Command("two")
                 {
                     CreateArgumentWithAcceptOnlyFromAmong("two-a", "two-b", "two-c")
                 },
-                new CliCommand("three")
+                new Command("three")
                 {
                     CreateArgumentWithAcceptOnlyFromAmong("three-a", "three-b", "three-c")
                 }
@@ -753,17 +753,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_parsing_from_array_then_argument_completions_are_based_on_the_proximate_command()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
-                new CliCommand("one")
+                new Command("one")
                 {
                     CreateArgumentWithAcceptOnlyFromAmong("one-a", "one-b", "one-c")
                 },
-                new CliCommand("two")
+                new Command("two")
                 {
                     CreateArgumentWithAcceptOnlyFromAmong("two-a", "two-b", "two-c")
                 },
-                new CliCommand("three")
+                new Command("three")
                 {
                     CreateArgumentWithAcceptOnlyFromAmong("three-a", "three-b", "three-c")
                 }
@@ -780,13 +780,13 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1518
         public void When_parsing_from_text_if_the_proximate_option_is_completed_then_completions_consider_other_option_tokens()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 CreateOptionWithAcceptOnlyFromAmong(name: "--framework", "net7.0"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "--language", "C#"),
-                new CliOption<string>("--langVersion")
+                new Option<string>("--langVersion")
             };
-            var configuration = new CliConfiguration(command);
+            var configuration = new CommandLineConfiguration(command);
             var completions = command.Parse("--framework net7.0 --l", configuration).GetCompletions();
 
             completions.Select(item => item.Label)
@@ -797,13 +797,13 @@ namespace System.CommandLine.Tests
         [Fact] 
         public void When_parsing_from_array_if_the_proximate_option_is_completed_then_completions_consider_other_option_tokens()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 CreateOptionWithAcceptOnlyFromAmong(name: "--framework", "net7.0"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "--language", "C#"),
-                new CliOption<string>("--langVersion")
+                new Option<string>("--langVersion")
             };
-            var configuration = new CliConfiguration(command);
+            var configuration = new CommandLineConfiguration(command);
             var completions = command.Parse(new[]{"--framework","net7.0","--l"}, configuration).GetCompletions();
 
             completions.Select(item => item.Label)
@@ -814,9 +814,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Arguments_of_type_enum_provide_enum_values_as_suggestions()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<FileMode>("arg")
+                new Argument<FileMode>("arg")
             };
 
             var completions = command.Parse("the-command create")
@@ -831,14 +831,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_that_have_been_specified_to_their_maximum_arity_are_not_suggested()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliOption<string>("--allows-one"),
-                new CliOption<string[]>("--allows-many")
+                new Option<string>("--allows-one"),
+                new Option<string[]>("--allows-many")
             };
 
             var commandLine = "--allows-one x";
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var completions = command.Parse(commandLine, simpleConfig).GetCompletions(commandLine.Length + 1);
 
             completions.Select(item => item.Label)
@@ -849,10 +849,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_current_symbol_is_an_option_that_requires_arguments_then_parent_symbol_completions_are_omitted()
         {
-            var configuration = new CliConfiguration(new CliRootCommand
+            var configuration = new CommandLineConfiguration(new RootCommand
                          {
-                             new CliOption<string>("--allows-one"),
-                             new CliOption<string[]>("--allows-many")
+                             new Option<string>("--allows-one"),
+                             new Option<string[]>("--allows-many")
                          });
 
             var completions = configuration.Parse("--allows-one ").GetCompletions();
@@ -863,10 +863,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_substring_matching_when_arguments_have_default_values()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<string>("--implicit") { DefaultValueFactory = (_) => "the-default" },
-                new CliOption<string>("--not") { DefaultValueFactory = (_) => "the-default" }
+                new Option<string>("--implicit") { DefaultValueFactory = (_) => "the-default" },
+                new Option<string>("--not") { DefaultValueFactory = (_) => "the-default" }
             };
 
             var completions = command.Parse("m").GetCompletions();
@@ -888,10 +888,10 @@ namespace System.CommandLine.Tests
                 "\"nuget:Microsoft.DotNet.Interactive\""
             };
 
-            var argument = new CliArgument<string>("arg");
+            var argument = new Argument<string>("arg");
             argument.CompletionSources.Add(expectedSuggestions);
 
-            var r = new CliCommand("#r")
+            var r = new Command("#r")
             {
                 argument
             };
@@ -909,14 +909,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Default_completions_can_be_cleared_and_replaced()
         {
-            var argument = new CliArgument<DayOfWeek>("day");
+            var argument = new Argument<DayOfWeek>("day");
             argument.CompletionSources.Clear();
             argument.CompletionSources.Add(new[] { "mon", "tues", "wed", "thur", "fri", "sat", "sun" });
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 argument
             };
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var completions = command.Parse("the-command s", simpleConfig)
                                      .GetCompletions();
 
@@ -928,15 +928,15 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Default_completions_can_be_appended_to()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<DayOfWeek>("day")
+                new Argument<DayOfWeek>("day")
                 {
                     CompletionSources = { "mon", "tues", "wed", "thur", "fri", "sat", "sun" }
                 }
             };
 
-            CliConfiguration simpleConfig = new (command);
+            CommandLineConfiguration simpleConfig = new (command);
             var completions = command.Parse("the-command s", simpleConfig)
                                      .GetCompletions();
 
@@ -958,9 +958,9 @@ namespace System.CommandLine.Tests
         public void Completions_for_options_provide_a_description()
         {
             var description = "The option before -y.";
-            var option = new CliOption<string>("-x") { Description = description };
+            var option = new Option<string>("-x") { Description = description };
 
-            var completions = new CliCommand("test") { option }.GetCompletions(CompletionContext.Empty);
+            var completions = new Command("test") { option }.GetCompletions(CompletionContext.Empty);
 
             completions.Should().ContainSingle()
                        .Which
@@ -973,9 +973,9 @@ namespace System.CommandLine.Tests
         public void Completions_for_subcommands_provide_a_description()
         {
             var description = "The description for the subcommand";
-            var subcommand = new CliCommand("-x", description);
+            var subcommand = new Command("-x", description);
 
-            var completions = new CliCommand("test") { subcommand }.GetCompletions(CompletionContext.Empty);
+            var completions = new Command("test") { subcommand }.GetCompletions(CompletionContext.Empty);
 
             completions.Should().ContainSingle()
                        .Which
@@ -987,9 +987,9 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1629
         public void When_option_completions_are_available_then_they_are_suggested_when_a_validation_error_occurs()
         {
-            CliOption<DayOfWeek> option = new ("--day");
-            CliRootCommand rootCommand = new () { option };
-            CliConfiguration simpleConfig = new (rootCommand);
+            Option<DayOfWeek> option = new ("--day");
+            RootCommand rootCommand = new () { option };
+            CommandLineConfiguration simpleConfig = new (rootCommand);
 
             var result = rootCommand.Parse("--day SleepyDay", simpleConfig);
 
@@ -1003,16 +1003,16 @@ namespace System.CommandLine.Tests
                       $"Cannot parse argument 'SleepyDay' for option '--day' as expected type 'System.DayOfWeek'. Did you mean one of the following?{NewLine}Friday{NewLine}Monday{NewLine}Saturday{NewLine}Sunday{NewLine}Thursday{NewLine}Tuesday{NewLine}Wednesday");
         }
 
-        private static CliArgument<string> CreateArgumentWithAcceptOnlyFromAmong(params string[] values)
+        private static Argument<string> CreateArgumentWithAcceptOnlyFromAmong(params string[] values)
         {
-            CliArgument<string> argument = new("arg");
+            Argument<string> argument = new("arg");
             argument.AcceptOnlyFromAmong(values);
             return argument;
         }
 
-        private static CliOption<string> CreateOptionWithAcceptOnlyFromAmong(string name, params string[] values)
+        private static Option<string> CreateOptionWithAcceptOnlyFromAmong(string name, params string[] values)
         {
-            CliOption<string> option = new(name);
+            Option<string> option = new(name);
             option.AcceptOnlyFromAmong(values);
             return option;
         }

--- a/src/System.CommandLine.Tests/CustomParsingTests.cs
+++ b/src/System.CommandLine.Tests/CustomParsingTests.cs
@@ -18,7 +18,7 @@ public class CustomParsingTests
     [Fact]
     public void HasDefaultValue_can_be_set_to_true()
     {
-        var argument = new CliArgument<FileSystemInfo>("arg")
+        var argument = new Argument<FileSystemInfo>("arg")
         {
             DefaultValueFactory = result => null
         };
@@ -31,7 +31,7 @@ public class CustomParsingTests
     [Fact]
     public void HasDefaultValue_can_be_set_to_false()
     {
-        var argument = new CliArgument<FileSystemInfo>("arg")
+        var argument = new Argument<FileSystemInfo>("arg")
         {
             DefaultValueFactory = null
         };
@@ -44,7 +44,7 @@ public class CustomParsingTests
     [Fact]
     public void GetDefaultValue_returns_specified_value()
     {
-        var argument = new CliArgument<string>("arg")
+        var argument = new Argument<string>("arg")
         {
             DefaultValueFactory = result => "the-default"
         };
@@ -57,7 +57,7 @@ public class CustomParsingTests
     [Fact]
     public void GetDefaultValue_returns_null_when_custom_parser_returns_true_without_setting_a_value()
     {
-        var argument = new CliArgument<string>("arg")
+        var argument = new Argument<string>("arg")
         {
             DefaultValueFactory = result => null
         };
@@ -70,7 +70,7 @@ public class CustomParsingTests
     [Fact]
     public void GetDefaultValue_can_return_null()
     {
-        var argument = new CliArgument<string>("arg")
+        var argument = new Argument<string>("arg")
         {
             DefaultValueFactory = result => null
         };
@@ -83,7 +83,7 @@ public class CustomParsingTests
     [Fact]
     public void Validation_failure_message_can_be_specified_when_parsing_tokens()
     {
-        var argument = new CliArgument<FileSystemInfo>("arg")
+        var argument = new Argument<FileSystemInfo>("arg")
         {
             CustomParser = result =>
             {
@@ -92,7 +92,7 @@ public class CustomParsingTests
             }
         };
 
-        new CliRootCommand { argument }.Parse("x")
+        new RootCommand { argument }.Parse("x")
                                        .Errors
                                        .Should()
                                        .ContainSingle(e => ((ArgumentResult)e.SymbolResult).Argument == argument)
@@ -105,7 +105,7 @@ public class CustomParsingTests
     [Fact]
     public void Validation_failure_message_can_be_specified_when_evaluating_default_argument_value()
     {
-        var argument = new CliArgument<FileSystemInfo>("arg")
+        var argument = new Argument<FileSystemInfo>("arg")
         {
             DefaultValueFactory = result =>
             {
@@ -114,7 +114,7 @@ public class CustomParsingTests
             }
         };
 
-        new CliRootCommand { argument }.Parse("")
+        new RootCommand { argument }.Parse("")
                                        .Errors
                                        .Should()
                                        .ContainSingle(e => ((ArgumentResult)e.SymbolResult).Argument == argument)
@@ -127,7 +127,7 @@ public class CustomParsingTests
     [Fact]
     public void Validation_failure_message_can_be_specified_when_evaluating_default_option_value()
     {
-        var option = new CliOption<FileSystemInfo>("-x")
+        var option = new Option<FileSystemInfo>("-x")
         {
             DefaultValueFactory = result =>
             {
@@ -136,7 +136,7 @@ public class CustomParsingTests
             }
         };
 
-        new CliRootCommand { option }.Parse("")
+        new RootCommand { option }.Parse("")
                                      .Errors
                                      .Should()
                                      .ContainSingle()
@@ -149,12 +149,12 @@ public class CustomParsingTests
     [Fact]
     public void custom_parsing_of_scalar_value_from_an_argument_with_one_token()
     {
-        var argument = new CliArgument<int>("arg")
+        var argument = new Argument<int>("arg")
         {
             CustomParser = result => int.Parse(result.Tokens.Single().Value)
         };
 
-        new CliRootCommand { argument }.Parse("123")
+        new RootCommand { argument }.Parse("123")
                                        .GetValue(argument)
                                        .Should()
                                        .Be(123);
@@ -163,12 +163,12 @@ public class CustomParsingTests
     [Fact]
     public void custom_parsing_of_sequence_value_from_an_argument_with_one_token()
     {
-        var argument = new CliArgument<IEnumerable<int>>("arg")
+        var argument = new Argument<IEnumerable<int>>("arg")
         {
             CustomParser = result => result.Tokens.Single().Value.Split(',').Select(int.Parse)
         };
 
-        new CliRootCommand { argument }.Parse("1,2,3")
+        new RootCommand { argument }.Parse("1,2,3")
                                        .GetValue(argument)
                                        .Should()
                                        .BeEquivalentTo(new[] { 1, 2, 3 });
@@ -177,12 +177,12 @@ public class CustomParsingTests
     [Fact]
     public void custom_parsing_of_sequence_value_from_an_argument_with_multiple_tokens()
     {
-        var argument = new CliArgument<IEnumerable<int>>("arg")
+        var argument = new Argument<IEnumerable<int>>("arg")
         {
             CustomParser = result => result.Tokens.Select(t => int.Parse(t.Value)).ToArray()
         };
 
-        new CliRootCommand { argument }.Parse("1 2 3")
+        new RootCommand { argument }.Parse("1 2 3")
                                        .GetValue(argument)
                                        .Should()
                                        .BeEquivalentTo(new[] { 1, 2, 3 });
@@ -191,13 +191,13 @@ public class CustomParsingTests
     [Fact]
     public void custom_parsing_of_scalar_value_from_an_argument_with_multiple_tokens()
     {
-        var argument = new CliArgument<int>("arg")
+        var argument = new Argument<int>("arg")
         {
             CustomParser = result => result.Tokens.Select(t => int.Parse(t.Value)).Sum(),
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        new CliRootCommand { argument }.Parse("1 2 3")
+        new RootCommand { argument }.Parse("1 2 3")
                                        .GetValue(argument)
                                        .Should()
                                        .Be(6);
@@ -208,9 +208,9 @@ public class CustomParsingTests
     {
         ArgumentResult argumentResult = null;
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
-            new CliOption<string>("-x")
+            new Option<string>("-x")
             {
                 DefaultValueFactory = argResult =>
                 {
@@ -220,7 +220,7 @@ public class CustomParsingTests
             }
         };
 
-        CliConfiguration simpleConfig = new (command);
+        CommandLineConfiguration simpleConfig = new (command);
         command.Parse("", simpleConfig);
 
         argumentResult
@@ -238,9 +238,9 @@ public class CustomParsingTests
     {
         ArgumentResult argumentResult = null;
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
-            new CliOption<string>("-x")
+            new Option<string>("-x")
             {
                 DefaultValueFactory = argResult =>
                 {
@@ -269,12 +269,12 @@ public class CustomParsingTests
     public void Symbol_can_be_found_without_explicitly_traversing_result_tree(string commandLine)
     {
         SymbolResult resultForOptionX = null;
-        var optionX = new CliOption<string>("-x")
+        var optionX = new Option<string>("-x")
         {
             CustomParser = _ => string.Empty
         };
                 
-        var optionY = new CliOption<string>("-y")
+        var optionY = new Option<string>("-y")
         {
             CustomParser = argResult =>
             {
@@ -283,7 +283,7 @@ public class CustomParsingTests
             }
         };
             
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
             optionX,
             optionY,
@@ -305,9 +305,9 @@ public class CustomParsingTests
     {
         ArgumentResult argumentResult = null;
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
-            new CliArgument<string>("arg")
+            new Argument<string>("arg")
             {
                 DefaultValueFactory = argResult =>
                 {
@@ -335,7 +335,7 @@ public class CustomParsingTests
         var callCount = 0;
         var handlerWasCalled = false;
 
-        var option = new CliOption<int>("--value")
+        var option = new Option<int>("--value")
         {
             CustomParser = result =>
             {
@@ -344,7 +344,7 @@ public class CustomParsingTests
             }
         };
 
-        var command = new CliRootCommand();
+        var command = new RootCommand();
         command.SetAction((ctx) => handlerWasCalled = true);
         command.Options.Add(option);
 
@@ -357,13 +357,13 @@ public class CustomParsingTests
     [Fact]
     public void Default_value_and_custom_argument_parser_can_be_used_together()
     {
-        var argument = new CliArgument<int>("arg")
+        var argument = new Argument<int>("arg")
         {
             CustomParser = _ => 789,
             DefaultValueFactory = _ => 123
         };
 
-        var result = new CliRootCommand { argument }.Parse("");
+        var result = new RootCommand { argument }.Parse("");
 
         result.GetValue(argument)
               .Should()
@@ -373,9 +373,9 @@ public class CustomParsingTests
     [Fact]
     public void Multiple_arguments_can_have_custom_parsers()
     {
-        var root = new CliRootCommand
+        var root = new RootCommand
         {
-            new CliArgument<FileInfo[]>("from")
+            new Argument<FileInfo[]>("from")
             {
                 CustomParser = argumentResult =>
                 {
@@ -384,7 +384,7 @@ public class CustomParsingTests
                 },
                 Arity = new ArgumentArity(0, 2)
             },
-            new CliArgument<DirectoryInfo>("to")
+            new Argument<DirectoryInfo>("to")
             {
                 CustomParser = argumentResult =>
                 {
@@ -414,7 +414,7 @@ public class CustomParsingTests
     [InlineData("--depends-on-option-with-error --option-with-error 123")]
     public void Custom_parser_can_check_another_option_result_for_custom_errors(string commandLine)
     {
-        var optionWithError = new CliOption<string>("--option-with-error")
+        var optionWithError = new Option<string>("--option-with-error")
         {
             CustomParser = r =>
             {
@@ -423,7 +423,7 @@ public class CustomParsingTests
             }
         };
 
-        var optionThatDependsOnOptionWithError = new CliOption<bool>("--depends-on-option-with-error")
+        var optionThatDependsOnOptionWithError = new Option<bool>("--depends-on-option-with-error")
         {
             CustomParser = result =>
             {
@@ -438,7 +438,7 @@ public class CustomParsingTests
             }
         };
 
-        var command = new CliCommand("cmd")
+        var command = new Command("cmd")
         {
             optionWithError,
             optionThatDependsOnOptionWithError
@@ -457,9 +457,9 @@ public class CustomParsingTests
     [Fact]
     public void Validation_reports_all_parse_errors()
     {
-        CliOption<string> firstOptionWithError = new("--first-option-with-error");
+        Option<string> firstOptionWithError = new("--first-option-with-error");
         firstOptionWithError.Validators.Add(optionResult => optionResult.AddError("first error"));
-        CliOption<string> secondOptionWithError = new("--second-option-with-error")
+        Option<string> secondOptionWithError = new("--second-option-with-error")
         {
             CustomParser = r =>
             {
@@ -468,7 +468,7 @@ public class CustomParsingTests
             }
         };
 
-        CliCommand command = new ("cmd")
+        Command command = new ("cmd")
         {
             firstOptionWithError,
             secondOptionWithError
@@ -489,10 +489,10 @@ public class CustomParsingTests
     [Fact]
     public void When_custom_conversion_fails_then_an_option_does_not_accept_further_arguments()
     {
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
-            new CliArgument<string>("arg"),
-            new CliOption<string>("-x")
+            new Argument<string>("arg"),
+            new Option<string>("-x")
             {
                 CustomParser = argResult =>
                 {
@@ -510,7 +510,7 @@ public class CustomParsingTests
     [Fact]
     public void When_argument_cannot_be_parsed_as_the_specified_type_then_getting_value_throws()
     {
-        var option = new CliOption<int>("--one", "-o")
+        var option = new Option<int>("--one", "-o")
         {
             CustomParser = argumentResult =>
             {
@@ -525,7 +525,7 @@ public class CustomParsingTests
             }
         };
 
-        var command = new CliCommand("the-command")
+        var command = new Command("the-command")
         {
             option
         };
@@ -548,9 +548,9 @@ public class CustomParsingTests
     {
         var i = 0;
 
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
-            new CliOption<int>("-x")
+            new Option<int>("-x")
             {
                 CustomParser = result => ++i,
             }
@@ -567,9 +567,9 @@ public class CustomParsingTests
     {
         var i = 0;
 
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
-            new CliOption<int>("-x")
+            new Option<int>("-x")
             {
                 DefaultValueFactory = result => ++i,
             }
@@ -604,14 +604,14 @@ public class CustomParsingTests
             }
         };
 
-        var opt = new CliOption<string>("--bananas")
+        var opt = new Option<string>("--bananas")
         {
             DefaultValueFactory = both,
             CustomParser = both,
             Arity = ArgumentArity.ZeroOrOne
         };
 
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
             opt
         };
@@ -625,7 +625,7 @@ public class CustomParsingTests
     [InlineData("1 2 3 -o 999 4 5 6 7 8")]
     public void Custom_parser_can_pass_on_remaining_tokens(string commandLine)
     {
-        var argument1 = new CliArgument<int[]>("one")
+        var argument1 = new Argument<int[]>("one")
         {
             CustomParser = result =>
             {
@@ -639,15 +639,15 @@ public class CustomParsingTests
                 };
             }
         };
-        var argument2 = new CliArgument<int[]>("two")
+        var argument2 = new Argument<int[]>("two")
         {
             CustomParser = result => result.Tokens.Select(t => t.Value).Select(int.Parse).ToArray()
         };
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
             argument1,
             argument2,
-            new CliOption<int>("-o")
+            new Option<int>("-o")
         };
 
         var parseResult = command.Parse(commandLine);
@@ -668,7 +668,7 @@ public class CustomParsingTests
     [Fact]
     public void Custom_parser_can_return_null()
     {
-        CliOption<IPAddress> option = new("-ip")
+        Option<IPAddress> option = new("-ip")
         {
             CustomParser = (argumentResult) =>
             {
@@ -683,7 +683,7 @@ public class CustomParsingTests
             }
         };
 
-        ParseResult parseResult = new CliRootCommand() { option }.Parse("-ip a.b.c.d");
+        ParseResult parseResult = new RootCommand() { option }.Parse("-ip a.b.c.d");
 
         parseResult.Errors.Should().Contain(error => error.Message == "'a.b.c.d' is not a valid value");
     }
@@ -692,7 +692,7 @@ public class CustomParsingTests
     public void When_tokens_are_passed_on_by_custom_parser_on_last_argument_then_they_become_unmatched_tokens()
     {
 
-        var argument1 = new CliArgument<int[]>("one")
+        var argument1 = new Argument<int[]>("one")
         {
             CustomParser = result =>
             {
@@ -707,7 +707,7 @@ public class CustomParsingTests
             }
         };
              
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
             argument1
         };
@@ -723,7 +723,7 @@ public class CustomParsingTests
     [Fact]
     public void When_custom_parser_passes_on_tokens_the_argument_result_tokens_reflect_the_change()
     {
-        var argument1 = new CliArgument<int[]>("one")
+        var argument1 = new Argument<int[]>("one")
         {
             CustomParser = result =>
             {
@@ -737,11 +737,11 @@ public class CustomParsingTests
                 };
             }
         };
-        var argument2 = new CliArgument<int[]>("two")
+        var argument2 = new Argument<int[]>("two")
         {
             CustomParser = result => result.Tokens.Select(t => t.Value).Select(int.Parse).ToArray()
         };
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
             argument1,
             argument2
@@ -767,7 +767,7 @@ public class CustomParsingTests
     [Fact]
     public void OnlyTake_throws_when_called_with_a_negative_value()
     {
-        var argument = new CliArgument<int[]>("one")
+        var argument = new Argument<int[]>("one")
         {
             CustomParser = result =>
             {
@@ -777,7 +777,7 @@ public class CustomParsingTests
             }
         };
 
-        argument.Invoking(a => new CliRootCommand { a }.Parse("1 2 3"))
+        argument.Invoking(a => new RootCommand { a }.Parse("1 2 3"))
                 .Should()
                 .Throw<ArgumentOutOfRangeException>()
                 .Which
@@ -789,7 +789,7 @@ public class CustomParsingTests
     [Fact]
     public void OnlyTake_throws_when_called_twice()
     {
-        var argument = new CliArgument<int[]>("one")
+        var argument = new Argument<int[]>("one")
         {
             CustomParser = result =>
             {
@@ -800,7 +800,7 @@ public class CustomParsingTests
             }
         };
 
-        argument.Invoking(a => new CliRootCommand { a }.Parse("1 2 3"))
+        argument.Invoking(a => new RootCommand { a }.Parse("1 2 3"))
                 .Should()
                 .Throw<InvalidOperationException>()
                 .Which
@@ -812,7 +812,7 @@ public class CustomParsingTests
     [Fact]
     public void OnlyTake_can_pass_on_all_tokens_from_one_multiple_arity_argument_to_another()
     {
-        var argument1 = new CliArgument<int[]>("arg1")
+        var argument1 = new Argument<int[]>("arg1")
         {
             CustomParser = result =>
             {
@@ -820,8 +820,8 @@ public class CustomParsingTests
                 return null;
             }
         };
-        var argument2 = new CliArgument<int[]>("arg2");
-        var command = new CliRootCommand
+        var argument2 = new Argument<int[]>("arg2");
+        var command = new RootCommand
         {
             argument1,
             argument2
@@ -837,7 +837,7 @@ public class CustomParsingTests
     [Fact] // https://github.com/dotnet/command-line-api/issues/1759 
     public void OnlyTake_can_pass_on_all_tokens_from_a_single_arity_argument_to_another()
     {
-        var scalar = new CliArgument<int?>("arg")
+        var scalar = new Argument<int?>("arg")
         {
             CustomParser = ctx =>
             {
@@ -845,9 +845,9 @@ public class CustomParsingTests
                 return null;
             }
         };
-        CliArgument<int[]> multiple = new("args");
+        Argument<int[]> multiple = new("args");
 
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
             scalar,
             multiple
@@ -864,7 +864,7 @@ public class CustomParsingTests
     [Fact] //https://github.com/dotnet/command-line-api/issues/1779
     public void OnlyTake_can_pass_on_all_tokens_from_a_single_arity_argument_to_another_that_also_passes_them_all_on()
     {
-        var first = new CliArgument<string>("first")
+        var first = new Argument<string>("first")
         {
             CustomParser = ctx =>
             {
@@ -874,7 +874,7 @@ public class CustomParsingTests
             Arity = ArgumentArity.ZeroOrOne
         };
 
-        var second = new CliArgument<string[]>(name: "second")
+        var second = new Argument<string[]>(name: "second")
         {
             CustomParser = ctx =>
             {
@@ -884,7 +884,7 @@ public class CustomParsingTests
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        var third = new CliArgument<string[]>(name: "third")
+        var third = new Argument<string[]>(name: "third")
         {
             CustomParser = ctx =>
             {
@@ -894,7 +894,7 @@ public class CustomParsingTests
             Arity = ArgumentArity.ZeroOrMore
         };
 
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
             first,
             second,
@@ -914,9 +914,9 @@ public class CustomParsingTests
         ArgumentResult firstResult = null;
         ArgumentResult secondResult = null;
 
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
-            new CliArgument<string>("first")
+            new Argument<string>("first")
             {
                 CustomParser = ctx =>
                 {
@@ -926,7 +926,7 @@ public class CustomParsingTests
                 },
             },
 
-            new CliArgument<string>("second")
+            new Argument<string>("second")
             {
                 CustomParser = ctx =>
                 {
@@ -936,7 +936,7 @@ public class CustomParsingTests
                 },
             },
 
-            new CliArgument<string>("third")
+            new Argument<string>("third")
         };
 
         var result = command.Parse("one two three");
@@ -954,9 +954,9 @@ public class CustomParsingTests
         OptionResult firstOptionResult = null;
         OptionResult secondOptionResult = null;
 
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
-            new CliOption<string>("--first")
+            new Option<string>("--first")
             {
                 CustomParser = ctx =>
                 {
@@ -966,7 +966,7 @@ public class CustomParsingTests
                 },
             },
 
-            new CliOption<string>("--second")
+            new Option<string>("--second")
             {
                 CustomParser = ctx =>
                 {
@@ -976,7 +976,7 @@ public class CustomParsingTests
                 },
             },
 
-            new CliOption<string>("--third")
+            new Option<string>("--third")
         };
 
         var parseResult = command.Parse(commandLine);

--- a/src/System.CommandLine.Tests/DirectiveTests.cs
+++ b/src/System.CommandLine.Tests/DirectiveTests.cs
@@ -14,9 +14,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Directives_should_be_considered_as_unmatched_tokens_when_they_are_not_matched()
         {
-            CliDirective directive = new("parse");
+            Directive directive = new("parse");
 
-            ParseResult result = Parse(new CliOption<bool>("-y"), directive, $"{CliRootCommand.ExecutableName} [nonExisting] -y");
+            ParseResult result = Parse(new Option<bool>("-y"), directive, $"{RootCommand.ExecutableName} [nonExisting] -y");
 
             result.UnmatchedTokens.Should().ContainSingle("[nonExisting]");
         }
@@ -24,9 +24,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Raw_tokens_still_hold_directives()
         {
-            CliDirective directive = new ("parse");
+            Directive directive = new ("parse");
 
-            ParseResult result = Parse(new CliOption<bool>("-y"), directive, "[parse] -y");
+            ParseResult result = Parse(new Option<bool>("-y"), directive, "[parse] -y");
 
             result.GetResult(directive).Should().NotBeNull();
             result.Tokens.Should().Contain(t => t.Value == "[parse]");
@@ -35,9 +35,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Directives_must_precede_other_symbols()
         {
-            CliDirective directive = new("parse");
+            Directive directive = new("parse");
 
-            ParseResult result = Parse(new CliOption<bool>("-y"), directive, "-y [parse]");
+            ParseResult result = Parse(new Option<bool>("-y"), directive, "-y [parse]");
 
             result.GetResult(directive).Should().BeNull();
         }
@@ -45,10 +45,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Multiple_directives_are_allowed()
         {
-            CliRootCommand root = new() { new CliOption<bool>("-y") };
-            CliDirective parseDirective = new ("parse");
-            CliDirective suggestDirective = new ("suggest");
-            CliConfiguration config = new(root);
+            RootCommand root = new() { new Option<bool>("-y") };
+            Directive parseDirective = new ("parse");
+            Directive suggestDirective = new ("suggest");
+            CommandLineConfiguration config = new(root);
             root.Add(parseDirective);
             root.Add(suggestDirective);
 
@@ -76,7 +76,7 @@ namespace System.CommandLine.Tests
                              : new SynchronousTestAction(incrementCallCount, terminating: false)
             };
 
-            var config = new CliConfiguration(new CliRootCommand
+            var config = new CommandLineConfiguration(new RootCommand
             {
                 Action = invokeAsync
                              ? new AsynchronousTestAction(verifyActionWasCalled, terminating: false)
@@ -116,7 +116,7 @@ namespace System.CommandLine.Tests
             {
                 Action = new SynchronousTestAction(_ => directiveTwoActionWasCalled = true, terminating: false)
             };
-            var config = new CliConfiguration(new CliRootCommand
+            var config = new CommandLineConfiguration(new RootCommand
             {
                 Action = new SynchronousTestAction(_ => commandActionWasCalled = true, terminating: false), Directives = { directiveOne, directiveTwo }
             });
@@ -137,7 +137,7 @@ namespace System.CommandLine.Tests
             directiveTwoActionWasCalled.Should().BeTrue();
         }
 
-        public class TestDirective : CliDirective
+        public class TestDirective : Directive
         {
             public TestDirective(string name) : base(name)
             {
@@ -153,9 +153,9 @@ namespace System.CommandLine.Tests
             string key,
             string expectedValue)
         {
-            CliDirective directive = new(key);
+            Directive directive = new(key);
 
-            ParseResult result = Parse(new CliOption<bool>("-y"), directive, $"{wholeText} -y");
+            ParseResult result = Parse(new Option<bool>("-y"), directive, $"{wholeText} -y");
 
             result.GetResult(directive).Values.Single().Should().Be(expectedValue);
         }
@@ -163,9 +163,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Directives_without_a_value_specified_have_no_values()
         {
-            CliDirective directive = new("parse");
+            Directive directive = new("parse");
 
-            ParseResult result = Parse(new CliOption<bool>("-y"), directive, "[parse] -y");
+            ParseResult result = Parse(new Option<bool>("-y"), directive, "[parse] -y");
 
             result.GetResult(directive).Values.Should().BeEmpty();
         }
@@ -175,8 +175,8 @@ namespace System.CommandLine.Tests
         [InlineData("[:value]")]
         public void Directives_must_have_a_non_empty_key(string directive)
         {
-            CliOption<bool> option = new ("-a");
-            CliRootCommand root = new () { option };
+            Option<bool> option = new ("-a");
+            RootCommand root = new () { option };
 
             var result = root.Parse($"{directive} -a");
 
@@ -189,11 +189,11 @@ namespace System.CommandLine.Tests
         [InlineData("[parse ]", "[parse", "]")]
         public void Directives_cannot_contain_spaces(string value, string firstUnmatchedToken, string secondUnmatchedToken)
         {
-            Action create = () => new CliDirective(value);
+            Action create = () => new Directive(value);
             create.Should().Throw<ArgumentException>();
 
-            CliDirective directive = new("parse");
-            ParseResult result = Parse(new CliOption<bool>("-y"), directive, $"{value} -y");
+            Directive directive = new("parse");
+            ParseResult result = Parse(new Option<bool>("-y"), directive, $"{value} -y");
             result.GetResult(directive).Should().BeNull();
 
             result.UnmatchedTokens.Should().BeEquivalentTo(firstUnmatchedToken, secondUnmatchedToken);
@@ -202,17 +202,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_directive_is_specified_more_than_once_then_its_values_are_aggregated()
         {
-            CliDirective directive = new("directive");
+            Directive directive = new("directive");
 
-            ParseResult result = Parse(new CliOption<bool>("-a"), directive, "[directive:one] [directive:two] -a");
+            ParseResult result = Parse(new Option<bool>("-a"), directive, "[directive:one] [directive:two] -a");
 
             result.GetResult(directive).Values.Should().BeEquivalentTo("one", "two");
         }
 
-        private static ParseResult Parse(CliOption option, CliDirective directive, string commandLine)
+        private static ParseResult Parse(Option option, Directive directive, string commandLine)
         {
-            CliRootCommand root = new() { option };
-            CliConfiguration config = new(root);
+            RootCommand root = new() { option };
+            CommandLineConfiguration config = new(root);
             root.Directives.Add(directive);
 
             return root.Parse(commandLine, config);

--- a/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/EnvironmentVariableDirectiveTests.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine.Tests
         {
             bool asserted = false;
             const string value = "hello";
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 new EnvironmentVariablesDirective()
             };
@@ -28,7 +28,7 @@ namespace System.CommandLine.Tests
                 Environment.GetEnvironmentVariable(_testVariableName).Should().Be(value);
             });
 
-            var config = new CliConfiguration(rootCommand)
+            var config = new CommandLineConfiguration(rootCommand)
             {
                 EnableDefaultExceptionHandler = false
             };
@@ -43,7 +43,7 @@ namespace System.CommandLine.Tests
         {
             bool asserted = false;
             const string value = "1=2";
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 new EnvironmentVariablesDirective()
             };
@@ -53,7 +53,7 @@ namespace System.CommandLine.Tests
                 Environment.GetEnvironmentVariable(_testVariableName).Should().Be(value);
             });
 
-            var config = new CliConfiguration(rootCommand)
+            var config = new CommandLineConfiguration(rootCommand)
             {
                 EnableDefaultExceptionHandler = false
             };
@@ -68,7 +68,7 @@ namespace System.CommandLine.Tests
         {
             bool asserted = false;
             string variable = _testVariableName;
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 new EnvironmentVariablesDirective()
             };
@@ -78,7 +78,7 @@ namespace System.CommandLine.Tests
                 Environment.GetEnvironmentVariable(variable).Should().BeNull();
             });
 
-            var config = new CliConfiguration(rootCommand)
+            var config = new CommandLineConfiguration(rootCommand)
             {
                 EnableDefaultExceptionHandler = false
             };
@@ -93,7 +93,7 @@ namespace System.CommandLine.Tests
         {
             bool asserted = false;
             string value = "value";
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 new EnvironmentVariablesDirective()
             };
@@ -104,7 +104,7 @@ namespace System.CommandLine.Tests
                 env.Values.Cast<string>().Should().NotContain(value);
             });
 
-            var config = new CliConfiguration(rootCommand)
+            var config = new CommandLineConfiguration(rootCommand)
             {
                 EnableDefaultExceptionHandler = false
             };
@@ -119,13 +119,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void It_does_not_prevent_help_from_being_invoked()
         {
-            var root = new CliRootCommand();
+            var root = new RootCommand();
             root.SetAction(_ => { });
 
             var customHelpAction = new CustomHelpAction();
             root.Options.OfType<HelpOption>().Single().Action = customHelpAction;
 
-            var config = new CliConfiguration(root);
+            var config = new CommandLineConfiguration(root);
             root.Directives.Add(new EnvironmentVariablesDirective());
 
             root.Parse($"[env:{_testVariableName}=1] -h", config).Invoke();
@@ -134,7 +134,7 @@ namespace System.CommandLine.Tests
             Environment.GetEnvironmentVariable(_testVariableName).Should().Be("1");
         }
 
-        private class CustomHelpAction : SynchronousCliAction
+        private class CustomHelpAction : SynchronousCommandLineAction
         {
             public bool WasCalled { get; private set; }
 

--- a/src/System.CommandLine.Tests/GetValueByNameParserTests.cs
+++ b/src/System.CommandLine.Tests/GetValueByNameParserTests.cs
@@ -12,15 +12,15 @@ public class GetValueByNameTests
     [Fact]
     public void In_case_of_argument_name_conflict_the_value_which_belongs_to_the_last_parsed_command_is_returned()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliArgument<int>("arg"),
-            new CliCommand("inner1")
+            new Argument<int>("arg"),
+            new Command("inner1")
             {
-                new CliArgument<int>("arg"),
-                new CliCommand("inner2")
+                new Argument<int>("arg"),
+                new Command("inner2")
                 {
-                    new CliArgument<int>("arg"),
+                    new Argument<int>("arg"),
                 }
             }
         };
@@ -33,15 +33,15 @@ public class GetValueByNameTests
     [Fact]
     public void In_case_of_option_name_conflict_the_value_which_belongs_to_the_last_parsed_command_is_returned()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliOption<int>("--integer", "-i"),
-            new CliCommand("inner1")
+            new Option<int>("--integer", "-i"),
+            new Command("inner1")
             {
-                new CliOption<int>("--integer", "-i"),
-                new CliCommand("inner2")
+                new Option<int>("--integer", "-i"),
+                new Command("inner2")
                 {
-                    new CliOption<int>("--integer", "-i")
+                    new Option<int>("--integer", "-i")
                 }
             }
         };
@@ -54,9 +54,9 @@ public class GetValueByNameTests
     [Fact]
     public void When_option_is_not_provided_then_default_value_is_returned()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliOption<int>("--integer", "-i")
+            new Option<int>("--integer", "-i")
         };
 
         ParseResult parseResult = command.Parse("");
@@ -67,9 +67,9 @@ public class GetValueByNameTests
     [Fact]
     public void When_option_is_not_provided_then_configured_default_value_is_returned()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliOption<int>("--integer", "-i")
+            new Option<int>("--integer", "-i")
             {
                 DefaultValueFactory = _ => 123
             }
@@ -83,9 +83,9 @@ public class GetValueByNameTests
     [Fact]
     public void When_optional_argument_is_not_provided_then_default_value_is_returned()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliArgument<int>("arg")
+            new Argument<int>("arg")
             {
                 Arity = ArgumentArity.ZeroOrOne
             }
@@ -99,9 +99,9 @@ public class GetValueByNameTests
     [Fact]
     public void When_optional_argument_is_not_provided_then_configured_default_value_is_returned()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliArgument<int>("arg")
+            new Argument<int>("arg")
             {
                 Arity = ArgumentArity.ZeroOrOne,
                 DefaultValueFactory = _ => 123
@@ -116,9 +116,9 @@ public class GetValueByNameTests
     [Fact]
     public void When_required_option_value_is_not_provided_then_an_exception_is_thrown()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliOption<int>("--required")
+            new Option<int>("--required")
             {
                 Required = true
             }
@@ -137,9 +137,9 @@ public class GetValueByNameTests
     [Fact]
     public void When_required_argument_value_is_not_provided_then_an_exception_is_thrown()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliArgument<int>("required")
+            new Argument<int>("required")
             {
                 Arity = ArgumentArity.ExactlyOne
             }
@@ -159,7 +159,7 @@ public class GetValueByNameTests
     public void When_non_existing_name_is_used_then_exception_is_thrown()
     {
         const string nonExistingName = "nonExisting";
-        CliCommand command = new ("noSymbols");
+        Command command = new ("noSymbols");
         ParseResult parseResult = command.Parse("");
 
         Action getRequired = () => parseResult.GetValue<int>(nonExistingName);
@@ -175,13 +175,13 @@ public class GetValueByNameTests
     {
         const string sameName = "same";
 
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliArgument<int>(sameName)
+            new Argument<int>(sameName)
             {
                 Arity = ArgumentArity.ZeroOrOne
             },
-            new CliOption<int>(sameName)
+            new Option<int>(sameName)
         };
 
         ParseResult parseResult = command.Parse("");
@@ -199,12 +199,12 @@ public class GetValueByNameTests
     {
         const string sameName = "same";
 
-        CliCommand command = new("outer")
+        Command command = new("outer")
         {
-            new CliArgument<int>(sameName),
-            new CliCommand("inner")
+            new Argument<int>(sameName),
+            new Command("inner")
             {
-                new CliOption<int>(sameName)
+                new Option<int>(sameName)
             }
         };
 
@@ -220,15 +220,15 @@ public class GetValueByNameTests
     {
         const string sameName = "same";
 
-        CliCommand command = new("outer")
+        Command command = new("outer")
         {
-            new CliArgument<int>(sameName)
+            new Argument<int>(sameName)
             {
                 DefaultValueFactory = _ => 123
             },
-            new CliCommand("inner")
+            new Command("inner")
             {
-                new CliOption<int>(sameName)
+                new Option<int>(sameName)
                 {
                     DefaultValueFactory = _ => 456
                 }
@@ -245,9 +245,9 @@ public class GetValueByNameTests
     [Fact]
     public void T_can_be_cast_to_nullable_of_T()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliArgument<int>("name")
+            new Argument<int>("name")
         };
 
         ParseResult parseResult = command.Parse("123");
@@ -258,9 +258,9 @@ public class GetValueByNameTests
     [Fact]
     public void Array_of_T_can_be_cast_to_IEnumerable_of_T()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliArgument<int[]>("name")
+            new Argument<int[]>("name")
         };
 
         ParseResult parseResult = command.Parse("1 2 3");
@@ -273,9 +273,9 @@ public class GetValueByNameTests
     {
         const string Name = "name";
 
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliArgument<int>(Name)
+            new Argument<int>(Name)
         };
 
         ParseResult parseResult = command.Parse("123");
@@ -291,9 +291,9 @@ public class GetValueByNameTests
     [Fact]
     public void Parse_errors_have_precedence_over_type_mismatch()
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
-            new CliOption<int>("--required")
+            new Option<int>("--required")
             {
                 Required = true
             }
@@ -312,11 +312,11 @@ public class GetValueByNameTests
     [Fact]
     public void Recursive_option_on_parent_command_can_be_looked_up_when_subcommand_is_specified()
     {
-        var cmd = new CliRootCommand
+        var cmd = new RootCommand
         {
-            new CliCommand("subcommand"),
+            new Command("subcommand"),
 
-            new CliOption<string>("--opt")
+            new Option<string>("--opt")
             {
                 Recursive = true
             }

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -11,9 +11,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Global_options_appear_in_options_list_of_symbols_they_are_directly_added_to()
         {
-            var root = new CliCommand("parent");
+            var root = new Command("parent");
 
-            var option = new CliOption<int>("--global") { Recursive = true };
+            var option = new Option<int>("--global") { Recursive = true };
 
             root.Options.Add(option);
 
@@ -23,10 +23,10 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1540
         public void When_a_required_global_option_is_omitted_it_results_in_an_error()
         {
-            var command = new CliCommand("child");
-            var rootCommand = new CliRootCommand { command };
+            var command = new Command("child");
+            var rootCommand = new RootCommand { command };
             command.SetAction((_) => { });
-            var requiredOption = new CliOption<bool>("--i-must-be-set")
+            var requiredOption = new Option<bool>("--i-must-be-set")
             {
                 Required = true,
                 Recursive = true
@@ -44,8 +44,8 @@ namespace System.CommandLine.Tests
         [Fact] 
         public void When_a_required_global_option_has_multiple_aliases_the_error_message_uses_the_name()
         {
-            var rootCommand = new CliRootCommand();
-            var requiredOption = new CliOption<bool>("-i", "--i-must-be-set")
+            var rootCommand = new RootCommand();
+            var requiredOption = new Option<bool>("-i", "--i-must-be-set")
             {
                 Required = true,
                 Recursive = true
@@ -63,10 +63,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_required_global_option_is_present_on_child_of_command_it_was_added_to_it_does_not_result_in_an_error()
         {
-            var command = new CliCommand("child");
-            var rootCommand = new CliRootCommand { command };
+            var command = new Command("child");
+            var rootCommand = new RootCommand { command };
             command.SetAction((_) => { });
-            var requiredOption = new CliOption<bool>("--i-must-be-set")
+            var requiredOption = new Option<bool>("--i-must-be-set")
             {
                 Required = true,
                 Recursive = true
@@ -81,13 +81,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Subcommands_added_after_a_global_option_is_added_to_parent_will_recognize_the_global_option()
         {
-            var root = new CliCommand("parent");
+            var root = new Command("parent");
 
-            var option = new CliOption<int>("--global") { Recursive = true };
+            var option = new Option<int>("--global") { Recursive = true };
 
             root.Options.Add(option);
 
-            var child = new CliCommand("child");
+            var child = new Command("child");
 
             root.Subcommands.Add(child);
 
@@ -99,17 +99,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Subcommands_with_global_option_should_propagate_option_to_children()
         {
-            var root = new CliCommand("parent");
+            var root = new Command("parent");
             
-            var firstChild = new CliCommand("first");
+            var firstChild = new Command("first");
             
             root.Subcommands.Add(firstChild);
             
-            var option = new CliOption<int>("--global") { Recursive = true };
+            var option = new Option<int>("--global") { Recursive = true };
             
             firstChild.Options.Add(option);
             
-            var secondChild = new CliCommand("second");
+            var secondChild = new Command("second");
             
             firstChild.Subcommands.Add(secondChild);
             

--- a/src/System.CommandLine.Tests/Help/HelpBuilderExtensions.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderExtensions.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Tests.Help
     {
         public static void Write(
             this HelpBuilder builder,
-            CliCommand command,
+            Command command,
             TextWriter writer) =>
             builder.Write(new HelpContext(builder, command, writer));
     }

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
@@ -14,60 +14,60 @@ namespace System.CommandLine.Tests.Help
         [UseReporter(typeof(DiffReporter))]
         public void Help_layout_has_not_changed()
         {
-            var command = new CliCommand("the-root-command", "Test description")
+            var command = new Command("the-root-command", "Test description")
             {
-                new CliArgument<string>("the-root-arg-no-description-no-default"),
-                new CliArgument<string>("the-root-arg-no-description-default")
+                new Argument<string>("the-root-arg-no-description-no-default"),
+                new Argument<string>("the-root-arg-no-description-default")
                 {
                     DefaultValueFactory = (_) => "the-root-arg-no-description-default-value",
                 },
-                new CliArgument<string>("the-root-arg-no-default")
+                new Argument<string>("the-root-arg-no-default")
                 {
                     Description = "the-root-arg-no-default-description",
                 },
-                new CliArgument<string>("the-root-arg")
+                new Argument<string>("the-root-arg")
                 {
                     DefaultValueFactory = (_) => "the-root-arg-one-value",
                     Description = "the-root-arg-description"
                 },
-                new CliArgument<FileAccess>("the-root-arg-enum-default")
+                new Argument<FileAccess>("the-root-arg-enum-default")
                 {
                     DefaultValueFactory = (_) => FileAccess.Read,
                     Description = "the-root-arg-enum-default-description"
                 },
-                new CliOption<bool>("--the-root-option-no-arg", "-trna") 
+                new Option<bool>("--the-root-option-no-arg", "-trna") 
                 {
                     Description = "the-root-option-no-arg-description",
                     Required = true
                 },
-                new CliOption<string>("--the-root-option-no-description-default-arg", "-trondda")
+                new Option<string>("--the-root-option-no-description-default-arg", "-trondda")
                 {
                     DefaultValueFactory = (_) => "the-root-option--no-description-default-arg-value",
                 },
-                new CliOption<string>("--the-root-option-no-default-arg", "-tronda")
+                new Option<string>("--the-root-option-no-default-arg", "-tronda")
                 {
                     Description = "the-root-option-no-default-description",
                     HelpName = "the-root-option-arg-no-default-arg",
                     Required = true
                 },
-                new CliOption<string>("--the-root-option-default-arg", "-troda")
+                new Option<string>("--the-root-option-default-arg", "-troda")
                 {
                     DefaultValueFactory = (_) => "the-root-option-arg-value",
                     Description = "the-root-option-default-arg-description",
                     HelpName = "the-root-option-arg",
                 },
-                new CliOption<FileAccess>("--the-root-option-enum-arg", "-troea")
+                new Option<FileAccess>("--the-root-option-enum-arg", "-troea")
                 {
                     DefaultValueFactory = (_) => FileAccess.Read,
                     Description = "the-root-option-description",
                 },
-                new CliOption<FileAccess>("--the-root-option-required-enum-arg", "-trorea")
+                new Option<FileAccess>("--the-root-option-required-enum-arg", "-trorea")
                 {
                     DefaultValueFactory = (_) => FileAccess.Read,
                     Description = "the-root-option-description",
                     Required = true
                 },
-                new CliOption<bool>("--the-root-option-multi-line-description", "-tromld")
+                new Option<bool>("--the-root-option-multi-line-description", "-tromld")
                 {
                     Description = "the-root-option\r\nmulti-line\ndescription"
                 },

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
@@ -33,8 +33,8 @@ public partial class HelpBuilderTests
         [Fact]
         public void Option_can_customize_displayed_default_value()
         {
-            var option = new CliOption<string>("--the-option") { DefaultValueFactory = _ => "not 42" };
-            var command = new CliCommand("the-command", "command help")
+            var option = new Option<string>("--the-option") { DefaultValueFactory = _ => "not 42" };
+            var command = new Command("the-command", "command help")
             {
                 option
             };
@@ -52,8 +52,8 @@ public partial class HelpBuilderTests
         [Fact]
         public void Option_can_customize_first_column_text()
         {
-            var option = new CliOption<string>("--the-option") { Description = "option description" };
-            var command = new CliCommand("the-command", "command help")
+            var option = new Option<string>("--the-option") { Description = "option description" };
+            var command = new Command("the-command", "command help")
             {
                 option
             };
@@ -71,16 +71,16 @@ public partial class HelpBuilderTests
         [Fact]
         public void Option_can_customize_first_column_text_based_on_parse_result()
         {
-            var option = new CliOption<bool>("option");
-            var commandA = new CliCommand("a", "a command help")
+            var option = new Option<bool>("option");
+            var commandA = new Command("a", "a command help")
             {
                 option
             };
-            var commandB = new CliCommand("b", "b command help")
+            var commandB = new Command("b", "b command help")
             {
                 option
             };
-            var command = new CliCommand("root", "root command help")
+            var command = new Command("root", "root command help")
             {
                 commandA, commandB
             };
@@ -101,7 +101,7 @@ public partial class HelpBuilderTests
             });
 
             var console = new StringWriter();
-            var config = new CliConfiguration(command)
+            var config = new CommandLineConfiguration(command)
             {
                 Output = console
             };
@@ -117,16 +117,16 @@ public partial class HelpBuilderTests
         [Fact]
         public void Option_can_customize_second_column_text_based_on_parse_result()
         {
-            var option = new CliOption<bool>("option");
-            var commandA = new CliCommand("a", "a command help")
+            var option = new Option<bool>("option");
+            var commandA = new Command("a", "a command help")
             {
                 option
             };
-            var commandB = new CliCommand("b", "b command help")
+            var commandB = new Command("b", "b command help")
             {
                 option
             };
-            var command = new CliCommand("root", "root command help")
+            var command = new Command("root", "root command help")
             {
                 commandA, commandB
             };
@@ -146,7 +146,7 @@ public partial class HelpBuilderTests
                 }
             });
 
-            var config = new CliConfiguration(command)
+            var config = new CommandLineConfiguration(command)
             {
                 Output = new StringWriter()
             };
@@ -162,8 +162,8 @@ public partial class HelpBuilderTests
         [Fact]
         public void Subcommand_can_customize_first_column_text()
         {
-            var subcommand = new CliCommand("subcommand", "subcommand description");
-            var command = new CliCommand("the-command", "command help")
+            var subcommand = new Command("subcommand", "subcommand description");
+            var command = new Command("the-command", "command help")
             {
                 subcommand
             };
@@ -181,8 +181,8 @@ public partial class HelpBuilderTests
         [Fact]
         public void Command_arguments_can_customize_first_column_text()
         {
-            var argument = new CliArgument<string>("arg-name") { Description = "arg description" };
-            var command = new CliCommand("the-command", "command help")
+            var argument = new Argument<string>("arg-name") { Description = "arg description" };
+            var command = new Command("the-command", "command help")
             {
                 argument
             };
@@ -200,12 +200,12 @@ public partial class HelpBuilderTests
         [Fact]
         public void Command_arguments_can_customize_second_column_text()
         {
-            var argument = new CliArgument<string>("some-arg")
+            var argument = new Argument<string>("some-arg")
             {
                 Description = "Default description",
                 DefaultValueFactory = _ => "not 42"
             };
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
                 argument
             };
@@ -223,11 +223,11 @@ public partial class HelpBuilderTests
         [Fact]
         public void Command_arguments_can_customize_default_value()
         {
-            var argument = new CliArgument<string>("some-arg")
+            var argument = new Argument<string>("some-arg")
             {
                 DefaultValueFactory = (_) => "not 42"
             };
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
                 argument
             };
@@ -257,8 +257,8 @@ public partial class HelpBuilderTests
         [InlineData(true, true, "custom 1st\\s*custom 2nd")]
         public void Option_can_fallback_to_default_when_customizing(bool conditionA, bool conditionB, string expected)
         {
-            var command = new CliCommand("test");
-            var option = new CliOption<string>("--option") { Description = "description" };
+            var command = new Command("test");
+            var option = new Option<string>("--option") { Description = "description" };
 
             command.Options.Add(option);
 
@@ -275,7 +275,7 @@ public partial class HelpBuilderTests
                 }
             });
 
-            CliConfiguration config = new (command);
+            CommandLineConfiguration config = new (command);
             var console = new StringWriter();
             config.Output = console;
             command.Parse("test -h", config).Invoke();
@@ -297,8 +297,8 @@ public partial class HelpBuilderTests
             bool conditionC, 
             string expected)
         {
-            var command = new CliCommand("test");
-            var argument = new CliArgument<string>("arg")
+            var command = new Command("test");
+            var argument = new Argument<string>("arg")
             {
                 Description = "description",
                 DefaultValueFactory = _ => "default"
@@ -313,7 +313,7 @@ public partial class HelpBuilderTests
                                         defaultValue: ctx => conditionC ? "custom def" : HelpBuilder.Default.GetArgumentDefaultValue(argument));
 
 
-            CliConfiguration config = new (command);
+            CommandLineConfiguration config = new (command);
 
             command.Options.Add(new HelpOption
             {
@@ -332,18 +332,18 @@ public partial class HelpBuilderTests
         [Fact]
         public void Individual_symbols_can_be_customized()
         {
-            var subcommand = new CliCommand("subcommand", "The default command description");
-            var option = new CliOption<int>("-x") { Description = "The default option description" };
-            var argument = new CliArgument<int>("int-value") { Description = "The default argument description" };
+            var subcommand = new Command("subcommand", "The default command description");
+            var option = new Option<int>("-x") { Description = "The default option description" };
+            var argument = new Argument<int>("int-value") { Description = "The default argument description" };
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 subcommand,
                 option,
                 argument,
             };
 
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -370,7 +370,7 @@ public partial class HelpBuilderTests
         [Fact]
         public void Help_sections_can_be_replaced()
         {
-            CliConfiguration config = new(new CliRootCommand())
+            CommandLineConfiguration config = new(new RootCommand())
             {
                 Output = new StringWriter()
             };
@@ -397,7 +397,7 @@ public partial class HelpBuilderTests
         [Fact]
         public void Help_sections_can_be_supplemented()
         {
-            CliConfiguration config = new(new CliRootCommand("hello"))
+            CommandLineConfiguration config = new(new RootCommand("hello"))
             {
                 Output = new StringWriter(),
             };
@@ -436,9 +436,9 @@ public partial class HelpBuilderTests
         public void Layout_can_be_composed_dynamically_based_on_context()
         {
             HelpBuilder helpBuilder = new();
-            var commandWithTypicalHelp = new CliCommand("typical");
-            var commandWithCustomHelp = new CliCommand("custom");
-            var command = new CliRootCommand
+            var commandWithTypicalHelp = new Command("typical");
+            var commandWithCustomHelp = new Command("custom");
+            var command = new RootCommand
             {
                 commandWithTypicalHelp,
                 commandWithCustomHelp
@@ -449,7 +449,7 @@ public partial class HelpBuilderTests
                 Builder = helpBuilder
             };
 
-            var config = new CliConfiguration(command);
+            var config = new CommandLineConfiguration(command);
             helpBuilder.CustomizeLayout(c =>
                                             c.Command == commandWithTypicalHelp
                                                 ? HelpBuilder.Default.GetLayout()
@@ -471,9 +471,9 @@ public partial class HelpBuilderTests
         [Fact]
         public void Help_default_sections_can_be_wrapped()
         {
-            CliCommand command = new("test")
+            Command command = new("test")
             {
-                new CliOption<string>("--option")
+                new Option<string>("--option")
                 {
                     Description = "option description",
                     HelpName = "option"
@@ -487,7 +487,7 @@ public partial class HelpBuilderTests
                 }
             };
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter()
             };
@@ -509,7 +509,7 @@ public partial class HelpBuilderTests
         [Fact]
         public void Help_customized_sections_can_be_wrapped()
         {
-            CliConfiguration config = new(new CliRootCommand())
+            CommandLineConfiguration config = new(new RootCommand())
             {
                 Output = new StringWriter()
             };
@@ -533,7 +533,7 @@ public partial class HelpBuilderTests
             }
         }
 
-        private string GetDefaultHelp(CliCommand command, bool trimOneNewline = true)
+        private string GetDefaultHelp(Command command, bool trimOneNewline = true)
         {
             // The command might have already defined a HelpOption with custom settings,
             // we need to overwrite it to get the actual defaults.
@@ -549,7 +549,7 @@ public partial class HelpBuilderTests
                 command.Options.Add(defaultHelp);
             }
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter()
             };

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -30,7 +30,7 @@ namespace System.CommandLine.Tests.Help
             _helpBuilder = GetHelpBuilder(LargeMaxWidth);
             _columnPadding = new string(' ', ColumnGutterWidth);
             _indentation = new string(' ', IndentationWidth);
-            _executableName = CliRootCommand.ExecutableName;
+            _executableName = RootCommand.ExecutableName;
         }
 
         private HelpBuilder GetHelpBuilder(int maxWidth = SmallMaxWidth) => new(maxWidth);
@@ -40,7 +40,7 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Synopsis_section_keeps_added_newlines()
         {
-            var command = new CliRootCommand(
+            var command = new RootCommand(
                 $"test{NewLine}\r\ndescription with\nline breaks");
 
             _helpBuilder.Write(command, _console);
@@ -62,7 +62,7 @@ namespace System.CommandLine.Tests.Help
                 "description with some tabs that is long enough to wrap to a\t" +
                 "new line";
 
-            var command = new CliRootCommand(description: longSynopsisText);
+            var command = new RootCommand(description: longSynopsisText);
 
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
             helpBuilder.Write(command, _console);
@@ -77,7 +77,7 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Command_name_in_synopsis_can_be_specified()
         {
-            var command = new CliCommand("custom-name");
+            var command = new Command("custom-name");
 
             var helpBuilder = GetHelpBuilder(SmallMaxWidth);
             helpBuilder.Write(command, _console);
@@ -101,19 +101,19 @@ namespace System.CommandLine.Tests.Help
             int maxArity,
             string expectedArgsUsage)
         {
-            var argument = new CliArgument<string>("the-args")
+            var argument = new Argument<string>("the-args")
             {
                 Arity = new ArgumentArity(minArity, maxArity)
             };
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
                 argument,
-                new CliOption<string>("--verbosity", "-v")
+                new Option<string>("--verbosity", "-v")
                 {
                     Description = "Sets the verbosity"
                 }
             };
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
             rootCommand.Subcommands.Add(command);
 
             new HelpBuilder(LargeMaxWidth).Write(command, _console);
@@ -136,26 +136,26 @@ namespace System.CommandLine.Tests.Help
             int maxArityForArg2,
             string expectedArgsUsage)
         {
-            var arg1 = new CliArgument<string>("arg1")
+            var arg1 = new Argument<string>("arg1")
             {
                 Arity = new ArgumentArity(
                     minArityForArg1,
                     maxArityForArg1)
             };
-            var arg2 = new CliArgument<string>("arg2")
+            var arg2 = new Argument<string>("arg2")
             {
                 Arity = new ArgumentArity(
                     minArityForArg2,
                     maxArityForArg2)
             };
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
                 arg1,
                 arg2,
-                new CliOption<string>("--verbosity", "-v") { Description = "Sets the verbosity" }
+                new Option<string>("--verbosity", "-v") { Description = "Sets the verbosity" }
             };
 
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
             rootCommand.Subcommands.Add(command);
 
             _helpBuilder.Write(command, _console);
@@ -170,13 +170,13 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_for_subcommand_shows_names_of_parent_commands()
         {
-            var outer = new CliCommand("outer", "the outer command");
-            var inner = new CliCommand("inner", "the inner command");
+            var outer = new Command("outer", "the outer command");
+            var inner = new Command("inner", "the inner command");
             outer.Subcommands.Add(inner);
-            var innerEr = new CliCommand("inner-er", "the inner-er command");
+            var innerEr = new Command("inner-er", "the inner-er command");
             inner.Subcommands.Add(innerEr);
-            innerEr.Options.Add(new CliOption<string>("--some-option") { Description = "some option" });
-            var rootCommand = new CliRootCommand();
+            innerEr.Options.Add(new Option<string>("--some-option") { Description = "some option" });
+            var rootCommand = new RootCommand();
             rootCommand.Add(outer);
 
             _helpBuilder.Write(innerEr, _console);
@@ -191,15 +191,15 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_for_subcommand_shows_arguments_for_subcommand_and_parent_command()
         {
-            var inner = new CliCommand("inner", "command help")
+            var inner = new Command("inner", "command help")
             {
-                new CliOption<string>("-v") {Description = "Sets the verbosity" },
-                new CliArgument<string[]>("inner-args")
+                new Option<string>("-v") {Description = "Sets the verbosity" },
+                new Argument<string[]>("inner-args")
             };
-            _ = new CliCommand("outer", "command help")
+            _ = new Command("outer", "command help")
             {
                 inner,
-                new CliArgument<string[]>("outer-args")
+                new Argument<string[]>("outer-args")
             };
 
             _helpBuilder.Write(inner, _console);
@@ -214,11 +214,11 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_does_not_show_additional_arguments_when_TreatUnmatchedTokensAsErrors_is_not_specified()
         {
-            var command = new CliCommand(
+            var command = new Command(
                 "some-command",
                 "Does something");
             command.Options.Add(
-                new CliOption<string>("-x") { Description = "Indicates whether x" });
+                new Option<string>("-x") { Description = "Indicates whether x" });
 
             _helpBuilder.Write(command, _console);
 
@@ -228,10 +228,10 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_does_not_show_additional_arguments_when_TreatUnmatchedTokensAsErrors_is_true()
         {
-            var command = new CliRootCommand();
-            var subcommand = new CliCommand("some-command", "Does something");
+            var command = new RootCommand();
+            var subcommand = new Command("some-command", "Does something");
             command.Subcommands.Add(subcommand);
-            subcommand.Options.Add(new CliOption<string>("-x") { Description = "Indicates whether x" });
+            subcommand.Options.Add(new Option<string>("-x") { Description = "Indicates whether x" });
             subcommand.TreatUnmatchedTokensAsErrors = true;
 
             _helpBuilder.Write(subcommand, _console);
@@ -242,10 +242,10 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_shows_additional_arguments_when_TreatUnmatchedTokensAsErrors_is_false()
         {
-            var command = new CliRootCommand();
-            var subcommand = new CliCommand("some-command", "Does something");
+            var command = new RootCommand();
+            var subcommand = new Command("some-command", "Does something");
             command.Subcommands.Add(subcommand);
-            subcommand.Options.Add(new CliOption<string>("-x") { Description = "Indicates whether x" });
+            subcommand.Options.Add(new Option<string>("-x") { Description = "Indicates whether x" });
             subcommand.TreatUnmatchedTokensAsErrors = false;
 
             _helpBuilder.Write(subcommand, _console);
@@ -256,12 +256,12 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Usage_section_keeps_added_newlines()
         {
-            var outer = new CliCommand("outer-command", "command help")
+            var outer = new Command("outer-command", "command help")
             {
-                new CliArgument<string[]>($"outer args {NewLine}\r\nwith new\nlines"),
-                new CliCommand("inner-command", "command help")
+                new Argument<string[]>($"outer args {NewLine}\r\nwith new\nlines"),
+                new Command("inner-command", "command help")
                 {
-                    new CliArgument<string>("inner-args")
+                    new Argument<string>("inner-args")
                 }
             };
 
@@ -282,18 +282,18 @@ namespace System.CommandLine.Tests.Help
         {
             var helpBuilder = GetHelpBuilder(SmallMaxWidth);
 
-            var outerCommand = new CliCommand("outer-command", "command help")
+            var outerCommand = new Command("outer-command", "command help")
             {
-                new CliArgument<string[]>("outer args long enough to wrap to a new line"),
-                new CliCommand("inner-command", "command help")
+                new Argument<string[]>("outer args long enough to wrap to a new line"),
+                new Command("inner-command", "command help")
                 {
-                    new CliArgument<string[]>("inner-args")
+                    new Argument<string[]>("inner-args")
                 }
             };
             //NB: Using Command with a fixed name, rather than RootCommand here
             //because RootCommand.ExecutableName returns different values when
             //run under net5 vs net462
-            _ = new CliCommand("System.CommandLine")
+            _ = new Command("System.CommandLine")
             {
                 outerCommand
             };
@@ -313,12 +313,12 @@ namespace System.CommandLine.Tests.Help
         {
             var commandName = "the-command";
             var visibleArgName = "visible";
-            var command = new CliCommand(commandName, "Does things");
-            var hiddenArg = new CliArgument<int>("hidden")
+            var command = new Command(commandName, "Does things");
+            var hiddenArg = new Argument<int>("hidden")
             {
                 Hidden = true
             };
-            var visibleArg = new CliArgument<int>(visibleArgName)
+            var visibleArg = new Argument<int>(visibleArgName)
             {
                 Hidden = false
             };
@@ -343,7 +343,7 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_is_not_included_if_there_are_no_commands_configured()
         {
-            _helpBuilder.Write(new CliRootCommand(), _console);
+            _helpBuilder.Write(new RootCommand(), _console);
 
             _console.ToString().Should().NotContain("Arguments:");
         }
@@ -351,7 +351,7 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_is_not_included_if_there_are_commands_but_no_arguments_configured()
         {
-            var command = new CliCommand("the-command", "command help");
+            var command = new Command("the-command", "command help");
 
             _helpBuilder.Write(command, _console);
             _console.ToString().Should().NotContain("Arguments:");
@@ -363,9 +363,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_is_included_if_there_are_commands_with_arguments_configured()
         {
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
-                new CliArgument<string>("arg command name")
+                new Argument<string>("arg command name")
                 {
                     Description = "test"
                 }
@@ -379,9 +379,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_is_not_included_if_there_are_options_with_no_arguments_configured()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<string>("--verbosity", "-v") { Description = "Sets the verbosity." }
+                new Option<string>("--verbosity", "-v") { Description = "Sets the verbosity." }
             };
 
             _helpBuilder.Write(command, _console);
@@ -392,9 +392,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_is_not_included_if_there_are_only_options_with_arguments_configured()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliOption<string>("-v")
+                new Option<string>("-v")
                 {
                     Description = "Sets the verbosity.",
                     HelpName = "argument for options"
@@ -409,9 +409,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_includes_configured_argument_aliases()
         {
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
-                new CliOption<string>("--verbosity", "-v")
+                new Option<string>("--verbosity", "-v")
                 {
                     HelpName = "LEVEL",
                     Description = "Sets the verbosity."
@@ -436,9 +436,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_uses_name_over_suggestions_if_specified()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<VerbosityOptions>("--verbosity", "-v")
+                new Option<VerbosityOptions>("--verbosity", "-v")
                 {
                     HelpName = "LEVEL"
                 }
@@ -453,9 +453,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_uses_description_if_provided()
         {
-            var command = new CliCommand("the-command", "Help text from description")
+            var command = new Command("the-command", "Help text from description")
             {
-                new CliArgument<string>("the-arg")
+                new Argument<string>("the-arg")
                 {
                     Description = "Help text from HelpDetail"
                 }
@@ -473,17 +473,17 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_does_not_contain_hidden_argument()
         {
-            var command = new CliCommand("the-command");
+            var command = new Command("the-command");
             var hiddenArgName = "the-hidden";
             var hiddenDesc = "the hidden desc";
             var visibleArgName = "the-visible";
             var visibleDesc = "the visible desc";
-            var hiddenArg = new CliArgument<int>(hiddenArgName)
+            var hiddenArg = new Argument<int>(hiddenArgName)
             {
                 Description = hiddenDesc,
                 Hidden = true
             };
-            var visibleArg = new CliArgument<int>(visibleArgName)
+            var visibleArg = new Argument<int>(visibleArgName)
             {
                 Description = visibleDesc,
                 Hidden = false
@@ -506,15 +506,15 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_does_not_repeat_arguments_that_appear_on_parent_command()
         {
-            var reused = new CliArgument<string>("reused")
+            var reused = new Argument<string>("reused")
             {
                 Description = "This argument is valid on both outer and inner commands"
             };
-            var inner = new CliCommand("inner", "The inner command")
+            var inner = new Command("inner", "The inner command")
             {
                 reused
             };
-            _ = new CliCommand("outer")
+            _ = new Command("outer")
             {
                 reused,
                 inner
@@ -531,16 +531,16 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_aligns_arguments_on_new_lines()
         {
-            var inner = new CliCommand("inner", "HelpDetail text for the inner command")
+            var inner = new Command("inner", "HelpDetail text for the inner command")
             {
-                new CliArgument<string>("the-inner-command-arg")
+                new Argument<string>("the-inner-command-arg")
                 {
                     Description = "The argument for the inner command",
                 }
             };
-            _ = new CliCommand("outer", "HelpDetail text for the outer command")
+            _ = new Command("outer", "HelpDetail text for the outer command")
             {
-                new CliArgument<string>("outer-command-arg")
+                new Argument<string>("outer-command-arg")
                 {
                     Description = "The argument for the outer command"
                 },
@@ -560,9 +560,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_keeps_added_newlines()
         {
-            var command = new CliCommand("outer", "Help text for the outer command")
+            var command = new Command("outer", "Help text for the outer command")
             {
-                new CliArgument<string>("outer-command-arg")
+                new Argument<string>("outer-command-arg")
                 {
                     Description = $"The argument\r\nfor the\ninner command"
                 }
@@ -582,9 +582,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Arguments_section_keeps_added_newlines_when_width_is_very_small()
         {
-            var command = new CliCommand("outer", "Help text for the outer command")
+            var command = new Command("outer", "Help text for the outer command")
             {
-                new CliArgument<string>("outer-command-arg")
+                new Argument<string>("outer-command-arg")
                 {
                     Description = $"The argument\r\nfor the\ninner command",
                 }
@@ -613,9 +613,9 @@ namespace System.CommandLine.Tests.Help
                 $"for inner command with some tabs that is long enough to wrap to a\t" +
                 $"new line";
 
-            var command = new CliCommand("outer", "Help text for the outer command")
+            var command = new Command("outer", "Help text for the outer command")
             {
-                new CliArgument<string>("outer-command-arg")
+                new Argument<string>("outer-command-arg")
                 {
                     Description = longCmdText
                 }
@@ -639,9 +639,9 @@ namespace System.CommandLine.Tests.Help
             var name = "argument-name-for-a-command-that-is-long-enough-to-wrap-to-a-new-line";
             var description = "Argument description for a command with line breaks that is long enough to wrap to a new line.";
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliArgument<string>(name)
+                new Argument<string>(name)
                 {
                     Description = description
                 }
@@ -667,12 +667,12 @@ namespace System.CommandLine.Tests.Help
         {
             var description = "This is the argument description";
 
-            CliArgument argument = nullable
-                               ? new CliArgument<FileAccess?>("arg")
-                               : new CliArgument<FileAccess>("arg");
+            Argument argument = nullable
+                               ? new Argument<FileAccess?>("arg")
+                               : new Argument<FileAccess>("arg");
             argument.Description = description;
 
-            var command = new CliCommand("outer", "Help text for the outer command")
+            var command = new Command("outer", "Help text for the outer command")
             {
                 argument
             };
@@ -695,11 +695,11 @@ namespace System.CommandLine.Tests.Help
         {
             var description = "This is the option description";
 
-            CliOption option = nullable
-                                ? new CliOption<bool?>("--opt") { Description = description }
-                                : new CliOption<bool>("--opt") { Description = description };
+            Option option = nullable
+                                ? new Option<bool?>("--opt") { Description = description }
+                                : new Option<bool>("--opt") { Description = description };
 
-            var command = new CliCommand(
+            var command = new Command(
                 "outer", "Help text for the outer command")
             {
                 option
@@ -715,10 +715,10 @@ namespace System.CommandLine.Tests.Help
         [Fact] // https://github.com/dotnet/command-line-api/issues/1157
         public void Command_arguments_show_argument_name_in_first_column()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliArgument<bool>("boolArgument") { Description = "Some value" },
-                new CliArgument<int>("intArgument") { Description = "Another value" },
+                new Argument<bool>("boolArgument") { Description = "Some value" },
+                new Argument<int>("intArgument") { Description = "Another value" },
             };
             
             var helpBuilder = GetHelpBuilder(SmallMaxWidth);
@@ -740,11 +740,11 @@ namespace System.CommandLine.Tests.Help
         {
             var description = "This is the argument description";
 
-            CliOption option = nullable
-                                ? new CliOption<FileAccess?>("--opt") { Description = description }
-                                : new CliOption<FileAccess>("--opt") { Description = description };
+            Option option = nullable
+                                ? new Option<FileAccess?>("--opt") { Description = description }
+                                : new Option<FileAccess>("--opt") { Description = description };
 
-            var command = new CliCommand(
+            var command = new Command(
                 "outer", "Help text for the outer command")
             {
                 option
@@ -760,13 +760,13 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Help_describes_default_value_for_argument()
         {
-            var argument = new CliArgument<string>("the-arg")
+            var argument = new Argument<string>("the-arg")
             {
                 Description = "Help text from HelpDetail",
                 DefaultValueFactory = (_) => "the-arg-value"
             };
 
-            var command = new CliCommand("the-command",
+            var command = new Command("the-command",
                 "Help text from description") { argument };
 
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
@@ -781,13 +781,13 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Help_does_not_show_default_value_for_argument_when_default_value_is_empty()
         {
-            var argument = new CliArgument<string>("the-arg")
+            var argument = new Argument<string>("the-arg")
             { 
                 Description = "The argument description",
                 DefaultValueFactory = (_) => ""
             };
             
-            var command = new CliCommand("the-command", "The command description")
+            var command = new Command("the-command", "The command description")
             {
                 argument
             };
@@ -804,13 +804,13 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Help_does_not_show_default_value_for_option_when_default_value_is_empty()
         {
-            var option = new CliOption<string>("-x")
+            var option = new Option<string>("-x")
             {
                 Description = "The option description",
                 DefaultValueFactory = (_) => "",
             };
 
-            var command = new CliCommand("the-command", "The command description")
+            var command = new Command("the-command", "The command description")
             {
                 option
             };
@@ -827,15 +827,15 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Command_arguments_default_value_provided()
         {
-            var argument = new CliArgument<string>("the-arg")
+            var argument = new Argument<string>("the-arg")
             {
                 DefaultValueFactory = (_) => "the-arg-value",
             };
-            var otherArgument = new CliArgument<string>("the-other-arg")
+            var otherArgument = new Argument<string>("the-other-arg")
             {
                 DefaultValueFactory = (_) => "the-other-arg-value"
             };
-            var command = new CliCommand("the-command",
+            var command = new Command("the-command",
                 "Help text from description")
             {
                 argument,
@@ -859,9 +859,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Command_arguments_with_default_values_that_are_enumerable_display_pipe_delimited_list()
         {
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
-                new CliArgument<List<int>>("filter-size")
+                new Argument<List<int>>("filter-size")
                 {
                     DefaultValueFactory = (_) => new List<int>() { 0, 2, 4 }
                 }   
@@ -878,21 +878,21 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Command_shared_arguments_with_one_or_more_arity_are_displayed_as_being_required()
         {
-            var arg = new CliArgument<string[]>("shared-args")
+            var arg = new Argument<string[]>("shared-args")
             {
                 Arity = ArgumentArity.OneOrMore
             };
 
-            var inner = new CliCommand("inner", "command help")
+            var inner = new Command("inner", "command help")
             {
                 arg
             };
-            _ = new CliCommand("outer", "command help")
+            _ = new Command("outer", "command help")
             {
                 inner,
                 arg
             };
-            _ = new CliCommand("unused", "command help")
+            _ = new Command("unused", "command help")
             {
                 arg
             };
@@ -913,9 +913,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_section_is_not_included_if_no_options_configured()
         {
-            var commandLineBuilder = new CliCommand("noOptions")
+            var commandLineBuilder = new Command("noOptions")
             {
-                new CliCommand("outer", "description for outer")
+                new Command("outer", "description for outer")
             };
 
             _helpBuilder.Write(commandLineBuilder, _console);
@@ -926,8 +926,8 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_section_is_not_included_if_only_subcommands_configured()
         {
-            var command = new CliCommand("outer", "description for outer");
-            command.Subcommands.Add(new CliCommand("inner"));
+            var command = new Command("outer", "description for outer");
+            command.Subcommands.Add(new Command("inner"));
 
             _helpBuilder.Write(command, _console);
 
@@ -937,10 +937,10 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_section_includes_option_with_empty_description()
         {
-            var command = new CliCommand("the-command", "Does things.")
+            var command = new Command("the-command", "Does things.")
                           {
-                              new CliOption<string>("-x"),
-                              new CliOption<string>("-n"),
+                              new Option<string>("-x"),
+                              new Option<string>("-n"),
                               new HelpOption()
                           };
 
@@ -954,13 +954,13 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_section_does_not_contain_option_with_HelpDefinition_that_IsHidden()
         {
-            var command = new CliCommand("the-command");
-            command.Options.Add(new CliOption<string>("-x")
+            var command = new Command("the-command");
+            command.Options.Add(new Option<string>("-x")
             {
                 Description = "Is Hidden",
                 Hidden = true
             });
-            command.Options.Add(new CliOption<string>("-n")
+            command.Options.Add(new Option<string>("-n")
             {
                 Description = "Not Hidden",
                 Hidden = false
@@ -979,13 +979,13 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_section_aligns_options_on_new_lines()
         {
-            var command = new CliCommand("the-command", "Help text for the command")
+            var command = new Command("the-command", "Help text for the command")
             {
-                new CliOption<string>("--aaa", "-a")
+                new Option<string>("--aaa", "-a")
                 {
                     Description = "An option with 8 characters",
                 },
-                new CliOption<string>("--bbbbbbbbbb","-b")
+                new Option<string>("--bbbbbbbbbb","-b")
                 {
                     Description = "An option with 15 characters"
                 }
@@ -1007,9 +1007,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Retains_single_dash_on_multi_char_option()
         {
-            var command = new CliCommand("command", "Help Test")
+            var command = new Command("command", "Help Test")
             {
-                new CliOption<string>("-multi", "--alt-option") { Description = "HelpDetail for option" }
+                new Option<string>("-multi", "--alt-option") { Description = "HelpDetail for option" }
             };
 
             _helpBuilder.Write(command, _console);
@@ -1022,9 +1022,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_section_retains_multiple_dashes_on_single_char_option()
         {
-            var command = new CliCommand("command", "Help Test")
+            var command = new Command("command", "Help Test")
             {
-                new CliOption<string>("--m", "--alt-option") { Description = "HelpDetail for option" }
+                new Option<string>("--m", "--alt-option") { Description = "HelpDetail for option" }
             };
 
             _helpBuilder.Write(command, _console);
@@ -1036,11 +1036,11 @@ namespace System.CommandLine.Tests.Help
         public void Options_section_keeps_added_newlines()
         {
             var command =
-                new CliCommand(
+                new Command(
                     "test-command",
                     "Help text for the command")
                 {
-                    new CliOption<bool>("--aaa", "-a")
+                    new Option<bool>("--aaa", "-a")
                     {
                         Description = $"Help{NewLine}for \r\n the\noption"
                     }
@@ -1064,11 +1064,11 @@ namespace System.CommandLine.Tests.Help
             var longOptionText =
                 "The option whose description is long enough that it wraps to a new line";
 
-            var command = new CliCommand("test-command", "Help text for the command")
+            var command = new Command("test-command", "Help text for the command")
             {
-                new CliOption<string>("-x") { Description = "Option with a short description" },
-                new CliOption<bool>("--aaa", "-a") { Description = longOptionText },
-                new CliOption<string>("-y") { Description = "Option with a short description" },
+                new Option<string>("-x") { Description = "Option with a short description" },
+                new Option<bool>("--aaa", "-a") { Description = longOptionText },
+                new Option<string>("-y") { Description = "Option with a short description" },
             };
 
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
@@ -1089,15 +1089,15 @@ namespace System.CommandLine.Tests.Help
             var longOptionText =
                 "The option whose description is long enough that it wraps to a new line";
 
-            var command = new CliCommand("test-command", "Help text for the command")
+            var command = new Command("test-command", "Help text for the command")
             {
-                new CliOption<string>("-x") { Description = "Option with a short description" },
-                new CliOption<string>("--aaa", "-a")
+                new Option<string>("-x") { Description = "Option with a short description" },
+                new Option<string>("--aaa", "-a")
                 {
                     Description = longOptionText,
                     DefaultValueFactory = (_) => "the quick brown fox jumps over the lazy dog"
                 },
-                new CliOption<string>("-y") { Description = "Option with a short description" },
+                new Option<string>("-y") { Description = "Option with a short description" },
             };
 
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
@@ -1117,9 +1117,9 @@ namespace System.CommandLine.Tests.Help
             var alias = "--option-alias-for-a-command-that-is-long-enough-to-wrap-to-a-new-line";
             var description = "Option description that is long enough to wrap.";
 
-            var command = new CliCommand("test")
+            var command = new Command("test")
             {
-                new CliOption<bool>(alias) { Description = description }
+                new Option<bool>(alias) { Description = description }
             };
 
             HelpBuilder helpBuilder = GetHelpBuilder(SmallMaxWidth);
@@ -1137,9 +1137,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Required_options_are_indicated()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<bool>("--required")
+                new Option<bool>("--required")
                 {
                     Required = true
                 }
@@ -1156,9 +1156,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Required_options_are_indicated_when_argument_is_named()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<string>("--required", "-r")
+                new Option<string>("--required", "-r")
                 {
                     Required = true,
                     HelpName = "ARG"
@@ -1176,7 +1176,7 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Help_option_is_shown_in_help()
         {
-            var configuration = new CliConfiguration(new CliRootCommand());
+            var configuration = new CommandLineConfiguration(new RootCommand());
 
             _helpBuilder.Write(configuration.RootCommand, _console);
 
@@ -1190,9 +1190,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_aliases_differing_only_by_prefix_are_deduplicated_favoring_dashed_prefixes()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<string>("-x", "/x")
+                new Option<string>("-x", "/x")
             };
 
             _helpBuilder.Write(command, _console);
@@ -1205,9 +1205,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_aliases_differing_only_by_prefix_are_deduplicated_favoring_double_dashed_prefixes()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<string>("--long", "/long")
+                new Option<string>("--long", "/long")
             };
 
             _helpBuilder.Write(command, _console);
@@ -1220,12 +1220,12 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Options_help_preserves_the_order_options_are_added_the_the_parent_command()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<bool>("--first", "-f"),
-                new CliOption<bool>("--second", "-s"),
-                new CliOption<bool>("--third"),
-                new CliOption<bool>("--last", "-l")
+                new Option<bool>("--first", "-f"),
+                new Option<bool>("--second", "-s"),
+                new Option<bool>("--third"),
+                new Option<bool>("--last", "-l")
             };
 
             _helpBuilder.Write(command, _console);
@@ -1244,9 +1244,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Option_aliases_are_shown_before_long_names_regardless_of_alphabetical_order()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<string>("-z", "-a", "--zzz", "--aaa")
+                new Option<string>("-z", "-a", "--zzz", "--aaa")
             };
 
             _helpBuilder.Write(command, _console);
@@ -1257,9 +1257,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Help_describes_default_value_for_option_with_argument_having_default_value()
         {
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
-                new CliOption<string>("-arg")
+                new Option<string>("-arg")
                 {
                     DefaultValueFactory = (_) => "the-arg-value",
                     HelpName = "the-arg"
@@ -1278,9 +1278,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Option_arguments_with_default_values_that_are_enumerable_display_pipe_delimited_list()
         {
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
-                new CliOption<List<int>>("--filter-size")
+                new Option<List<int>>("--filter-size")
                 {
                     DefaultValueFactory = (_) => new List<int> { 0, 2, 4 }
                 }
@@ -1297,9 +1297,9 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Option_arguments_with_default_values_that_are_array_display_pipe_delimited_list()
         {
-            var command = new CliCommand("the-command", "command help")
+            var command = new Command("the-command", "command help")
             {
-                new CliOption<string[]>("--prefixes")
+                new Option<string[]>("--prefixes")
                 {
                     DefaultValueFactory = (_) => new[]{ "^(TODO|BUG)", "^HACK" }
                 }
@@ -1322,17 +1322,17 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Subcommand_help_does_not_include_names_of_sibling_commands()
         {
-            var inner = new CliCommand("inner", "inner description")
+            var inner = new Command("inner", "inner description")
             {
-                new CliCommand("inner-er", "inner-er description")
+                new Command("inner-er", "inner-er description")
                 {
-                    new CliOption<string>("some-option") { Description = "some-option description" }
+                    new Option<string>("some-option") { Description = "some-option description" }
                 }
             };
 
-            var sibling = new CliCommand("sibling", "sibling description");
+            var sibling = new Command("sibling", "sibling description");
 
-            var outer = new CliCommand("outer", "outer description")
+            var outer = new Command("outer", "outer description")
             {
                 sibling,
                 inner
@@ -1346,12 +1346,12 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Subcommands_keep_added_newlines()
         {
-            var command = new CliCommand("outer", "outer command help")
+            var command = new Command("outer", "outer command help")
             {
-                new CliArgument<string>("outer-args"),
-                new CliCommand("inner", $"inner{NewLine}command help \r\n with \nnewlines")
+                new Argument<string>("outer-args"),
+                new Command("inner", $"inner{NewLine}command help \r\n with \nnewlines")
                 {
-                    new CliArgument<string>("inner-args")
+                    new Argument<string>("inner-args")
                 }
             };
 
@@ -1377,13 +1377,13 @@ namespace System.CommandLine.Tests.Help
 
             var helpBuilder = GetHelpBuilder(SmallMaxWidth);
 
-            var command = new CliCommand("outer-command", "outer command help")
+            var command = new Command("outer-command", "outer command help")
             {
-                new CliArgument<string[]>("outer-args"),
-                new CliCommand("inner-command", longSubcommandDescription)
+                new Argument<string[]>("outer-args"),
+                new Command("inner-command", longSubcommandDescription)
                 {
-                    new CliArgument<string[]>("inner-args"),
-                    new CliOption<string>("--verbosity", "-v")
+                    new Argument<string[]>("inner-args"),
+                    new Option<string>("--verbosity", "-v")
                 }
             };
 
@@ -1403,9 +1403,9 @@ namespace System.CommandLine.Tests.Help
             var name = "subcommand-name-that-is-long-enough-to-wrap-to-a-new-line";
             var description = "Subcommand description that is really long. So long that it caused the line to wrap.";
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliCommand(name, description)
+                new Command(name, description)
             };
 
             var helpBuilder = GetHelpBuilder(SmallMaxWidth);
@@ -1423,8 +1423,8 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Subcommand_help_contains_command_with_empty_description()
         {
-            var command = new CliCommand("the-command", "Does things.");
-            var subCommand = new CliCommand("the-subcommand", description: null);
+            var command = new Command("the-command", "Does things.");
+            var subCommand = new Command("the-subcommand", description: null);
             command.Subcommands.Add(subCommand);
 
             _helpBuilder.Write(command, _console);
@@ -1436,12 +1436,12 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Subcommand_help_does_not_contain_hidden_command()
         {
-            var command = new CliCommand("the-command", "Does things.");
-            var hiddenSubCommand = new CliCommand("the-hidden")
+            var command = new Command("the-command", "Does things.");
+            var hiddenSubCommand = new Command("the-hidden")
             {
                 Hidden = true
             };
-            var visibleSubCommand = new CliCommand("the-visible")
+            var visibleSubCommand = new Command("the-visible")
             {
                 Hidden = false
             };
@@ -1458,13 +1458,13 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Subcommand_help_does_not_contain_hidden_argument()
         {
-            var command = new CliCommand("the-command", "Does things.");
-            var subCommand = new CliCommand("the-subcommand");
-            var hidden = new CliArgument<int>("the-hidden")
+            var command = new Command("the-command", "Does things.");
+            var subCommand = new Command("the-subcommand");
+            var hidden = new Argument<int>("the-hidden")
             {
                 Hidden = true
             };
-            var visible = new CliArgument<int>("the-visible")
+            var visible = new Argument<int>("the-visible")
             {
                 Hidden = false
             };
@@ -1486,22 +1486,22 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Help_describes_default_value_for_subcommand_with_arguments_and_only_defaultable_is_shown()
         {
-            var argument = new CliArgument<string>("the-arg");
-            var otherArgumentHidden = new CliArgument<string>("the-other-hidden-arg")
+            var argument = new Argument<string>("the-arg");
+            var otherArgumentHidden = new Argument<string>("the-other-hidden-arg")
             {
                 Hidden = true
             };
             argument.DefaultValueFactory = _  => "the-arg-value";
             otherArgumentHidden.DefaultValueFactory = _ => "the-other-hidden-arg-value";
 
-            var command = new CliCommand("outer", "outer command help")
+            var command = new Command("outer", "outer command help")
                 {
-                    new CliArgument<string>("outer-args"),
-                    new CliCommand("inner", $"inner command help")
+                    new Argument<string>("outer-args"),
+                    new Command("inner", $"inner command help")
                     {
                         argument,
                         otherArgumentHidden,
-                        new CliArgument<string>("inner-other-arg-no-default")
+                        new Argument<string>("inner-other-arg-no-default")
                     }
                 };
 
@@ -1517,19 +1517,19 @@ namespace System.CommandLine.Tests.Help
         [Fact]
         public void Help_describes_default_values_for_subcommand_with_multiple_defaultable_arguments()
         {
-            var argument = new CliArgument<string>("the-arg")
+            var argument = new Argument<string>("the-arg")
             {
                 DefaultValueFactory = (_) => "the-arg-value"
             };
-            var otherArgument = new CliArgument<string>("the-other-arg")
+            var otherArgument = new Argument<string>("the-other-arg")
             {
                 DefaultValueFactory = (_) => "the-other-arg-value"
             };
 
-            var command = new CliCommand("outer", "outer command help")
+            var command = new Command("outer", "outer command help")
                 {
-                    new CliArgument<string>("outer-args"),
-                    new CliCommand("inner", "inner command help")
+                    new Argument<string>("outer-args"),
+                    new Command("inner", "inner command help")
                     {
                         argument, otherArgument
                     }
@@ -1557,9 +1557,9 @@ namespace System.CommandLine.Tests.Help
         [Fact] // https://github.com/dotnet/command-line-api/issues/1506
         public void Commands_without_arguments_do_not_produce_extra_newlines_between_usage_and_options_sections()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<string>("-x") { Description = "the-option-description" }
+                new Option<string>("-x") { Description = "the-option-description" }
             };
 
             var helpBuilder = GetHelpBuilder();

--- a/src/System.CommandLine.Tests/HelpOptionTests.cs
+++ b/src/System.CommandLine.Tests/HelpOptionTests.cs
@@ -15,15 +15,15 @@ public class HelpOptionTests
     [Fact]
     public async Task Help_option_writes_help_for_the_specified_command()
     {
-        CliCommand command = new CliRootCommand
+        Command command = new RootCommand
         {
-            new CliCommand("command")
+            new Command("command")
             {
-                new CliCommand("subcommand")
+                new Command("subcommand")
             }
         };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             Output = new StringWriter()
         };
@@ -32,19 +32,19 @@ public class HelpOptionTests
 
         await result.InvokeAsync();
 
-        config.Output.ToString().Should().Contain($"{CliRootCommand.ExecutableName} command subcommand [options]");
+        config.Output.ToString().Should().Contain($"{RootCommand.ExecutableName} command subcommand [options]");
     }
          
     [Fact]
     public async Task Help_option_interrupts_execution_of_the_specified_command()
     {
         var wasCalled = false;
-        var command = new CliCommand("command") { new HelpOption() };
-        var subcommand = new CliCommand("subcommand");
+        var command = new Command("command") { new HelpOption() };
+        var subcommand = new Command("subcommand");
         subcommand.SetAction(_ => wasCalled = true);
         command.Subcommands.Add(subcommand);
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             Output = new StringWriter()
         };
@@ -61,7 +61,7 @@ public class HelpOptionTests
     [InlineData("/?")]
     public async Task Help_option_accepts_default_values(string value)
     {
-        CliConfiguration config = new(new CliCommand("command") { new HelpOption() })
+        CommandLineConfiguration config = new(new Command("command") { new HelpOption() })
         {
             Output = new StringWriter()
         };
@@ -77,10 +77,10 @@ public class HelpOptionTests
     [Fact]
     public async Task Help_option_does_not_display_when_option_defined_with_same_alias()
     {
-        var command = new CliCommand("command");
-        command.Options.Add(new CliOption<bool>("-h"));
+        var command = new Command("command");
+        command.Options.Add(new Option<bool>("-h"));
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             Output = new StringWriter()
         };
@@ -93,7 +93,7 @@ public class HelpOptionTests
     [Fact]
     public void There_are_no_parse_errors_when_help_is_invoked_on_root_command()
     {
-        CliRootCommand rootCommand = new();
+        RootCommand rootCommand = new();
 
         var result = rootCommand.Parse("-h");
 
@@ -105,9 +105,9 @@ public class HelpOptionTests
     [Fact]
     public void There_are_no_parse_errors_when_help_is_invoked_on_subcommand()
     {
-        var root = new CliRootCommand
+        var root = new RootCommand
         {
-            new CliCommand("subcommand"),
+            new Command("subcommand"),
         };
 
         var result = root.Parse("subcommand -h");
@@ -120,9 +120,9 @@ public class HelpOptionTests
     [Fact]
     public void There_are_no_parse_errors_when_help_is_invoked_on_a_command_with_subcommands()
     {
-        var root = new CliRootCommand
+        var root = new RootCommand
         {
-            new CliCommand("subcommand"),
+            new Command("subcommand"),
         };
 
         var result = root.Parse("-h");
@@ -133,9 +133,9 @@ public class HelpOptionTests
     [Fact]
     public void There_are_no_parse_errors_when_help_is_invoked_on_a_command_with_required_options()
     {
-        var command = new CliRootCommand
+        var command = new RootCommand
         {
-            new CliOption<string>("-x")
+            new Option<string>("-x")
             {
                 Required = true
             },
@@ -151,11 +151,11 @@ public class HelpOptionTests
     [InlineData("--confused")]
     public async Task HelpOption_with_custom_aliases_uses_aliases(string helpAlias)
     {
-        CliRootCommand command = new()
+        RootCommand command = new()
         {
             new HelpOption("/lost", "--confused")
         };
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             Output = new StringWriter()
         };
@@ -173,11 +173,11 @@ public class HelpOptionTests
     [InlineData("/?")]
     public async Task Help_option_with_custom_aliases_does_not_recognize_default_aliases(string helpAlias)
     {
-        CliRootCommand command = new();
+        RootCommand command = new();
         command.Options.Clear();
         command.Options.Add(new HelpOption("--confused"));
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             Output = new StringWriter(),
         };

--- a/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/CancelOnProcessTerminationTests.cs
@@ -20,7 +20,7 @@ namespace System.CommandLine.Tests.Invocation
         private const int SIGTERM_EXIT_CODE = 143;
         private const int GracefulExitCode = 42;
 
-        private static readonly CliOption<bool> InfiniteDelayOption = new("--infiniteDelay");
+        private static readonly Option<bool> InfiniteDelayOption = new("--infiniteDelay");
 
         public enum Signals
         {
@@ -50,19 +50,19 @@ namespace System.CommandLine.Tests.Invocation
 
         private static Task<int> Program(string[] args)
         {
-            CliRootCommand command = new ()
+            RootCommand command = new ()
             {
                 InfiniteDelayOption
             };
             command.Action = new CustomCliAction();
 
-            return new CliConfiguration(command)
+            return new CommandLineConfiguration(command)
             {
                 ProcessTerminationTimeout = TimeSpan.FromSeconds(2)
             }.InvokeAsync(args);
         }
 
-        private sealed class CustomCliAction : AsynchronousCliAction
+        private sealed class CustomCliAction : AsynchronousCommandLineAction
         {
             public override async Task<int> InvokeAsync(ParseResult context, CancellationToken cancellationToken = default)
             {

--- a/src/System.CommandLine.Tests/Invocation/InvocationTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/InvocationTests.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Command_InvokeAsync_enables_help_by_default()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 new HelpOption()
             };
@@ -26,7 +26,7 @@ namespace System.CommandLine.Tests.Invocation
             command.Description = theHelpText;
 
             StringWriter output = new();
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Output = output
             };
@@ -41,7 +41,7 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public void Command_Invoke_enables_help_by_default()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 new HelpOption()
             };
@@ -49,7 +49,7 @@ namespace System.CommandLine.Tests.Invocation
             command.Description = theHelpText;
 
             StringWriter output = new ();
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Output = output
             };
@@ -65,7 +65,7 @@ namespace System.CommandLine.Tests.Invocation
         public async Task RootCommand_InvokeAsync_returns_0_when_handler_is_successful()
         {
             var wasCalled = false;
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
             rootCommand.SetAction((_) => wasCalled = true);
 
@@ -79,7 +79,7 @@ namespace System.CommandLine.Tests.Invocation
         public void RootCommand_Invoke_returns_0_when_handler_is_successful()
         {
             var wasCalled = false;
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
             rootCommand.SetAction(_ => wasCalled = true);
 
@@ -93,7 +93,7 @@ namespace System.CommandLine.Tests.Invocation
         public async Task RootCommand_InvokeAsync_returns_1_when_handler_throws()
         {
             var wasCalled = false;
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
             rootCommand.SetAction((_, _) =>
             {
@@ -112,7 +112,7 @@ namespace System.CommandLine.Tests.Invocation
         public void RootCommand_Invoke_returns_1_when_handler_throws()
         {
             var wasCalled = false;
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
             rootCommand.SetAction((_, _) =>
             {
@@ -134,7 +134,7 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public void Custom_RootCommand_Action_can_set_custom_result_code_via_Invoke()
         {
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
             rootCommand.SetAction(_ => 123);
 
             rootCommand.Parse("").Invoke().Should().Be(123);
@@ -143,7 +143,7 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Custom_RootCommand_Action_can_set_custom_result_code_via_InvokeAsync()
         {
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
             rootCommand.SetAction((_, _) => Task.FromResult(456));
 
             (await rootCommand.Parse("").InvokeAsync()).Should().Be(456);
@@ -152,7 +152,7 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public void Anonymous_RootCommand_Task_returning_Action_can_set_custom_result_code_via_Invoke()
         {
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
             rootCommand.SetAction((_, _) => Task.FromResult(123));
 
@@ -162,7 +162,7 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Anonymous_RootCommand_Task_returning_Action_can_set_custom_result_code_via_InvokeAsync()
         {
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
             rootCommand.SetAction((_, _) => Task.FromResult(123));
 
@@ -172,7 +172,7 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public void Anonymous_RootCommand_int_returning_Action_can_set_custom_result_code_via_Invoke()
         {
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
             rootCommand.SetAction(_ => 123);
 
@@ -182,7 +182,7 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Anonymous_RootCommand_int_returning_Action_can_set_custom_result_code_via_InvokeAsync()
         {
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
             rootCommand.SetAction(_ => 123);
 
@@ -196,11 +196,11 @@ namespace System.CommandLine.Tests.Invocation
             SynchronousTestAction optionAction = new(_ => optionActionWasCalled = true, terminating: true);
             bool commandActionWasCalled = false;
 
-            CliOption<bool> option = new("--test")
+            Option<bool> option = new("--test")
             {
                 Action = optionAction
             };
-            CliCommand command = new CliCommand("cmd")
+            Command command = new Command("cmd")
             {
                 option
             };
@@ -227,11 +227,11 @@ namespace System.CommandLine.Tests.Invocation
             SynchronousTestAction optionAction = new(_ => optionActionWasCalled = true, terminating: false);
             bool commandActionWasCalled = false;
 
-            CliOption<bool> option = new("--test")
+            Option<bool> option = new("--test")
             {
                 Action = optionAction
             };
-            CliCommand command = new CliCommand("cmd")
+            Command command = new Command("cmd")
             {
                 option
             };
@@ -255,11 +255,11 @@ namespace System.CommandLine.Tests.Invocation
             SynchronousTestAction optionAction2 = new(_ => optionAction2WasCalled = true);
             SynchronousTestAction optionAction3 = new(_ => optionAction3WasCalled = true);
 
-            CliCommand command = new CliCommand("cmd")
+            Command command = new Command("cmd")
             {
-                new CliOption<bool>("--1") { Action = optionAction1 },
-                new CliOption<bool>("--2") { Action = optionAction2 },
-                new CliOption<bool>("--3") { Action = optionAction3 }
+                new Option<bool>("--1") { Action = optionAction1 },
+                new Option<bool>("--2") { Action = optionAction2 },
+                new Option<bool>("--3") { Action = optionAction3 }
             };
 
             ParseResult parseResult = command.Parse("cmd --1 true --3 false --2 true");
@@ -282,18 +282,18 @@ namespace System.CommandLine.Tests.Invocation
             SynchronousTestAction optionAction = new(_ => optionActionWasCalled = true);
             SynchronousTestAction directiveAction = new(_ => directiveActionWasCalled = true);
 
-            var directive = new CliDirective("directive")
+            var directive = new Directive("directive")
             {
                 Action = directiveAction
             };
 
-            CliRootCommand command = new("cmd")
+            RootCommand command = new("cmd")
             {
-                new CliOption<bool>("-x") { Action = optionAction },
+                new Option<bool>("-x") { Action = optionAction },
                 directive
             };
 
-            ParseResult parseResult = command.Parse("[directive] cmd -x", new CliConfiguration(command));
+            ParseResult parseResult = command.Parse("[directive] cmd -x", new CommandLineConfiguration(command));
 
             using var _ = new AssertionScope();
 
@@ -310,9 +310,9 @@ namespace System.CommandLine.Tests.Invocation
         {
             var nonexclusiveAction = new SynchronousTestAction(_ => throw new Exception("oops!"), terminating: false);
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<bool>("-x")
+                new Option<bool>("-x")
                 {
                     Action = nonexclusiveAction
                 }
@@ -321,7 +321,7 @@ namespace System.CommandLine.Tests.Invocation
 
             int returnCode;
 
-            var parseResult = CliParser.Parse(command, "-x");
+            var parseResult = CommandLineParser.Parse(command, "-x");
 
             if (invokeAsync)
             {
@@ -339,7 +339,7 @@ namespace System.CommandLine.Tests.Invocation
         public async Task Command_InvokeAsync_with_cancelation_token_invokes_command_handler()
         {
             using CancellationTokenSource cts = new();
-            var command = new CliCommand("test");
+            var command = new Command("test");
             command.SetAction((_, cancellationToken) =>
             {
                 cancellationToken.Should().Be(cts.Token);

--- a/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
+++ b/src/System.CommandLine.Tests/Invocation/TypoCorrectionTests.cs
@@ -14,12 +14,12 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task When_option_is_mistyped_it_is_suggested()
         {
-            CliRootCommand rootCommand = new () 
+            RootCommand rootCommand = new () 
             {
-                new CliOption<string>("info")
+                new Option<string>("info")
             };
 
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -34,12 +34,12 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Typo_corrections_can_be_disabled()
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
-                new CliOption<string>("info")
+                new Option<string>("info")
             };
 
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -59,10 +59,10 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task When_there_are_no_matches_then_nothing_is_suggested()
         {
-            var option = new CliOption<bool>("info");
-            CliRootCommand rootCommand = new() { option };
+            var option = new Option<bool>("info");
+            RootCommand rootCommand = new() { option };
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -77,10 +77,10 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task When_command_is_mistyped_it_is_suggested()
         {
-            var command = new CliCommand("restore");
-            CliRootCommand rootCommand = new() { command };
+            var command = new Command("restore");
+            RootCommand rootCommand = new() { command };
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -95,18 +95,18 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task When_there_are_multiple_matches_it_picks_the_best_matches()
         {
-            var fromCommand = new CliCommand("from");
-            var seenCommand = new CliCommand("seen");
-            var aOption = new CliOption<bool>("a");
-            var beenOption = new CliOption<bool>("been");
-            CliRootCommand rootCommand = new ()
+            var fromCommand = new Command("from");
+            var seenCommand = new Command("seen");
+            var aOption = new Option<bool>("a");
+            var beenOption = new Option<bool>("been");
+            RootCommand rootCommand = new ()
             {
                 fromCommand,
                 seenCommand,
                 aOption,
                 beenOption
             };
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -121,17 +121,17 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Hidden_commands_are_not_suggested()
         {
-            var fromCommand = new CliCommand("from");
-            var seenCommand = new CliCommand("seen") { Hidden = true };
-            var beenCommand = new CliCommand("been");
-            CliRootCommand rootCommand = new CliRootCommand
+            var fromCommand = new Command("from");
+            var seenCommand = new Command("seen") { Hidden = true };
+            var beenCommand = new Command("been");
+            RootCommand rootCommand = new RootCommand
             {
                 fromCommand,
                 seenCommand,
                 beenCommand
             };
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -146,15 +146,15 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Arguments_are_not_suggested()
         {
-            var argument = new CliArgument<string>("the-argument");
-            var command = new CliCommand("been");
-            var rootCommand = new CliRootCommand
+            var argument = new Argument<string>("the-argument");
+            var command = new Command("been");
+            var rootCommand = new RootCommand
             {
                 argument,
                 command
             };
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -173,16 +173,16 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Hidden_options_are_not_suggested()
         {
-            var fromOption = new CliOption<string>("from");
-            var seenOption = new CliOption<string>("seen") { Hidden = true };
-            var beenOption = new CliOption<string>("been");
-            var rootCommand = new CliRootCommand
+            var fromOption = new Option<string>("from");
+            var seenOption = new Option<string>("seen") { Hidden = true };
+            var beenOption = new Option<string>("been");
+            var rootCommand = new RootCommand
             {
                 fromOption,
                 seenOption,
                 beenOption
             };
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -197,12 +197,12 @@ namespace System.CommandLine.Tests.Invocation
         [Fact]
         public async Task Suggestions_favor_matches_with_prefix()
         {
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
-                new CliOption<string>("/call", "-call", "--call"),
-                new CliOption<string>("/email", "-email", "--email")
+                new Option<string>("/call", "-call", "--call"),
+                new Option<string>("/email", "-email", "--email")
             };
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };

--- a/src/System.CommandLine.Tests/OptionTests.MultipleArgumentsPerToken.cs
+++ b/src/System.CommandLine.Tests/OptionTests.MultipleArgumentsPerToken.cs
@@ -26,13 +26,13 @@ namespace System.CommandLine.Tests
                 [Fact]
                 public void When_option_is_not_respecified_but_limit_is_not_reached_then_the_following_token_is_used_as_value()
                 {
-                    var animalsOption = new CliOption<string[]>("-a", "--animals")
+                    var animalsOption = new Option<string[]>("-a", "--animals")
                     {
                         AllowMultipleArgumentsPerToken = true,
                     };
-                    var vegetablesOption = new CliOption<string>("-v", "--vegetables");
+                    var vegetablesOption = new Option<string>("-v", "--vegetables");
 
-                    var command = new CliRootCommand
+                    var command = new RootCommand
                     {
                         animalsOption,
                         vegetablesOption
@@ -63,13 +63,13 @@ namespace System.CommandLine.Tests
                 [Fact]
                 public void When_option_is_not_respecified_and_limit_is_reached_then_the_following_token_is_unmatched()
                 {
-                    var animalsOption = new CliOption<string>("-a", "--animals")
+                    var animalsOption = new Option<string>("-a", "--animals")
                     {
                         AllowMultipleArgumentsPerToken = true
                     };
-                    var vegetablesOption = new CliOption<string[]>("-v", "--vegetables");
+                    var vegetablesOption = new Option<string[]>("-v", "--vegetables");
 
-                    var command = new CliRootCommand
+                    var command = new RootCommand
                     {
                         animalsOption,
                         vegetablesOption
@@ -102,14 +102,14 @@ namespace System.CommandLine.Tests
                 [InlineData("--option 1 --option 2 xyz")]
                 public void When_max_arity_is_1_then_subsequent_option_args_overwrite_previous_ones(string commandLine)
                 {
-                    var option = new CliOption<string>("--option")
+                    var option = new Option<string>("--option")
                     {
                         AllowMultipleArgumentsPerToken = true
                     };
-                    var command = new CliCommand("the-command")
+                    var command = new Command("the-command")
                     {
                         option,
-                        new CliArgument<string>("arg")
+                        new Argument<string>("arg")
                     };
 
                     var result = command.Parse(commandLine);
@@ -122,12 +122,12 @@ namespace System.CommandLine.Tests
                 [Fact]
                 public void All_consumed_tokens_are_present_in_option_result()
                 {
-                    var option = new CliOption<int>("-x")
+                    var option = new Option<int>("-x")
                     {
                         AllowMultipleArgumentsPerToken = true
                     };
 
-                    var result = new CliRootCommand { option }.Parse("-x 1 -x 2 -x 3 -x 4");
+                    var result = new RootCommand { option }.Parse("-x 1 -x 2 -x 3 -x 4");
 
                     _output.WriteLine(result.Diagram());
 
@@ -142,16 +142,16 @@ namespace System.CommandLine.Tests
                 [Fact]
                 public void Multiple_option_arguments_that_match_single_arity_option_aliases_are_parsed_correctly()
                 {
-                    var optionX = new CliOption<string>("-x")
+                    var optionX = new Option<string>("-x")
                     {
                         AllowMultipleArgumentsPerToken = true
                     };
-                    var optionY = new CliOption<string>("-y")
+                    var optionY = new Option<string>("-y")
                     {
                         AllowMultipleArgumentsPerToken = true
                     };
 
-                    var command = new CliRootCommand
+                    var command = new RootCommand
                     {
                         optionX,
                         optionY
@@ -172,8 +172,8 @@ namespace System.CommandLine.Tests
                 [Fact]
                 public void Single_option_arg_is_matched()
                 {
-                    var option = new CliOption<string[]>("--option") { AllowMultipleArgumentsPerToken = false };
-                    var command = new CliCommand("the-command") { option };
+                    var option = new Option<string[]>("--option") { AllowMultipleArgumentsPerToken = false };
+                    var command = new Command("the-command") { option };
 
                     var result = command.Parse("--option 1 2");
 
@@ -185,8 +185,8 @@ namespace System.CommandLine.Tests
                 [Fact]
                 public void Subsequent_matched_arguments_result_in_errors()
                 {
-                    var option = new CliOption<string[]>("--option") { AllowMultipleArgumentsPerToken = false };
-                    var command = new CliCommand("the-command") { option };
+                    var option = new Option<string[]>("--option") { AllowMultipleArgumentsPerToken = false };
+                    var command = new Command("the-command") { option };
 
                     var result = command.Parse("--option 1 2");
 
@@ -197,8 +197,8 @@ namespace System.CommandLine.Tests
                 [Fact]
                 public void When_max_arity_is_greater_than_1_then_multiple_option_args_are_matched()
                 {
-                    var option = new CliOption<string[]>("--option") { AllowMultipleArgumentsPerToken = false };
-                    var command = new CliCommand("the-command") { option };
+                    var option = new Option<string[]>("--option") { AllowMultipleArgumentsPerToken = false };
+                    var command = new Command("the-command") { option };
 
                     var result = command.Parse("--option 1 --option 2");
 

--- a/src/System.CommandLine.Tests/OptionTests.cs
+++ b/src/System.CommandLine.Tests/OptionTests.cs
@@ -13,7 +13,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void By_default_there_is_no_default_value()
         {
-            CliOption<string> option = new("name");
+            Option<string> option = new("name");
 
             option.HasDefaultValue.Should().BeFalse();
         }
@@ -21,7 +21,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_default_value_factory_is_set_then_HasDefaultValue_is_true()
         {
-            CliOption<string[]> option = new("name");
+            Option<string[]> option = new("name");
 
             option.DefaultValueFactory = (_) => Array.Empty<string>();
 
@@ -31,7 +31,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_only_name_then_it_has_no_aliases()
         {
-            var option = new CliOption<string>("myname");
+            var option = new Option<string>("myname");
 
             option.Name.Should().Be("myname");
             option.Aliases.Should().BeEmpty();
@@ -40,7 +40,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_several_aliases_then_they_do_not_affect_its_name()
         {
-            var option = new CliOption<string>(name: "m", aliases: new[] { "longer" });
+            var option = new Option<string>(name: "m", aliases: new[] { "longer" });
 
             option.Name.Should().Be("m");
         }
@@ -48,7 +48,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_names_can_contain_prefix_characters()
         {
-            var option = new CliOption<string>("--myname");
+            var option = new Option<string>("--myname");
 
             option.Name.Should().Be("--myname");
         }
@@ -56,7 +56,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Aliases_is_aware_of_added_alias()
         {
-            var option = new CliOption<string>("--original");
+            var option = new Option<string>("--original");
 
             option.Aliases.Add("--added");
 
@@ -66,7 +66,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void RawAliases_is_aware_of_added_alias()
         {
-            var option = new CliOption<string>("--original");
+            var option = new Option<string>("--original");
 
             option.Aliases.Add("--added");
 
@@ -76,7 +76,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void A_prefixed_alias_can_be_added_to_an_option()
         {
-            var option = new CliOption<string>("--apple");
+            var option = new Option<string>("--apple");
 
             option.Aliases.Add("-a");
 
@@ -86,7 +86,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_aliases_are_case_sensitive()
         {
-            var option = new CliOption<string>("name", "o");
+            var option = new Option<string>("name", "o");
 
             option.Aliases.Contains("O").Should().BeFalse();
         }
@@ -94,7 +94,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Aliases_contains_prefixed_short_value()
         {
-            var option = new CliOption<string>("--option", "-o");
+            var option = new Option<string>("--option", "-o");
 
             option.Aliases.Contains("-o").Should().BeTrue();
         }
@@ -102,7 +102,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Aliases_contains_prefixed_long_value()
         {
-            var option = new CliOption<string>("-o", "--option");
+            var option = new Option<string>("-o", "--option");
 
             option.Aliases.Contains("--option").Should().BeTrue();
         }
@@ -110,7 +110,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void It_is_not_necessary_to_specify_a_prefix_when_adding_an_option()
         {
-            var option = new CliOption<string>("o");
+            var option = new Option<string>("o");
 
             option.Name.Should().Be("o");
             option.Aliases.Should().BeEmpty();
@@ -119,7 +119,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_does_not_need_to_have_at_any_aliases()
         {
-            var option = new CliOption<string>("justName");
+            var option = new Option<string>("justName");
 
             option.Aliases.Should().BeEmpty();
         }
@@ -127,7 +127,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_cannot_have_an_empty_alias()
         {
-            Action create = () => new CliOption<string>("name", "");
+            Action create = () => new Option<string>("name", "");
 
             create.Should()
                   .Throw<ArgumentException>()
@@ -140,7 +140,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_cannot_have_an_alias_consisting_entirely_of_whitespace()
         {
-            Action create = () => new CliOption<string>("name", "  \t");
+            Action create = () => new Option<string>("name", "  \t");
 
             create.Should()
                   .Throw<ArgumentException>()
@@ -153,7 +153,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Raw_aliases_are_exposed_by_an_option()
         {
-            var option = new CliOption<string>("--help", "-h", "/?");
+            var option = new Option<string>("--help", "-h", "/?");
 
             option.Aliases
                   .Should()
@@ -167,7 +167,7 @@ namespace System.CommandLine.Tests
         public void When_an_option_is_created_with_a_name_that_contains_whitespace_then_an_informative_error_is_returned(
             string name)
         {
-            Action create = () => new CliOption<string>(name);
+            Action create = () => new Option<string>(name);
 
             create.Should()
                   .Throw<ArgumentException>()
@@ -183,7 +183,7 @@ namespace System.CommandLine.Tests
         [InlineData("--aa aa")]
         public void When_an_option_alias_is_added_and_contains_whitespace_then_an_informative_error_is_returned(string alias)
         {
-            var option = new CliOption<bool>("-x");
+            var option = new Option<bool>("-x");
 
             Action addAlias = () => option.Aliases.Add(alias);
 
@@ -201,11 +201,11 @@ namespace System.CommandLine.Tests
         [InlineData("/")]
         public void When_options_use_different_prefixes_they_still_work(string prefix)
         {
-            var optionA = new CliOption<string>(prefix + "a");
-            var optionB = new CliOption<string>(prefix + "b");
-            var optionC = new CliOption<string>(prefix + "c");
+            var optionA = new Option<string>(prefix + "a");
+            var optionB = new Option<string>(prefix + "b");
+            var optionC = new Option<string>(prefix + "c");
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
                               {
                                   optionA,
                                   optionB,
@@ -222,12 +222,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_T_default_value_can_be_set_via_the_constructor()
         {
-            var option = new CliOption<int>("-x")
+            var option = new Option<int>("-x")
             {
                 DefaultValueFactory = _ => 123
             };
 
-            new CliRootCommand { option }
+            new RootCommand { option }
                 .Parse("")
                 .GetResult(option)
                 .GetValueOrDefault<int>()
@@ -238,12 +238,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_T_default_value_can_be_set_after_instantiation()
         {
-            var option = new CliOption<int>("-x")
+            var option = new Option<int>("-x")
             {
                 DefaultValueFactory = (_) => 123
             };
 
-            new CliRootCommand { option }
+            new RootCommand { option }
                 .Parse("")
                 .GetResult(option)
                 .GetValueOrDefault<int>()
@@ -254,11 +254,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_T_default_value_factory_can_be_set_after_instantiation()
         {
-            var option = new CliOption<int>("-x");
+            var option = new Option<int>("-x");
 
             option.DefaultValueFactory = (_) => 123;
 
-            new CliRootCommand { option }
+            new RootCommand { option }
                 .Parse("")
                 .GetResult(option)
                 .GetValueOrDefault<int>()
@@ -269,7 +269,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_T_default_value_is_validated()
         {
-            var option = new CliOption<int>("-x") { DefaultValueFactory = (_) => 123 };
+            var option = new Option<int>("-x") { DefaultValueFactory = (_) => 123 };
             option.Validators.Add(symbol =>
                                     symbol.AddError(symbol.Tokens
                                                                 .Select(t => t.Value)
@@ -277,7 +277,7 @@ namespace System.CommandLine.Tests
                                                                 .Select(_ => "ERR")
                                                                 .First()));
 
-            new CliRootCommand { option }
+            new RootCommand { option }
                 .Parse("-x 123")
                 .Errors
                 .Select(e => e.Message)
@@ -288,9 +288,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_of_string_defaults_to_null_when_not_specified()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
 
-            var result = new CliRootCommand { option }.Parse("");
+            var result = new RootCommand { option }.Parse("");
             result.GetResult(option)
                 .Should()
                 .BeNull();
@@ -302,9 +302,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_of_boolean_defaults_to_false_when_not_specified()
         {
-            var option = new CliOption<bool>("-x");
+            var option = new Option<bool>("-x");
 
-            var result = new CliRootCommand { option }.Parse("");
+            var result = new RootCommand { option }.Parse("");
 
             result.GetResult(option)
                 .Should()
@@ -317,10 +317,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_of_enum_can_limit_enum_members_as_valid_values()
         {
-            CliOption<ConsoleColor> option = new("--color");
+            Option<ConsoleColor> option = new("--color");
             option.AcceptOnlyFromAmong(ConsoleColor.Red.ToString(), ConsoleColor.Green.ToString());
 
-            var result = new CliRootCommand { option }.Parse("--color Fuschia");
+            var result = new RootCommand { option }.Parse("--color Fuschia");
 
             result.Errors
                   .Select(e => e.Message)
@@ -331,12 +331,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_result_provides_identifier_token_if_name_was_provided()
         {
-            var option = new CliOption<int>("--name")
+            var option = new Option<int>("--name")
             {
                 Aliases = { "-n" }
             };
 
-            var result = new CliRootCommand { option }.Parse("--name 123");
+            var result = new RootCommand { option }.Parse("--name 123");
 
             result.GetResult(option).IdentifierToken.Value.Should().Be("--name");
         }
@@ -344,12 +344,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_result_provides_identifier_token_if_alias_was_provided()
         {
-            var option = new CliOption<int>("--name")
+            var option = new Option<int>("--name")
             {
                 Aliases = { "-n" }
             };
 
-            var result = new CliRootCommand { option }.Parse("-n 123");
+            var result = new RootCommand { option }.Parse("-n 123");
 
             result.GetResult(option).IdentifierToken.Value.Should().Be("-n");
         }
@@ -361,15 +361,15 @@ namespace System.CommandLine.Tests
         [InlineData("--name 123 -x different-option --name 456", 2)]
         public void Number_of_occurrences_of_identifier_token_is_exposed_by_option_result(string commandLine, int expectedCount)
         {
-            var option = new CliOption<int>("--name")
+            var option = new Option<int>("--name")
             {
                 Aliases = { "-n" }
             };
 
-            var root = new CliRootCommand
+            var root = new RootCommand
             {
                 option,
-                new CliOption<string>("-x")
+                new Option<string>("-x")
             };
 
             var optionResult = root.Parse(commandLine).GetResult(option);
@@ -380,9 +380,9 @@ namespace System.CommandLine.Tests
         [Fact] 
         public void Multiple_identifier_token_instances_without_argument_tokens_can_be_parsed()
         {
-            var option = new CliOption<bool>("-v");
+            var option = new Option<bool>("-v");
 
-            var root = new CliRootCommand
+            var root = new RootCommand
             {
                 option
             };
@@ -395,9 +395,9 @@ namespace System.CommandLine.Tests
         [Fact] 
         public void Multiple_bundled_identifier_token_instances_without_argument_tokens_can_be_parsed()
         {
-            var option = new CliOption<bool>("-v");
+            var option = new Option<bool>("-v");
 
-            var root = new CliRootCommand
+            var root = new RootCommand
             {
                 option
             };
@@ -412,14 +412,14 @@ namespace System.CommandLine.Tests
         [InlineData("-v -v -v")]
         public void Custom_parser_can_be_used_to_implement_int_binding_based_on_token_count(string commandLine)
         {
-            var option = new CliOption<int>("-v")
+            var option = new Option<int>("-v")
             {
                 Arity = ArgumentArity.Zero,
                 AllowMultipleArgumentsPerToken = true,
                 CustomParser = argumentResult => ((OptionResult)argumentResult.Parent).IdentifierTokenCount,
             };
 
-            var root = new CliRootCommand
+            var root = new RootCommand
             {
                 option
             };

--- a/src/System.CommandLine.Tests/ParseDiagramTests.cs
+++ b/src/System.CommandLine.Tests/ParseDiagramTests.cs
@@ -13,13 +13,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_result_diagram_helps_explain_parse_operation()
         {
-            CliCommand command = 
-                new CliCommand(
+            Command command = 
+                new Command(
                     "the-command")
                 {
-                    new CliOption<string>("-x"),
-                    new CliOption<bool>("-y"),
-                    new CliArgument<string[]>("arg")
+                    new Option<string>("-x"),
+                    new Option<bool>("-y"),
+                    new Argument<string[]>("arg")
                 };
 
             var result = command.Parse("the-command -x one -y two three");
@@ -32,10 +32,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_result_diagram_displays_unmatched_tokens()
         {
-            CliOption<string> option = new ("-x");
+            Option<string> option = new ("-x");
             option.AcceptOnlyFromAmong("arg1", "arg2", "arg3");
 
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 option
             };
@@ -50,26 +50,26 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_diagram_shows_type_conversion_errors()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<int>("-f")
+                new Option<int>("-f")
             };
 
             var result = command.Parse("-f not-an-int");
 
             result.Diagram()
                   .Should()
-                  .Be($"[ {CliRootCommand.ExecutableName} ![ -f <not-an-int> ] ]");
+                  .Be($"[ {RootCommand.ExecutableName} ![ -f <not-an-int> ] ]");
         }
 
         [Fact]
         public void Parse_diagram_identifies_options_where_default_values_have_been_applied()
         {
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
-                new CliOption<int>("--height", "-h") { DefaultValueFactory = _ => 10 },
-                new CliOption<int>("-w", "--width") { DefaultValueFactory = _ => 15 },
-                new CliOption<ConsoleColor>("--color", "-c") { DefaultValueFactory = _ => ConsoleColor.Cyan }
+                new Option<int>("--height", "-h") { DefaultValueFactory = _ => 10 },
+                new Option<int>("-w", "--width") { DefaultValueFactory = _ => 15 },
+                new Option<ConsoleColor>("--color", "-c") { DefaultValueFactory = _ => ConsoleColor.Cyan }
             };
 
             var result = rootCommand.Parse("-w 9000");
@@ -77,17 +77,17 @@ namespace System.CommandLine.Tests
             var diagram = result.Diagram();
 
             diagram.Should()
-                   .Be($"[ {CliRootCommand.ExecutableName} [ -w <9000> ] *[ --height <10> ] *[ --color <Cyan> ] ]");
+                   .Be($"[ {RootCommand.ExecutableName} [ -w <9000> ] *[ --height <10> ] *[ --color <Cyan> ] ]");
         }
 
         [Fact]
         public void Parse_diagram_indicates_which_tokens_were_applied_to_which_command_argument()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<string>("first"),
-                new CliArgument<string> ("second"),
-                new CliArgument<string[]> ("third")
+                new Argument<string>("first"),
+                new Argument<string> ("second"),
+                new Argument<string[]> ("third")
             };
 
             var result = command.Parse("one two three four five");
@@ -100,11 +100,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_diagram_indicates_which_tokens_were_applied_to_which_command_argument_for_sequences_of_complex_types()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<FileInfo> ("first"),
-                new CliArgument<FileInfo> ("second"),
-                new CliArgument<FileInfo[]> ("third")
+                new Argument<FileInfo> ("first"),
+                new Argument<FileInfo> ("second"),
+                new Argument<FileInfo[]> ("third")
             };
 
             var result = command.Parse("one two three four five");

--- a/src/System.CommandLine.Tests/ParseDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/ParseDirectiveTests.cs
@@ -23,14 +23,14 @@ namespace System.CommandLine.Tests
         [InlineData(false)]
         public async Task Diagram_directive_writes_parse_diagram(bool treatUnmatchedTokensAsErrors)
         {
-            var rootCommand = new CliRootCommand { new DiagramDirective() };
-            var subcommand = new CliCommand("subcommand");
+            var rootCommand = new RootCommand { new DiagramDirective() };
+            var subcommand = new Command("subcommand");
             rootCommand.Subcommands.Add(subcommand);
-            var option = new CliOption<int>("-c", "--count");
+            var option = new Option<int>("-c", "--count");
             subcommand.Options.Add(option);
             subcommand.TreatUnmatchedTokensAsErrors = treatUnmatchedTokensAsErrors;
 
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -42,8 +42,8 @@ namespace System.CommandLine.Tests
             await result.InvokeAsync();
 
             string expected = treatUnmatchedTokensAsErrors
-                                  ? $"[ {CliRootCommand.ExecutableName} ![ subcommand [ -c <34> ] ] ]   ???--> --nonexistent wat" + Environment.NewLine
-                                  : $"[ {CliRootCommand.ExecutableName} [ subcommand [ -c <34> ] ] ]   ???--> --nonexistent wat" + Environment.NewLine;
+                                  ? $"[ {RootCommand.ExecutableName} ![ subcommand [ -c <34> ] ] ]   ???--> --nonexistent wat" + Environment.NewLine
+                                  : $"[ {RootCommand.ExecutableName} [ subcommand [ -c <34> ] ] ]   ???--> --nonexistent wat" + Environment.NewLine;
 
             config.Output
                   .ToString()
@@ -54,12 +54,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_diagram_directive_is_used_the_help_is_not_displayed()
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
                 new DiagramDirective()
             };
 
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter(),
             };
@@ -73,18 +73,18 @@ namespace System.CommandLine.Tests
             config.Output
                    .ToString()
                    .Should()
-                   .Be($"[ {CliRootCommand.ExecutableName} [ --help ] ]" + Environment.NewLine);
+                   .Be($"[ {RootCommand.ExecutableName} [ --help ] ]" + Environment.NewLine);
         }
 
         [Fact]
         public async Task When_diagram_directive_is_used_the_version_is_not_displayed()
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
                 new DiagramDirective()
             };
 
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -98,19 +98,19 @@ namespace System.CommandLine.Tests
             config.Output
                   .ToString()
                   .Should()
-                  .Be($"[ {CliRootCommand.ExecutableName} [ --version ] ]" + Environment.NewLine);
+                  .Be($"[ {RootCommand.ExecutableName} [ --version ] ]" + Environment.NewLine);
         }
 
         [Fact]
         public async Task When_there_are_no_errors_then_diagram_directive_sets_exit_code_0()
         {
-            CliRootCommand command = new ()
+            RootCommand command = new ()
             {
-                new CliOption<int>("-x"),
+                new Option<int>("-x"),
                 new DiagramDirective()
             };
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter(),
             };
@@ -123,13 +123,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_there_are_errors_then_diagram_directive_sets_exit_code_1()
         {
-            CliRootCommand command = new()
+            RootCommand command = new()
             {
-                new CliOption<int>("-x"),
+                new Option<int>("-x"),
                 new DiagramDirective()
             };
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter(),
             };
@@ -142,16 +142,16 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_there_are_errors_then_diagram_directive_sets_exit_code_to_custom_value()
         {
-            CliRootCommand command = new()
+            RootCommand command = new()
             {
-                new CliOption<int>("-x"),
+                new Option<int>("-x"),
                 new DiagramDirective
                 {
                     ParseErrorReturnValue = 42
                 }
             };
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter()
             };

--- a/src/System.CommandLine.Tests/ParseErrorReportingTests.cs
+++ b/src/System.CommandLine.Tests/ParseErrorReportingTests.cs
@@ -17,14 +17,14 @@ public class ParseErrorReportingTests
     [Fact] // https://github.com/dotnet/command-line-api/issues/817
     public void Parse_error_reporting_reports_error_when_help_is_used_and_required_subcommand_is_missing()
     {
-        var root = new CliRootCommand
+        var root = new RootCommand
         {
-            new CliCommand("inner"),
+            new Command("inner"),
             new HelpOption()
         };
 
         var output = new StringWriter();
-        var parseResult = root.Parse("", new CliConfiguration(root)
+        var parseResult = root.Parse("", new CommandLineConfiguration(root)
         {
             Output = output,
         });
@@ -40,12 +40,12 @@ public class ParseErrorReportingTests
     [Fact]
     public void Help_display_can_be_disabled()
     {
-        CliRootCommand rootCommand = new()
+        RootCommand rootCommand = new()
         {
-            new CliOption<bool>("--verbose")
+            new Option<bool>("--verbose")
         };
 
-        CliConfiguration config = new(rootCommand)
+        CommandLineConfiguration config = new(rootCommand)
         {
             Output = new StringWriter()
         };
@@ -70,9 +70,9 @@ public class ParseErrorReportingTests
     public void When_there_are_parse_errors_then_customized_help_action_is_used_if_present(bool useAsyncAction)
     {
         var wasCalled = false;
-        CliRootCommand rootCommand = new();
+        RootCommand rootCommand = new();
         rootCommand.Options.Clear();
-        CliAction customHelpAction = useAsyncAction
+        CommandLineAction customHelpAction = useAsyncAction
                                          ? new AsynchronousTestAction(_ => wasCalled = true)
                                          : new SynchronousTestAction(_ => wasCalled = true);
 
@@ -91,11 +91,11 @@ public class ParseErrorReportingTests
     {
         bool rootHelpWasCalled = false;
 
-        var rootCommand = new CliRootCommand
+        var rootCommand = new RootCommand
         {
-            new CliCommand("child")
+            new Command("child")
             {
-                new CliCommand("grandchild")
+                new Command("grandchild")
             }
         };
 
@@ -104,7 +104,7 @@ public class ParseErrorReportingTests
             rootHelpWasCalled = true;
         });
 
-        var config = new CliConfiguration(rootCommand);
+        var config = new CommandLineConfiguration(rootCommand);
 
         await config.Parse("child grandchild oops").InvokeAsync();
 
@@ -114,10 +114,10 @@ public class ParseErrorReportingTests
     [Fact]
     public void When_no_help_option_is_present_then_help_is_not_shown_for_parse_errors()
     {
-        CliRootCommand rootCommand = new();
+        RootCommand rootCommand = new();
         rootCommand.Options.Clear();
         var output = new StringWriter();
-        CliConfiguration config = new(rootCommand)
+        CommandLineConfiguration config = new(rootCommand)
         {
             Output = output
         };

--- a/src/System.CommandLine.Tests/ParseResultTests.cs
+++ b/src/System.CommandLine.Tests/ParseResultTests.cs
@@ -14,9 +14,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_option_with_a_default_value_and_no_explicitly_provided_argument_has_an_empty_arguments_property()
         {
-            var option = new CliOption<string>("-x") { DefaultValueFactory = (_) => "default" };
+            var option = new Option<string>("-x") { DefaultValueFactory = (_) => "default" };
 
-            var result = new CliRootCommand
+            var result = new RootCommand
             {
                 option
             }.Parse("-x")
@@ -28,9 +28,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void FindResult_can_be_used_to_check_the_presence_of_an_option()
         {
-            var option = new CliOption<bool>("-h", "--help");
+            var option = new Option<bool>("-h", "--help");
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -43,8 +43,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void GetResult_can_be_used_to_check_the_presence_of_an_implicit_option()
         {
-            var option = new CliOption<int>("-c", "--count") { DefaultValueFactory = (_) => 5 };
-            var command = new CliCommand("the-command")
+            var option = new Option<int>("-c", "--count") { DefaultValueFactory = (_) => 5 };
+            var command = new Command("the-command")
             {
                 option
             };
@@ -57,11 +57,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void GetResult_can_be_used_for_root_command_itself()
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
-                new CliCommand("the-command")
+                new Command("the-command")
                 {
-                    new CliOption<int>("-c")
+                    new Option<int>("-c")
                 }
             };
 
@@ -74,30 +74,30 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_will_not_accept_a_command_if_a_sibling_command_has_already_been_accepted()
         {
-            var command = new CliCommand("outer")
+            var command = new Command("outer")
             {
-                new CliCommand("inner-one")
+                new Command("inner-one")
                 {
-                    new CliArgument<bool>("arg1")
+                    new Argument<bool>("arg1")
                     {
                         Arity = ArgumentArity.Zero
                     }
                 },
-                new CliCommand("inner-two")
+                new Command("inner-two")
                 {
-                    new CliArgument<bool>("arg2")
+                    new Argument<bool>("arg2")
                     {
                         Arity = ArgumentArity.Zero
                     }
                 }
             };
 
-            var result = CliParser.Parse(command, "outer inner-one inner-two");
+            var result = CommandLineParser.Parse(command, "outer inner-one inner-two");
 
             result.CommandResult.Command.Name.Should().Be("inner-one");
             result.Errors.Count.Should().Be(1);
 
-            var result2 = CliParser.Parse(command, "outer inner-two inner-one");
+            var result2 = CommandLineParser.Parse(command, "outer inner-two inner-one");
 
             result2.CommandResult.Command.Name.Should().Be("inner-two");
             result2.Errors.Count.Should().Be(1);
@@ -106,31 +106,31 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/pull/2030#issuecomment-1400275332
         public void ParseResult_GetCompletions_returns_global_options_of_given_command_only()
         {
-            var leafCommand = new CliCommand("leafCommand")
+            var leafCommand = new Command("leafCommand")
             {
-                new CliOption<string>("--one") { Description = "option one" },
-                new CliOption<string>("--two") { Description = "option two" }
+                new Option<string>("--one") { Description = "option one" },
+                new Option<string>("--two") { Description = "option two" }
             };
 
-            var midCommand1 = new CliCommand("midCommand1")
-            {
-                leafCommand
-            };
-            midCommand1.Options.Add(new CliOption<string>("--three1") { Description = "option three 1", Recursive = true });
-
-            var midCommand2 = new CliCommand("midCommand2")
+            var midCommand1 = new Command("midCommand1")
             {
                 leafCommand
             };
-            midCommand2.Options.Add(new CliOption<string>("--three2") { Description = "option three 2", Recursive = true });
+            midCommand1.Options.Add(new Option<string>("--three1") { Description = "option three 1", Recursive = true });
 
-            var rootCommand = new CliCommand("root")
+            var midCommand2 = new Command("midCommand2")
+            {
+                leafCommand
+            };
+            midCommand2.Options.Add(new Option<string>("--three2") { Description = "option three 2", Recursive = true });
+
+            var rootCommand = new Command("root")
             {
                 midCommand1,
                 midCommand2
             };
 
-            var result = CliParser.Parse(rootCommand, "root midCommand2 leafCommand --");
+            var result = CommandLineParser.Parse(rootCommand, "root midCommand2 leafCommand --");
 
             var completions = result.GetCompletions();
 
@@ -142,14 +142,14 @@ namespace System.CommandLine.Tests
 
         [Fact]
         public void Handler_is_null_when_parsed_command_did_not_specify_handler()
-            => new CliRootCommand().Parse("").Action.Should().BeNull();
+            => new RootCommand().Parse("").Action.Should().BeNull();
 
         [Fact]
         public void Handler_is_not_null_when_parsed_command_specified_handler()
         {
             bool handlerWasCalled = false;
 
-            CliRootCommand command = new();
+            RootCommand command = new();
             command.SetAction((_) => handlerWasCalled = true);
 
             ParseResult parseResult = command.Parse("");
@@ -157,7 +157,7 @@ namespace System.CommandLine.Tests
             parseResult.Action.Should().NotBeNull();
             handlerWasCalled.Should().BeFalse();
 
-            ((SynchronousCliAction)parseResult.Action!).Invoke(null!).Should().Be(0);
+            ((SynchronousCommandLineAction)parseResult.Action!).Invoke(null!).Should().Be(0);
             handlerWasCalled.Should().BeTrue();
         }
     }

--- a/src/System.CommandLine.Tests/ParserTests.DoubleDash.cs
+++ b/src/System.CommandLine.Tests/ParserTests.DoubleDash.cs
@@ -14,9 +14,9 @@ namespace System.CommandLine.Tests
             [Fact] // https://github.com/dotnet/command-line-api/issues/1238
             public void Subsequent_tokens_are_parsed_as_arguments_even_if_they_match_option_identifiers()
             {
-                var option = new CliOption<string[]>("-o", "--one");
-                var argument = new CliArgument<string[]>("arg");
-                var rootCommand = new CliRootCommand
+                var option = new Option<string[]>("-o", "--one");
+                var argument = new Argument<string[]>("arg");
+                var rootCommand = new RootCommand
                 {
                     option,
                     argument
@@ -36,9 +36,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Unmatched_tokens_is_empty()
             {
-                var option = new CliOption<string[]>("-o", "--one");
-                var argument = new CliArgument<string[]>("arg");
-                var rootCommand = new CliRootCommand
+                var option = new Option<string[]>("-o", "--one");
+                var argument = new Argument<string[]>("arg");
+                var rootCommand = new RootCommand
                 {
                     option,
                     argument
@@ -52,9 +52,9 @@ namespace System.CommandLine.Tests
             [Fact] // https://github.com/dotnet/command-line-api/issues/1631
             public void No_errors_are_generated()
             {
-                var option = new CliOption<string[]>("-o", "--one");
-                var argument = new CliArgument<string[]>("arg");
-                var rootCommand = new CliRootCommand
+                var option = new Option<string[]>("-o", "--one");
+                var argument = new Argument<string[]>("arg");
+                var rootCommand = new RootCommand
                 {
                     option,
                     argument
@@ -68,8 +68,8 @@ namespace System.CommandLine.Tests
             [Fact]
             public void A_second_double_dash_is_parsed_as_an_argument()
             {
-                var argument = new CliArgument<string[]>("arg");
-                var rootCommand = new CliRootCommand
+                var argument = new Argument<string[]>("arg");
+                var rootCommand = new RootCommand
                 {
                     argument
                 };

--- a/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultipleArguments.cs
@@ -17,17 +17,17 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Multiple_arguments_can_differ_by_arity()
             {
-                var multipleArityArg = new CliArgument<IEnumerable<string>>("several")
+                var multipleArityArg = new Argument<IEnumerable<string>>("several")
                 {
                     Arity = new ArgumentArity(3, 3),
                 };
 
-                var singleArityArg = new CliArgument<IEnumerable<string>>("one")
+                var singleArityArg = new Argument<IEnumerable<string>>("one")
                 {
                     Arity = ArgumentArity.ZeroOrMore,
                 };
 
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     multipleArityArg,
                     singleArityArg
@@ -46,10 +46,10 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Multiple_arguments_can_differ_by_type()
             {
-                var stringArg = new CliArgument<string>("the-string");
-                var intArg = new CliArgument<int>("the-int");
+                var stringArg = new Argument<string>("the-string");
+                var intArg = new Argument<int>("the-int");
 
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     stringArg,
                     intArg
@@ -76,12 +76,12 @@ namespace System.CommandLine.Tests
             [InlineData("one two three four five --verbose true")]
             public void When_multiple_arguments_are_present_then_their_order_relative_to_sibling_options_is_not_significant(string commandLine)
             {
-                var first = new CliArgument<string>("first");
-                var second = new CliArgument<string>("second");
-                var third = new CliArgument<string[]>("third");
-                var verbose = new CliOption<bool>("--verbose");
+                var first = new Argument<string>("first");
+                var second = new Argument<string>("second");
+                var third = new Argument<string[]>("third");
+                var verbose = new Option<bool>("--verbose");
 
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     first,
                     second,
@@ -115,9 +115,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Multiple_arguments_of_unspecified_type_are_parsed_correctly()
             {
-                var sourceArg = new CliArgument<string>("source");
-                var destinationArg = new CliArgument<string>("destination");
-                var root = new CliRootCommand
+                var sourceArg = new Argument<string>("source");
+                var destinationArg = new Argument<string>("destination");
+                var root = new RootCommand
                 {
                     sourceArg,
                     destinationArg
@@ -140,12 +140,12 @@ namespace System.CommandLine.Tests
             [Fact]
             public void When_multiple_arguments_are_defined_but_not_provided_then_option_parses_correctly()
             {
-                var option = new CliOption<string>("-e");
-                var command = new CliCommand("the-command")
+                var option = new Option<string>("-e");
+                var command = new Command("the-command")
                 {
                     option,
-                    new CliArgument<string>("arg1"),
-                    new CliArgument<string>("arg2")
+                    new Argument<string>("arg1"),
+                    new Argument<string>("arg2")
                 };
 
                 var result = command.Parse("-e foo");
@@ -158,10 +158,10 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Tokens_that_cannot_be_converted_by_multiple_arity_argument_flow_to_next_multiple_arity_argument()
             {
-                var ints = new CliArgument<int[]>("ints");
-                var strings = new CliArgument<string[]>("strings");
+                var ints = new Argument<int[]>("ints");
+                var strings = new Argument<string[]>("strings");
 
-                var root = new CliRootCommand
+                var root = new RootCommand
                 {
                     ints,
                     strings
@@ -185,10 +185,10 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Tokens_that_cannot_be_converted_by_multiple_arity_argument_flow_to_next_single_arity_argument()
             {
-                var ints = new CliArgument<int[]>("arg1");
-                var strings = new CliArgument<string>("arg2");
+                var ints = new Argument<int[]>("arg1");
+                var strings = new Argument<string>("arg2");
 
-                var root = new CliRootCommand
+                var root = new RootCommand
                 {
                     ints,
                     strings
@@ -218,16 +218,16 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Unsatisfied_subsequent_argument_with_min_arity_0_parses_as_default_value()
             {
-                var arg1 = new CliArgument<string>("arg1")
+                var arg1 = new Argument<string>("arg1")
                 {
                     Arity = ArgumentArity.ExactlyOne
                 };
-                var arg2 = new CliArgument<string>("arg2")
+                var arg2 = new Argument<string>("arg2")
                 {
                     Arity = ArgumentArity.ZeroOrOne,
                     DefaultValueFactory = (_) => "the-default"
                 };
-                var rootCommand = new CliRootCommand
+                var rootCommand = new RootCommand
                 {
                     arg1,
                     arg2,
@@ -242,13 +242,13 @@ namespace System.CommandLine.Tests
             [Fact] // https://github.com/dotnet/command-line-api/issues/1403
             public void Unsatisfied_subsequent_argument_with_min_arity_1_parses_as_default_value()
             {
-                CliArgument<string> arg1 = new(name: "arg1");
-                CliArgument<string> arg2 = new(name: "arg2")
+                Argument<string> arg1 = new(name: "arg1");
+                Argument<string> arg2 = new(name: "arg2")
                 {
                     DefaultValueFactory = (_) => "the-default"
                 };
 
-                var rootCommand = new CliRootCommand
+                var rootCommand = new RootCommand
                 {
                     arg1,
                     arg2,
@@ -263,11 +263,11 @@ namespace System.CommandLine.Tests
             [Fact] // https://github.com/dotnet/command-line-api/issues/1395
             public void When_subsequent_argument_with_ZeroOrOne_arity_is_not_provided_then_parse_is_correct()
             {
-                var argument1 = new CliArgument<string>("arg1");
-                var rootCommand = new CliRootCommand
+                var argument1 = new Argument<string>("arg1");
+                var rootCommand = new RootCommand
                 {
                     argument1,
-                    new CliArgument<string>("arg2")
+                    new Argument<string>("arg2")
                     {
                         Arity = ArgumentArity.ZeroOrOne
                     },
@@ -288,15 +288,15 @@ namespace System.CommandLine.Tests
             public void When_there_are_not_enough_tokens_for_all_arguments_then_the_correct_number_of_errors_is_reported(
                 string providedArgs)
             {
-                var command = new CliCommand("command")
+                var command = new Command("command")
                 {
-                    new CliArgument<string>("arg1"),
-                    new CliArgument<string>("arg2"),
-                    new CliArgument<string>("arg3"),
-                    new CliArgument<string>("arg4")
+                    new Argument<string>("arg1"),
+                    new Argument<string>("arg2"),
+                    new Argument<string>("arg3"),
+                    new Argument<string>("arg4")
                 };
 
-                var result = CliParser.Parse(command, providedArgs);
+                var result = CommandLineParser.Parse(command, providedArgs);
 
                 result
                     .Errors

--- a/src/System.CommandLine.Tests/ParserTests.MultiplePositions.cs
+++ b/src/System.CommandLine.Tests/ParserTests.MultiplePositions.cs
@@ -17,11 +17,11 @@ namespace System.CommandLine.Tests
             [InlineData("outer inner xyz")]
             public void An_argument_can_be_specified_in_more_than_one_position(string commandLine)
             {
-                var argument = new CliArgument<string>("the-argument");
+                var argument = new Argument<string>("the-argument");
 
-                var command = new CliCommand("outer")
+                var command = new Command("outer")
                 {
-                    new CliCommand("inner")
+                    new Command("inner")
                     {
                         argument
                     },
@@ -45,11 +45,11 @@ namespace System.CommandLine.Tests
             [InlineData("outer inner xyz")]
             public void When_an_argument_is_shared_between_an_outer_and_inner_command_then_specifying_in_one_does_not_result_in_error_on_other(string commandLine)
             {
-                var argument = new CliArgument<string>("the-argument");
+                var argument = new Argument<string>("the-argument");
 
-                var command = new CliCommand("outer")
+                var command = new Command("outer")
                 {
-                    new CliCommand("inner")
+                    new Command("inner")
                     {
                         argument
                     },
@@ -66,11 +66,11 @@ namespace System.CommandLine.Tests
             [InlineData("outer inner --the-option xyz")]
             public void An_option_can_be_specified_in_more_than_one_position(string commandLine)
             {
-                var option = new CliOption<string>("--the-option");
+                var option = new Option<string>("--the-option");
 
-                var command = new CliCommand("outer")
+                var command = new Command("outer")
                 {
-                    new CliCommand("inner")
+                    new Command("inner")
                     {
                         option
                     },
@@ -94,11 +94,11 @@ namespace System.CommandLine.Tests
             [InlineData("outer inner --the-option xyz")]
             public void When_an_option_is_shared_between_an_outer_and_inner_command_then_specifying_in_one_does_not_result_in_error_on_other(string commandLine)
             {
-                var option = new CliOption<string>("--the-option");
+                var option = new Option<string>("--the-option");
 
-                var command = new CliCommand("outer")
+                var command = new Command("outer")
                 {
-                    new CliCommand("inner")
+                    new Command("inner")
                     {
                         option
                     },
@@ -117,17 +117,17 @@ namespace System.CommandLine.Tests
                 string commandLine,
                 string expectedParent)
             {
-                var reusedCommand = new CliCommand("reused");
+                var reusedCommand = new Command("reused");
                 reusedCommand.SetAction((_) => { });
-                reusedCommand.Add(new CliOption<string>("--the-option"));
+                reusedCommand.Add(new Option<string>("--the-option"));
 
-                var outer = new CliCommand("outer")
+                var outer = new Command("outer")
                 {
-                    new CliCommand("inner1")
+                    new Command("inner1")
                     {
                         reusedCommand
                     },
-                    new CliCommand("inner2")
+                    new Command("inner2")
                     {
                         reusedCommand
                     }
@@ -150,25 +150,25 @@ namespace System.CommandLine.Tests
             [Fact]
             public void An_option_can_have_multiple_parents_with_the_same_name()
             {
-                var option = new CliOption<string>("--the-option");
+                var option = new Option<string>("--the-option");
 
-                var sprocket = new CliCommand("sprocket")
+                var sprocket = new Command("sprocket")
                 {
-                    new CliCommand("add")
+                    new Command("add")
                     {
                         option
                     }
                 };
 
-                var widget = new CliCommand("widget")
+                var widget = new Command("widget")
                 {
-                    new CliCommand("add")
+                    new Command("add")
                     {
                         option
                     }
                 };
 
-                var root = new CliRootCommand
+                var root = new RootCommand
                 {
                     sprocket,
                     widget

--- a/src/System.CommandLine.Tests/ParserTests.RootCommandAndArg0.cs
+++ b/src/System.CommandLine.Tests/ParserTests.RootCommandAndArg0.cs
@@ -15,11 +15,11 @@ public partial class ParserTests
         [Fact]
         public void When_parsing_a_string_array_a_root_command_can_be_omitted_from_the_parsed_args()
         {
-            var command = new CliCommand("outer")
+            var command = new Command("outer")
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliOption<string>("-x")
+                    new Option<string>("-x")
                 }
             };
 
@@ -32,31 +32,31 @@ public partial class ParserTests
         [Fact]
         public void When_parsing_a_string_array_input_then_a_full_path_to_an_executable_is_not_matched_by_the_root_command()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliOption<string>("-x")
+                    new Option<string>("-x")
                 }
             };
 
             command.Parse(Split("inner -x hello")).Errors.Should().BeEmpty();
 
-            var parserResult = command.Parse(Split($"\"{CliRootCommand.ExecutablePath}\" inner -x hello"));
+            var parserResult = command.Parse(Split($"\"{RootCommand.ExecutablePath}\" inner -x hello"));
             parserResult
                .Errors
                .Should()
-               .ContainSingle(e => e.Message == LocalizationResources.UnrecognizedCommandOrArgument(CliRootCommand.ExecutablePath));
+               .ContainSingle(e => e.Message == LocalizationResources.UnrecognizedCommandOrArgument(RootCommand.ExecutablePath));
         }
 
         [Fact]
         public void When_parsing_an_unsplit_string_a_root_command_can_be_omitted_from_the_parsed_args()
         {
-            var command = new CliCommand("outer")
+            var command = new Command("outer")
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliOption<string>("-x")
+                    new Option<string>("-x")
                 }
             };
 
@@ -69,38 +69,38 @@ public partial class ParserTests
         [Fact]
         public void When_parsing_an_unsplit_string_then_input_a_full_path_to_an_executable_is_matched_by_the_root_command()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliOption<string>("-x")
+                    new Option<string>("-x")
                 }
             };
 
-            var result2 = command.Parse($"\"{CliRootCommand.ExecutablePath}\" inner -x hello");
+            var result2 = command.Parse($"\"{RootCommand.ExecutablePath}\" inner -x hello");
 
-            result2.RootCommandResult.IdentifierToken.Value.Should().Be(CliRootCommand.ExecutablePath);
+            result2.RootCommandResult.IdentifierToken.Value.Should().Be(RootCommand.ExecutablePath);
         }
 
         [Fact]
         public void When_parsing_an_unsplit_string_then_a_renamed_RootCommand_can_be_omitted_from_the_parsed_args()
         {
-            var rootCommand = new CliCommand("outer")
+            var rootCommand = new Command("outer")
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliOption<string>("-x")
+                    new Option<string>("-x")
                 }
             };
 
             var result1 = rootCommand.Parse("inner -x hello");
             var result2 = rootCommand.Parse("outer inner -x hello");
-            var result3 = rootCommand.Parse($"{CliRootCommand.ExecutableName} inner -x hello");
+            var result3 = rootCommand.Parse($"{RootCommand.ExecutableName} inner -x hello");
 
             result2.RootCommandResult.Command.Should().BeSameAs(result1.RootCommandResult.Command);
             result3.RootCommandResult.Command.Should().BeSameAs(result1.RootCommandResult.Command);
         }
 
-        string[] Split(string value) => CliParser.SplitCommandLine(value).ToArray();
+        string[] Split(string value) => CommandLineParser.SplitCommandLine(value).ToArray();
     }
 }

--- a/src/System.CommandLine.Tests/ParserTests.SetupErrors.cs
+++ b/src/System.CommandLine.Tests/ParserTests.SetupErrors.cs
@@ -13,9 +13,9 @@ public partial class ParserTests
         [Fact]
         public void When_command_names_are_defined_more_than_once_on_the_same_parent_then_it_throws_on_parse()
         {
-            var rootCommand = new CliRootCommand();
-            rootCommand.Add(new CliCommand("one"));
-            rootCommand.Add(new CliCommand("one"));
+            var rootCommand = new RootCommand();
+            rootCommand.Add(new Command("one"));
+            rootCommand.Add(new Command("one"));
 
             rootCommand.Invoking(c => c.Parse("")).Should().Throw<ArgumentException>();
         }
@@ -23,9 +23,9 @@ public partial class ParserTests
         [Fact]
         public void When_command_names_collide_with_command_aliases_on_the_same_parent_then_it_throws_on_parse()
         {
-            var rootCommand = new CliRootCommand();
-            rootCommand.Add(new CliCommand("one"));
-            var commandTwo = new CliCommand("two");
+            var rootCommand = new RootCommand();
+            rootCommand.Add(new Command("one"));
+            var commandTwo = new Command("two");
             rootCommand.Add(commandTwo);
             commandTwo.Aliases.Add("one");
 
@@ -35,9 +35,9 @@ public partial class ParserTests
         [Fact(Skip = "https://github.com/dotnet/command-line-api/issues/2223")]
         public void When_command_names_collide_with_option_names_it_throws_on_parse()
         {
-            var rootCommand = new CliRootCommand();
-            rootCommand.Add(new CliCommand("one"));
-            rootCommand.Add(new CliOption<int>("one"));
+            var rootCommand = new RootCommand();
+            rootCommand.Add(new Command("one"));
+            rootCommand.Add(new Option<int>("one"));
 
             rootCommand.Invoking(c => c.Parse("")).Should().Throw<ArgumentException>();
         }
@@ -45,9 +45,9 @@ public partial class ParserTests
         [Fact(Skip = "https://github.com/dotnet/command-line-api/issues/2223")]
         public void When_command_names_collide_with_option_aliases_it_throws_on_parse()
         {
-            var rootCommand = new CliRootCommand();
-            rootCommand.Add(new CliCommand("one"));
-            var option = new CliOption<int>("two");
+            var rootCommand = new RootCommand();
+            rootCommand.Add(new Command("one"));
+            var option = new Option<int>("two");
             option.Aliases.Add("one");
             rootCommand.Add(option);
 
@@ -57,10 +57,10 @@ public partial class ParserTests
         [Fact]
         public void When_command_names_collide_with_directive_names_it_does_not_throw_on_parse()
         {
-            var rootCommand = new CliRootCommand();
-            rootCommand.Add(new CliCommand("one"));
-            rootCommand.Add(new CliDirective("one"));
-            var cliConfiguration = new CliConfiguration(rootCommand);
+            var rootCommand = new RootCommand();
+            rootCommand.Add(new Command("one"));
+            rootCommand.Add(new Directive("one"));
+            var cliConfiguration = new CommandLineConfiguration(rootCommand);
 
             rootCommand.Invoking(c => c.Parse("", cliConfiguration)).Should().NotThrow();
         }

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -16,18 +16,18 @@ namespace System.CommandLine.Tests
 {
     public partial class ParserTests
     {
-        private T GetValue<T>(ParseResult parseResult, CliOption<T> option)
+        private T GetValue<T>(ParseResult parseResult, Option<T> option)
             => parseResult.GetValue(option);
 
-        private T GetValue<T>(ParseResult parseResult, CliArgument<T> argument)
+        private T GetValue<T>(ParseResult parseResult, Argument<T> argument)
             => parseResult.GetValue(argument);
 
         [Fact]
         public void An_option_can_be_checked_by_object_instance()
         {
-            var option = new CliOption<bool>("--flag");
-            var option2 = new CliOption<bool>("--flag2");
-            var result = new CliRootCommand { option, option2 }
+            var option = new Option<bool>("--flag");
+            var option2 = new Option<bool>("--flag2");
+            var result = new RootCommand { option, option2 }
                 .Parse("--flag");
 
             result.GetResult(option).Should().NotBeNull();
@@ -37,11 +37,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Two_options_are_parsed_correctly()
         {
-            var optionOne = new CliOption<bool>("-o", "--one");
+            var optionOne = new Option<bool>("-o", "--one");
 
-            var optionTwo = new CliOption<bool>("-t", "--two");
+            var optionTwo = new Option<bool>("-t", "--two");
 
-            var result = new CliRootCommand { optionOne, optionTwo }.Parse("-o -t");
+            var result = new RootCommand { optionOne, optionTwo }.Parse("-o -t");
 
             result.GetResult(optionOne).Should().NotBeNull();
             result.GetResult(optionTwo).Should().NotBeNull();
@@ -52,7 +52,7 @@ namespace System.CommandLine.Tests
         [InlineData("/")]
         public void When_a_token_is_just_a_prefix_then_an_error_is_returned(string prefix)
         {
-            var result = new CliRootCommand().Parse(prefix);
+            var result = new RootCommand().Parse(prefix);
 
             result.Errors
                   .Select(e => e.Message)
@@ -63,9 +63,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Short_form_options_can_be_specified_using_equals_delimiter()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
 
-            var result = new CliRootCommand { option }.Parse("-x=some-value");
+            var result = new RootCommand { option }.Parse("-x=some-value");
 
             result.Errors.Should().BeEmpty();
 
@@ -75,9 +75,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Long_form_options_can_be_specified_using_equals_delimiter()
         {
-            var option = new CliOption<string>("--hello");
+            var option = new Option<string>("--hello");
 
-            var result = new CliRootCommand { option }.Parse("--hello=there");
+            var result = new RootCommand { option }.Parse("--hello=there");
 
             result.Errors.Should().BeEmpty();
 
@@ -87,9 +87,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Short_form_options_can_be_specified_using_colon_delimiter()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
 
-            var result = new CliRootCommand { option }.Parse("-x:some-value");
+            var result = new RootCommand { option }.Parse("-x:some-value");
 
             result.Errors.Should().BeEmpty();
 
@@ -99,9 +99,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Long_form_options_can_be_specified_using_colon_delimiter()
         {
-            var option = new CliOption<string>("--hello");
+            var option = new Option<string>("--hello");
 
-            var result = new CliRootCommand { option }.Parse("--hello:there");
+            var result = new RootCommand { option }.Parse("--hello:there");
 
             result.Errors.Should().BeEmpty();
 
@@ -111,10 +111,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_short_forms_can_be_bundled()
         {
-            var command = new CliCommand("the-command");
-            command.Options.Add(new CliOption<bool>("-x"));
-            command.Options.Add(new CliOption<bool>("-y"));
-            command.Options.Add(new CliOption<bool>("-z"));
+            var command = new Command("the-command");
+            command.Options.Add(new Option<bool>("-x"));
+            command.Options.Add(new Option<bool>("-y"));
+            command.Options.Add(new Option<bool>("-z"));
 
             var result = command.Parse("the-command -xyz");
 
@@ -128,17 +128,17 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_short_forms_do_not_get_unbundled_if_unbundling_is_turned_off()
         {
-            CliRootCommand rootCommand = new CliRootCommand()
+            RootCommand rootCommand = new RootCommand()
             {
-                new CliCommand("the-command")
+                new Command("the-command")
                 {
-                    new CliOption<bool>("-x"),
-                    new CliOption<bool>("-y"),
-                    new CliOption<bool>("-z")
+                    new Option<bool>("-x"),
+                    new Option<bool>("-y"),
+                    new Option<bool>("-z")
                 }
             };
 
-            CliConfiguration configuration = new (rootCommand)
+            CommandLineConfiguration configuration = new (rootCommand)
             {
                 EnablePosixBundling = false
             };
@@ -153,13 +153,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_long_forms_do_not_get_unbundled()
         {
-            CliCommand command =
-                new CliCommand("the-command")
+            Command command =
+                new Command("the-command")
                 {
-                    new CliOption<bool>("--xyz"),
-                    new CliOption<bool>("-x"),
-                    new CliOption<bool>("-y"),
-                    new CliOption<bool>("-z")
+                    new Option<bool>("--xyz"),
+                    new Option<bool>("-x"),
+                    new Option<bool>("-y"),
+                    new Option<bool>("-z")
                 };
 
             var result = command.Parse("the-command --xyz");
@@ -174,14 +174,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_do_not_get_unbundled_unless_all_resulting_options_would_be_valid_for_the_current_command()
         {
-            var outer = new CliCommand("outer");
-            outer.Options.Add(new CliOption<bool>("-a"));
-            var inner = new CliCommand("inner")
+            var outer = new Command("outer");
+            outer.Options.Add(new Option<bool>("-a"));
+            var inner = new Command("inner")
             {
-                new CliArgument<string[]>("arg")
+                new Argument<string[]>("arg")
             };
-            inner.Options.Add(new CliOption<bool>("-b"));
-            inner.Options.Add(new CliOption<bool>("-c"));
+            inner.Options.Add(new Option<bool>("-b"));
+            inner.Options.Add(new Option<bool>("-c"));
             outer.Subcommands.Add(inner);
 
             ParseResult result = outer.Parse("outer inner -abc");
@@ -196,11 +196,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Required_option_arguments_are_not_unbundled()
         {
-            var optionA = new CliOption<string>("-a");
-            var optionB = new CliOption<bool>("-b");
-            var optionC = new CliOption<bool>("-c");
+            var optionA = new Option<string>("-a");
+            var optionB = new Option<bool>("-b");
+            var optionC = new Option<bool>("-c");
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionA,
                 optionB,
@@ -218,11 +218,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Last_bundled_option_can_accept_argument_with_no_separator()
         {
-            var optionA = new CliOption<bool>("-a");
-            var optionB = new CliOption<string>("-b") { Arity = ArgumentArity.ZeroOrOne };
-            var optionC = new CliOption<string>("-c") { Arity = ArgumentArity.ExactlyOne };
+            var optionA = new Option<bool>("-a");
+            var optionB = new Option<string>("-b") { Arity = ArgumentArity.ZeroOrOne };
+            var optionC = new Option<string>("-c") { Arity = ArgumentArity.ExactlyOne };
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionA,
                 optionB,
@@ -242,11 +242,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Last_bundled_option_can_accept_argument_with_equals_separator()
         {
-            var optionA = new CliOption<bool>("-a");
-            var optionB = new CliOption<string>("-b") { Arity = ArgumentArity.ZeroOrOne };
-            var optionC = new CliOption<string>("-c") { Arity = ArgumentArity.ExactlyOne };
+            var optionA = new Option<bool>("-a");
+            var optionB = new Option<string>("-b") { Arity = ArgumentArity.ZeroOrOne };
+            var optionC = new Option<string>("-c") { Arity = ArgumentArity.ExactlyOne };
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionA,
                 optionB,
@@ -266,11 +266,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Last_bundled_option_can_accept_argument_with_colon_separator()
         {
-            var optionA = new CliOption<bool>("-a");
-            var optionB = new CliOption<string>("-b") { Arity = ArgumentArity.ZeroOrOne };
-            var optionC = new CliOption<string>("-c") { Arity = ArgumentArity.ExactlyOne };
+            var optionA = new Option<bool>("-a");
+            var optionB = new Option<string>("-b") { Arity = ArgumentArity.ZeroOrOne };
+            var optionC = new Option<string>("-c") { Arity = ArgumentArity.ExactlyOne };
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionA,
                 optionB,
@@ -290,11 +290,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Invalid_char_in_bundle_causes_rest_to_be_interpreted_as_value()
         {
-            var optionA = new CliOption<bool>("-a");
-            var optionB = new CliOption<string>("-b") { Arity = ArgumentArity.ZeroOrOne };
-            var optionC = new CliOption<string>("-c") { Arity = ArgumentArity.ExactlyOne };
+            var optionA = new Option<bool>("-a");
+            var optionB = new Option<string>("-b") { Arity = ArgumentArity.ZeroOrOne };
+            var optionC = new Option<string>("-c") { Arity = ArgumentArity.ExactlyOne };
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionA,
                 optionB,
@@ -316,9 +316,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parser_root_Options_can_be_specified_multiple_times_and_their_arguments_are_collated()
         {
-            var animalsOption = new CliOption<string[]>("-a", "--animals");
-            var vegetablesOption = new CliOption<string[]>("-v", "--vegetables");
-            var parser = new CliRootCommand
+            var animalsOption = new Option<string[]>("-a", "--animals");
+            var vegetablesOption = new Option<string[]>("-v", "--vegetables");
+            var parser = new RootCommand
             {
                 animalsOption,
                 vegetablesOption
@@ -342,11 +342,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_can_be_specified_multiple_times_and_their_arguments_are_collated()
         {
-            var animalsOption = new CliOption<string[]>("-a", "--animals");
+            var animalsOption = new Option<string[]>("-a", "--animals");
             animalsOption.AcceptOnlyFromAmong("dog", "cat", "sheep");
-            var vegetablesOption = new CliOption<string[]>("-v", "--vegetables");
-            CliCommand command =
-                new CliCommand("the-command") {
+            var vegetablesOption = new Option<string[]>("-v", "--vegetables");
+            Command command =
+                new Command("the-command") {
                     animalsOption,
                     vegetablesOption
                 };
@@ -369,16 +369,16 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_is_not_respecified_but_limit_is_reached_then_the_following_token_is_considered_an_argument_to_the_parent_command()
         {
-            var animalsOption = new CliOption<string[]>("-a", "--animals");
+            var animalsOption = new Option<string[]>("-a", "--animals");
 
-            var vegetablesOption = new CliOption<string[]>("-v", "--vegetables");
+            var vegetablesOption = new Option<string[]>("-v", "--vegetables");
 
-            CliCommand command = 
-                new CliCommand("the-command")
+            Command command = 
+                new Command("the-command")
                 {
                     animalsOption,
                     vegetablesOption,
-                    new CliArgument<string[]>("arg")
+                    new Argument<string[]>("arg")
                 };
 
             var result = command.Parse("the-command -a cat some-arg -v carrot");
@@ -405,10 +405,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_with_multiple_options_is_parsed_correctly()
         {
-            var command = new CliCommand("outer")
+            var command = new Command("outer")
             {
-                new CliOption<string>("--inner1"),
-                new CliOption<string>("--inner2")
+                new Option<string>("--inner1"),
+                new Option<string>("--inner2")
             };
 
             var result = command.Parse("outer --inner1 argument1 --inner2 argument2");
@@ -430,10 +430,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Relative_order_of_arguments_and_options_within_a_command_does_not_matter()
         {
-            var command = new CliCommand("move")
+            var command = new Command("move")
             {
-                new CliArgument<string[]>("arg"),
-                new CliOption<string>("-X")
+                new Argument<string[]>("arg"),
+                new Option<string>("-X")
             };
 
             // option before args
@@ -473,13 +473,13 @@ namespace System.CommandLine.Tests
         [InlineData("not a valid command line --one 1")]
         public void Original_order_of_tokens_is_preserved_in_ParseResult_Tokens(string commandLine)
         {
-            var rawSplit = CliParser.SplitCommandLine(commandLine);
+            var rawSplit = CommandLineParser.SplitCommandLine(commandLine);
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
                           {
-                              new CliArgument<string[]>("arg"),
-                              new CliOption<string>("--one"),
-                              new CliOption<string[]>("--many")
+                              new Argument<string[]>("arg"),
+                              new Option<string>("--one"),
+                              new Option<string[]>("--many")
                           };
 
             var result = command.Parse(commandLine);
@@ -490,13 +490,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_outer_command_with_the_same_name_does_not_capture()
         {
-            var command = new CliCommand("one")
+            var command = new Command("one")
                           {
-                              new CliCommand("two")
+                              new Command("two")
                               {
-                                  new CliCommand("three")
+                                  new Command("three")
                               },
-                              new CliCommand("three")
+                              new Command("three")
                           };
 
             ParseResult result = command.Parse("one two three");
@@ -507,13 +507,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void An_inner_command_with_the_same_name_does_not_capture()
         {
-            var command = new CliCommand("one")
+            var command = new Command("one")
                           {
-                              new CliCommand("two")
+                              new Command("two")
                               {
-                                  new CliCommand("three")
+                                  new Command("three")
                               },
-                              new CliCommand("three")
+                              new Command("three")
                           };
 
             ParseResult result = command.Parse("one three");
@@ -524,13 +524,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_nested_commands_all_accept_arguments_then_the_nearest_captures_the_arguments()
         {
-            var command = new CliCommand(
+            var command = new Command(
                 "outer")
             {
-                new CliArgument<string[]>("arg1"),
-                new CliCommand("inner")
+                new Argument<string[]>("arg1"),
+                new Command("inner")
                 {
-                    new CliArgument<string[]>("arg2")
+                    new Argument<string[]>("arg2")
                 }
             };
 
@@ -552,19 +552,19 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Nested_commands_with_colliding_names_cannot_both_be_applied()
         {
-            var command = new CliCommand("outer")
+            var command = new Command("outer")
             {
-                new CliArgument<string>("arg1"),
-                new CliCommand("non-unique")
+                new Argument<string>("arg1"),
+                new Command("non-unique")
                 {
-                    new CliArgument<string>("arg2")
+                    new Argument<string>("arg2")
                 },
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliArgument<string>("arg3"),
-                    new CliCommand("non-unique")
+                    new Argument<string>("arg3"),
+                    new Command("non-unique")
                     {
-                        new CliArgument<string>("arg4")
+                        new Argument<string>("arg4")
                     }
                 }
             };
@@ -577,11 +577,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_child_option_will_not_accept_arg_then_parent_can()
         {
-            var option = new CliOption<bool>("-x");
-            var command = new CliCommand("the-command")
+            var option = new Option<bool>("-x");
+            var command = new Command("the-command")
                          {
                              option,
-                             new CliArgument<string>("arg")
+                             new Argument<string>("arg")
                          };
 
             var result = command.Parse("the-command -x the-argument");
@@ -594,8 +594,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_parent_option_will_not_accept_arg_then_child_can()
         {
-            var option = new CliOption<string>("-x");
-            var command = new CliCommand("the-command")
+            var option = new Option<string>("-x");
+            var command = new Command("the-command")
             {
                 option
             };
@@ -609,11 +609,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Required_arguments_on_parent_commands_do_not_create_parse_errors_when_an_inner_command_is_specified()
         {
-            var child = new CliCommand("child");
+            var child = new Command("child");
 
-            var parent = new CliCommand("parent")
+            var parent = new Command("parent")
             {
-                new CliArgument<string>("arg"),
+                new Argument<string>("arg"),
                 child
             };
 
@@ -625,12 +625,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Required_arguments_on_grandparent_commands_do_not_create_parse_errors_when_an_inner_command_is_specified()
         {
-            var grandchild = new CliCommand("grandchild");
+            var grandchild = new Command("grandchild");
 
-            var grandparent = new CliCommand("grandparent")
+            var grandparent = new Command("grandparent")
             {
-                new CliArgument<string>("arg"),
-                new CliCommand("parent")
+                new Argument<string>("arg"),
+                new Command("parent")
                 {
                     grandchild
                 }
@@ -644,13 +644,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_options_with_the_same_name_are_defined_on_parent_and_child_commands_and_specified_at_the_end_then_it_attaches_to_the_inner_command()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
                         {
-                            new CliCommand("inner")
+                            new Command("inner")
                             {
-                                new CliOption<bool>("-x")
+                                new Option<bool>("-x")
                             },
-                            new CliOption<bool>("-x")
+                            new Option<bool>("-x")
                         };
 
             ParseResult result = outer.Parse("outer inner -x");
@@ -672,10 +672,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_options_with_the_same_name_are_defined_on_parent_and_child_commands_and_specified_in_between_then_it_attaches_to_the_outer_command()
         {
-            var outer = new CliCommand("outer");
-            outer.Options.Add(new CliOption<bool>("-x"));
-            var inner = new CliCommand("inner");
-            inner.Options.Add(new CliOption<bool>("-x"));
+            var outer = new Command("outer");
+            outer.Options.Add(new Option<bool>("-x"));
+            var inner = new Command("inner");
+            inner.Options.Add(new Option<bool>("-x"));
             outer.Subcommands.Add(inner);
 
             var result = outer.Parse("outer -x inner");
@@ -697,12 +697,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Arguments_only_apply_to_the_nearest_command()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
-                new CliArgument<string>("arg1"),
-                new CliCommand("inner")
+                new Argument<string>("arg1"),
+                new Command("inner")
                 {
-                    new CliArgument<string>("arg2")
+                    new Argument<string>("arg2")
                 }
             };
 
@@ -726,12 +726,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_only_apply_to_the_nearest_command()
         {
-            var outerOption = new CliOption<string>("-x");
-            var innerOption = new CliOption<string>("-x");
+            var outerOption = new Option<string>("-x");
+            var innerOption = new Option<string>("-x");
 
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
                         {
-                            new CliCommand("inner")
+                            new Command("inner")
                             {
                                 innerOption
                             },
@@ -749,12 +749,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Subsequent_occurrences_of_tokens_matching_command_names_are_parsed_as_arguments()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliCommand("complete")
+                new Command("complete")
                 {
-                    new CliArgument<string>("arg"),
-                    new CliOption<int>("--position")
+                    new Argument<string>("arg"),
+                    new Option<int>("--position")
                 }
             };
 
@@ -775,9 +775,9 @@ namespace System.CommandLine.Tests
             const string commandText =
                 @"rm ""/temp/the file.txt""";
 
-            CliCommand command = new ("rm")
+            Command command = new ("rm")
             {
-                new CliArgument<string[]>("arg")
+                new Argument<string[]>("arg")
             };
 
             var result = command.Parse(commandText);
@@ -795,9 +795,9 @@ namespace System.CommandLine.Tests
             const string commandText =
                 @"rm ""c:\temp\the file.txt\""";
 
-            CliCommand command = new("rm")
+            Command command = new("rm")
             {
-                new CliArgument<string[]>("arg")
+                new Argument<string[]>("arg")
             };
 
             ParseResult result = command.Parse(commandText);
@@ -811,12 +811,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Commands_can_have_default_argument_values()
         {
-            var argument = new CliArgument<string>("the-arg")
+            var argument = new Argument<string>("the-arg")
             {
                 DefaultValueFactory = (_) => "default"
             };
 
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 argument
             };
@@ -831,8 +831,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_with_a_default_value_is_not_matched_then_the_option_can_still_be_accessed_as_though_it_had_been_applied()
         {
-            var command = new CliCommand("command");
-            var option = new CliOption<string>("-o", "--option")
+            var command = new Command("command");
+            var option = new Option<string>("-o", "--option")
             {
                 DefaultValueFactory = (_) => "the-default"
             };
@@ -847,12 +847,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_with_a_default_value_is_not_matched_then_the_option_result_is_implicit()
         {
-            var option = new CliOption<string>("-o", "--option")
+            var option = new Option<string>("-o", "--option")
             {
                 DefaultValueFactory = (_) => "the-default"
             };
 
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 option
             };
@@ -868,12 +868,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_with_a_default_value_is_not_matched_then_there_are_no_tokens()
         {
-            var option = new CliOption<string>("-o")
+            var option = new Option<string>("-o")
             {
                 DefaultValueFactory = (_) => "the-default"
             };
 
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 option
             };
@@ -883,18 +883,18 @@ namespace System.CommandLine.Tests
             result.GetResult(option)
                   .IdentifierToken
                   .Should()
-                  .BeEquivalentTo(default(CliToken));
+                  .BeEquivalentTo(default(Token));
         }
 
         [Fact]
         public void When_an_argument_with_a_default_value_is_not_matched_then_there_are_no_tokens()
         {
-            var argument = new CliArgument<string>("o")
+            var argument = new Argument<string>("o")
             {
                 DefaultValueFactory = (_) => "the-default"
             };
 
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 argument
             };
@@ -909,12 +909,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_default_argument_value_does_not_override_parsed_value()
         {
-            var argument = new CliArgument<DirectoryInfo>("the-arg")
+            var argument = new Argument<DirectoryInfo>("the-arg")
             {
                 DefaultValueFactory = (_) => new DirectoryInfo(Directory.GetCurrentDirectory())
             };
 
-            var command = new CliCommand("inner")
+            var command = new Command("inner")
             {
                 argument
             };
@@ -930,11 +930,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Unmatched_tokens_that_look_like_options_are_not_split_into_smaller_tokens()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliArgument<string[]>("arg")
+                    new Argument<string[]>("arg")
                     {
                         Arity = ArgumentArity.OneOrMore
                     }
@@ -953,9 +953,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void The_default_behavior_of_unmatched_tokens_resulting_in_errors_can_be_turned_off()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<string>("arg")
+                new Argument<string>("arg")
             };
             command.TreatUnmatchedTokensAsErrors = false;
 
@@ -971,18 +971,18 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_and_Command_can_have_the_same_alias()
         {
-            var innerCommand = new CliCommand("inner")
+            var innerCommand = new Command("inner")
             {
-                new CliArgument<string[]>("arg1")
+                new Argument<string[]>("arg1")
             };
 
-            var option = new CliOption<bool>("--inner");
+            var option = new Option<bool>("--inner");
 
-            var outerCommand = new CliCommand("outer")
+            var outerCommand = new Command("outer")
             {
                 innerCommand,
                 option,
-                new CliArgument<string[]>("arg2")
+                new Argument<string[]>("arg2")
             };
 
             outerCommand.Parse("outer inner")
@@ -1017,10 +1017,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Options_can_have_the_same_alias_differentiated_only_by_prefix()
         {
-            var option1 = new CliOption<bool>("-a");
-            var option2 = new CliOption<bool>("--a");
+            var option1 = new Option<bool>("-a");
+            var option2 = new Option<bool>("--a");
 
-            var parser = new CliRootCommand
+            var parser = new RootCommand
             {
                 option1, 
                 option2
@@ -1049,9 +1049,9 @@ namespace System.CommandLine.Tests
             string arg1,
             string arg2)
         {
-            var option = new CliOption<string[]>("-x");
+            var option = new Option<string[]>("-x");
 
-            var parseResult = new CliRootCommand { option }.Parse(new[] { arg1, arg2 });
+            var parseResult = new RootCommand { option }.Parse(new[] { arg1, arg2 });
 
             parseResult
                 .GetResult(option)
@@ -1064,11 +1064,11 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1445
         public void Trailing_option_delimiters_are_ignored()
         {
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
-                new CliCommand("subcommand")
+                new Command("subcommand")
                 {
-                    new CliOption<DirectoryInfo>("--directory")
+                    new Option<DirectoryInfo>("--directory")
                 }
             };
 
@@ -1090,12 +1090,12 @@ namespace System.CommandLine.Tests
         [InlineData("-x:-y")]
         public void Option_arguments_can_start_with_prefixes_that_make_them_look_like_options(string input)
         {
-            var optionX = new CliOption<string>("-x");
+            var optionX = new Option<string>("-x");
 
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 optionX,
-                new CliOption<string>("-z")
+                new Option<string>("-z")
             };
 
             var result = command.Parse(input);
@@ -1106,11 +1106,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_arguments_can_start_with_prefixes_that_make_them_look_like_bundled_options()
         {
-            var optionA = new CliOption<string>("-a");
-            var optionB = new CliOption<bool>("-b");
-            var optionC = new CliOption<bool>("-c");
+            var optionA = new Option<string>("-a");
+            var optionB = new Option<bool>("-b");
+            var optionC = new Option<bool>("-c");
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionA,
                 optionB,
@@ -1127,10 +1127,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_arguments_can_match_subcommands()
         {
-            var optionA = new CliOption<string>("-a");
-            var root = new CliRootCommand
+            var optionA = new Option<string>("-a");
+            var root = new RootCommand
             {
-                new CliCommand("subcommand"),
+                new Command("subcommand"),
                 optionA
             };
 
@@ -1143,12 +1143,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Arguments_can_match_subcommands()
         {
-            var argument = new CliArgument<string[]>("arg");
-            var subcommand = new CliCommand("subcommand")
+            var argument = new Argument<string[]>("arg");
+            var subcommand = new Command("subcommand")
             {
                 argument
             };
-            var root = new CliRootCommand
+            var root = new RootCommand
             {
                 subcommand
             };
@@ -1167,12 +1167,12 @@ namespace System.CommandLine.Tests
         [InlineData("-x:-y")]
         public void Option_arguments_can_match_the_aliases_of_sibling_options_when_non_space_argument_delimiter_is_used(string input)
         {
-            var optionX = new CliOption<string>("-x");
+            var optionX = new Option<string>("-x");
 
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 optionX,
-                new CliOption<string>("-y")
+                new Option<string>("-y")
             };
 
             var result = command.Parse(input);
@@ -1184,9 +1184,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Single_option_arguments_that_match_option_aliases_are_parsed_correctly()
         {
-            var optionX = new CliOption<string>("-x");
+            var optionX = new Option<string>("-x");
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionX
             };
@@ -1207,10 +1207,10 @@ namespace System.CommandLine.Tests
         [InlineData("-x=true -y:true")]
         public void Boolean_options_are_not_greedy(string commandLine)
         {
-            var optX = new CliOption<bool>("-x");
-            var optY = new CliOption<bool>("-y");
+            var optX = new Option<bool>("-x");
+            var optY = new Option<bool>("-y");
 
-            var root = new CliRootCommand("parent")
+            var root = new RootCommand("parent")
             {
                 optX,
                 optY,
@@ -1227,10 +1227,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Multiple_option_arguments_that_match_multiple_arity_option_aliases_are_parsed_correctly()
         {
-            var optionX = new CliOption<string[]>("-x");
-            var optionY = new CliOption<string[]>("-y");
+            var optionX = new Option<string[]>("-x");
+            var optionY = new Option<string[]>("-y");
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionX,
                 optionY
@@ -1245,10 +1245,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Bundled_option_arguments_that_match_option_aliases_are_parsed_correctly()
         {
-            var optionX = new CliOption<string>("-x");
-            var optionY = new CliOption<bool>("-y");
+            var optionX = new Option<string>("-x");
+            var optionY = new Option<bool>("-y");
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 optionX,
                 optionY
@@ -1262,10 +1262,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Argument_name_is_not_matched_as_a_token()
         {
-            var nameArg = new CliArgument<string>("name");
-            var columnsArg = new CliArgument<IEnumerable<string>>("columns");
+            var nameArg = new Argument<string>("name");
+            var columnsArg = new Argument<IEnumerable<string>>("columns");
 
-            var command = new CliCommand("add", "Adds a new series")
+            var command = new Command("add", "Adds a new series")
             {
                 nameArg,
                 columnsArg
@@ -1280,9 +1280,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_aliases_do_not_need_to_be_prefixed()
         {
-            var option = new CliOption<bool>("noprefix");
+            var option = new Option<bool>("noprefix");
 
-            var result = new CliRootCommand { option }.Parse("noprefix");
+            var result = new RootCommand { option }.Parse("noprefix");
 
             result.GetResult(option).Should().NotBeNull();
         }
@@ -1290,9 +1290,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Boolean_options_with_no_argument_specified_do_not_match_subsequent_arguments()
         {
-            var option = new CliOption<bool>("-v");
+            var option = new Option<bool>("-v");
 
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 option
             };
@@ -1305,13 +1305,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_command_line_has_unmatched_tokens_they_are_not_applied_to_subsequent_options()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
                 TreatUnmatchedTokensAsErrors = false
             };
-            var optionX = new CliOption<string>("-x");
+            var optionX = new Option<string>("-x");
             command.Options.Add(optionX);
-            var optionY = new CliOption<string>("-y");
+            var optionY = new Option<string>("-y");
             command.Options.Add(optionY);
 
             var result = command.Parse("-x 23 unmatched-token -y 42");
@@ -1326,12 +1326,12 @@ namespace System.CommandLine.Tests
         [InlineData(false)]
         public void When_a_command_line_has_unmatched_tokens_the_parse_result_action_should_depend_on_parsed_command_TreatUnmatchedTokensAsErrors(bool treatUnmatchedTokensAsErrors)
         {
-            CliRootCommand rootCommand = new();
-            CliCommand subcommand = new("vstest")
+            RootCommand rootCommand = new();
+            Command subcommand = new("vstest")
             {
-                new CliOption<string>("--Platform"),
-                new CliOption<string>("--Framework"),
-                new CliOption<string[]>("--logger")
+                new Option<string>("--Platform"),
+                new Option<string>("--Framework"),
+                new Option<string[]>("--logger")
             };
             subcommand.TreatUnmatchedTokensAsErrors = treatUnmatchedTokensAsErrors;
             rootCommand.Subcommands.Add(subcommand);
@@ -1355,13 +1355,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public void RootCommand_TreatUnmatchedTokensAsErrors_set_to_false_has_precedence_over_subcommands()
         {
-            CliRootCommand rootCommand = new();
+            RootCommand rootCommand = new();
             rootCommand.TreatUnmatchedTokensAsErrors = false;
-            CliCommand subcommand = new("vstest")
+            Command subcommand = new("vstest")
             {
-                new CliOption<string>("--Platform"),
-                new CliOption<string>("--Framework"),
-                new CliOption<string[]>("--logger")
+                new Option<string>("--Platform"),
+                new Option<string>("--Framework"),
+                new Option<string[]>("--logger")
             };
             subcommand.TreatUnmatchedTokensAsErrors = true; // the default, set to true to make it explicit
             rootCommand.Subcommands.Add(subcommand);
@@ -1377,7 +1377,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Parse_can_not_be_called_with_null_args()
         {
-            Action passNull = () => new CliRootCommand().Parse(args: null);
+            Action passNull = () => new RootCommand().Parse(args: null);
 
             passNull.Should().Throw<ArgumentNullException>();
         }
@@ -1385,11 +1385,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Command_argument_arity_can_be_a_fixed_value_greater_than_1()
         {
-            var argument = new CliArgument<string[]>("arg")
+            var argument = new Argument<string[]>("arg")
             {
                 Arity = new ArgumentArity(3, 3)
             };
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 argument
             };
@@ -1399,19 +1399,19 @@ namespace System.CommandLine.Tests
                    .Tokens
                    .Should()
                    .BeEquivalentTo(
-                       new CliToken("1", CliTokenType.Argument, argument),
-                       new CliToken("2", CliTokenType.Argument, argument),
-                       new CliToken("3", CliTokenType.Argument, argument));
+                       new Token("1", TokenType.Argument, argument),
+                       new Token("2", TokenType.Argument, argument),
+                       new Token("3", TokenType.Argument, argument));
         }
 
         [Fact]
         public void Command_argument_arity_can_be_a_range_with_a_lower_bound_greater_than_1()
         {
-            var argument = new CliArgument<string[]>("arg")
+            var argument = new Argument<string[]>("arg")
             {
                 Arity = new ArgumentArity(3, 5)
             };
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 argument
             };
@@ -1421,27 +1421,27 @@ namespace System.CommandLine.Tests
                    .Tokens
                    .Should()
                    .BeEquivalentTo(
-                       new CliToken("1", CliTokenType.Argument, argument),
-                       new CliToken("2", CliTokenType.Argument, argument),
-                       new CliToken("3", CliTokenType.Argument, argument));
+                       new Token("1", TokenType.Argument, argument),
+                       new Token("2", TokenType.Argument, argument),
+                       new Token("3", TokenType.Argument, argument));
             command.Parse("1 2 3 4 5")
                    .CommandResult
                    .Tokens
                    .Should()
                    .BeEquivalentTo(
-                       new CliToken("1", CliTokenType.Argument, argument),
-                       new CliToken("2", CliTokenType.Argument, argument),
-                       new CliToken("3", CliTokenType.Argument, argument),
-                       new CliToken("4", CliTokenType.Argument, argument),
-                       new CliToken("5", CliTokenType.Argument, argument));
+                       new Token("1", TokenType.Argument, argument),
+                       new Token("2", TokenType.Argument, argument),
+                       new Token("3", TokenType.Argument, argument),
+                       new Token("4", TokenType.Argument, argument),
+                       new Token("5", TokenType.Argument, argument));
         }
 
         [Fact]
         public void When_command_arguments_are_fewer_than_minimum_arity_then_an_error_is_returned()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<string[]>("arg")
+                new Argument<string[]>("arg")
                 {
                     Arity = new ArgumentArity(2, 3)
                 }
@@ -1458,9 +1458,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_command_arguments_are_greater_than_maximum_arity_then_an_error_is_returned()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliArgument<string[]>("arg")
+                new Argument<string[]>("arg")
                 {
                     Arity = new ArgumentArity(2, 3)
                 }
@@ -1478,9 +1478,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Option_argument_arity_can_be_a_fixed_value_greater_than_1()
         {
-            var option = new CliOption<int[]>("-x") { Arity = new ArgumentArity(3, 3)};
+            var option = new Option<int[]>("-x") { Arity = new ArgumentArity(3, 3)};
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -1490,17 +1490,17 @@ namespace System.CommandLine.Tests
                    .Tokens
                    .Should()
                    .BeEquivalentTo(
-                       new CliToken("1", CliTokenType.Argument, default),
-                       new CliToken("2", CliTokenType.Argument, default),
-                       new CliToken("3", CliTokenType.Argument, default));
+                       new Token("1", TokenType.Argument, default),
+                       new Token("2", TokenType.Argument, default),
+                       new Token("3", TokenType.Argument, default));
         }
 
         [Fact]
         public void Option_argument_arity_can_be_a_range_with_a_lower_bound_greater_than_1()
         {
-            var option = new CliOption<string[]>("-x") { Arity = new ArgumentArity(3, 5) };
+            var option = new Option<string[]>("-x") { Arity = new ArgumentArity(3, 5) };
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -1510,30 +1510,30 @@ namespace System.CommandLine.Tests
                    .Tokens
                    .Should()
                    .BeEquivalentTo(
-                       new CliToken("1", CliTokenType.Argument, default),
-                       new CliToken("2", CliTokenType.Argument, default),
-                       new CliToken("3", CliTokenType.Argument, default));
+                       new Token("1", TokenType.Argument, default),
+                       new Token("2", TokenType.Argument, default),
+                       new Token("3", TokenType.Argument, default));
             command.Parse("-x 1 -x 2 -x 3 -x 4 -x 5")
                    .GetResult(option)
                    .Tokens
                    .Should()
                    .BeEquivalentTo(
-                       new CliToken("1", CliTokenType.Argument, default),
-                       new CliToken("2", CliTokenType.Argument, default),
-                       new CliToken("3", CliTokenType.Argument, default),
-                       new CliToken("4", CliTokenType.Argument, default),
-                       new CliToken("5", CliTokenType.Argument, default));
+                       new Token("1", TokenType.Argument, default),
+                       new Token("2", TokenType.Argument, default),
+                       new Token("3", TokenType.Argument, default),
+                       new Token("4", TokenType.Argument, default),
+                       new Token("5", TokenType.Argument, default));
         }
 
         [Fact]
         public void When_option_arguments_are_fewer_than_minimum_arity_then_an_error_is_returned()
         {
-            var option = new CliOption<int[]>("-x") 
+            var option = new Option<int[]>("-x") 
             { 
                 Arity = new ArgumentArity(2, 3)
             };
 
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
                 option
             };
@@ -1549,9 +1549,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_option_arguments_are_greater_than_maximum_arity_then_an_error_is_returned()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<int[]>("-x") { Arity = new ArgumentArity(2, 3)}
+                new Option<int[]>("-x") { Arity = new ArgumentArity(2, 3)}
             };
 
             command.Parse("-x 1 2 3 4")
@@ -1564,8 +1564,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Tokens_are_not_split_if_the_part_before_the_delimiter_is_not_an_option()
         {
-            var rootCommand = new CliCommand("jdbc");
-            rootCommand.Add(new CliOption<string>("url"));
+            var rootCommand = new Command("jdbc");
+            rootCommand.Add(new Option<string>("url"));
             var result = rootCommand.Parse("jdbc url \"jdbc:sqlserver://10.0.0.2;databaseName=main\"");
 
             result.Tokens
@@ -1580,17 +1580,17 @@ namespace System.CommandLine.Tests
         {
             // Tests bug identified in https://github.com/dotnet/command-line-api/issues/997
 
-            var argument1 = new CliArgument<string>("arg1");
+            var argument1 = new Argument<string>("arg1");
 
-            var argument2 = new CliArgument<string[]>("arg2");
+            var argument2 = new Argument<string[]>("arg2");
 
-            var command = new CliCommand("subcommand")
+            var command = new Command("subcommand")
             {
                 argument1,
                 argument2
             };
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 command
             };
@@ -1607,12 +1607,12 @@ namespace System.CommandLine.Tests
         [InlineData("--exec-prefix=", "")]
         public void Parsed_value_of_empty_string_arg_is_an_empty_string(string arg1, string arg2)
         {
-            var option = new CliOption<string>("--exec-prefix")
+            var option = new Option<string>("--exec-prefix")
             {
                 DefaultValueFactory = _ => "/usr/local"
             };
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 option
             };

--- a/src/System.CommandLine.Tests/Parsing/CommandLineStringSplitterTests.cs
+++ b/src/System.CommandLine.Tests/Parsing/CommandLineStringSplitterTests.cs
@@ -19,7 +19,7 @@ namespace System.CommandLine.Tests.Parsing
         [InlineData(" one\r\ntwo\r\nthree\r\nfour\r\n")]
         public void It_splits_strings_based_on_whitespace(string commandLine)
         {
-            CliParser.SplitCommandLine(commandLine)
+            CommandLineParser.SplitCommandLine(commandLine)
                      .Should()
                      .BeEquivalentSequenceTo("one", "two", "three", "four");
         }
@@ -29,7 +29,7 @@ namespace System.CommandLine.Tests.Parsing
         {
             var commandLine = @"rm -r ""c:\temp files\""";
 
-            CliParser.SplitCommandLine(commandLine)
+            CommandLineParser.SplitCommandLine(commandLine)
                      .Should()
                      .BeEquivalentSequenceTo("rm", "-r", @"c:\temp files\");
         }
@@ -49,7 +49,7 @@ namespace System.CommandLine.Tests.Parsing
 
             var commandLine = $"the-command {optionAndArgument}";
 
-            CliParser.SplitCommandLine(commandLine)
+            CommandLineParser.SplitCommandLine(commandLine)
                      .Should()
                      .BeEquivalentSequenceTo("the-command", optionAndArgument.Replace("\"", ""));
         }
@@ -62,7 +62,7 @@ namespace System.CommandLine.Tests.Parsing
 
             var commandLine = $"move --from \"{source}\" --to \"{destination}\" --verbose";
 
-            var tokenized = CliParser.SplitCommandLine(commandLine);
+            var tokenized = CommandLineParser.SplitCommandLine(commandLine);
 
             tokenized.Should()
                      .BeEquivalentSequenceTo(
@@ -79,7 +79,7 @@ namespace System.CommandLine.Tests.Parsing
         {
             var commandLine = @"POST --raw='{""Id"":1,""Name"":""Alice""}'";
 
-            CliParser.SplitCommandLine(commandLine)
+            CommandLineParser.SplitCommandLine(commandLine)
                      .Should()
                      .BeEquivalentTo("POST", "--raw='{Id:1,Name:Alice}'");
         }
@@ -89,7 +89,7 @@ namespace System.CommandLine.Tests.Parsing
         {
             var commandLine = @"command --raw='{""Id"":1,""Movie Name"":""The Three Musketeers""}'";
 
-            CliParser.SplitCommandLine(commandLine)
+            CommandLineParser.SplitCommandLine(commandLine)
                      .Should()
                      .BeEquivalentTo("command", "--raw='{Id:1,Movie Name:The Three Musketeers}'");
         }

--- a/src/System.CommandLine.Tests/ParsingValidationTests.cs
+++ b/src/System.CommandLine.Tests/ParsingValidationTests.cs
@@ -24,10 +24,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_accepts_only_specific_arguments_but_a_wrong_one_is_supplied_then_an_informative_error_is_returned()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
             option.AcceptOnlyFromAmong("this", "that", "the-other-thing");
 
-            var result = new CliRootCommand { option }.Parse("-x none-of-those");
+            var result = new RootCommand { option }.Parse("-x none-of-those");
 
             result.Errors
                   .Select(e => e.Message)
@@ -40,10 +40,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_en_error_then_the_error_has_a_reference_to_the_option()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
             option.AcceptOnlyFromAmong("this", "that");
 
-            var result = new CliRootCommand { option }.Parse("-x something_else");
+            var result = new RootCommand { option }.Parse("-x something_else");
 
             result.Errors
                   .Where(e => e.SymbolResult != null)
@@ -54,9 +54,9 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1475
         public void When_FromAmong_is_used_then_the_OptionResult_ErrorMessage_is_set()
         {
-            var option = new CliOption<string>("--opt");
+            var option = new Option<string>("--opt");
             option.AcceptOnlyFromAmong("a", "b");
-            var command = new CliCommand("test") { option };
+            var command = new Command("test") { option };
 
             var parseResult = command.Parse("test --opt c");
 
@@ -76,10 +76,10 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1475
         public void When_FromAmong_is_used_then_the_ArgumentResult_ErrorMessage_is_set()
         {
-            var argument = new CliArgument<string>("arg");
+            var argument = new Argument<string>("arg");
             argument.AcceptOnlyFromAmong("a", "b");
 
-            var command = new CliCommand("test") { argument };
+            var command = new Command("test") { argument };
 
             var parseResult = command.Parse("test c");
 
@@ -98,7 +98,7 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1556
         public void When_FromAmong_is_used_for_multiple_arguments_and_valid_input_is_provided_then_there_are_no_errors()
         {
-            var command = new CliCommand("set")
+            var command = new Command("set")
             {
                 CreateArgumentWithAcceptOnlyFromAmong(name: "key", "key1", "key2"),
                 CreateArgumentWithAcceptOnlyFromAmong(name : "value", "value1", "value2")
@@ -112,7 +112,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_FromAmong_is_used_for_multiple_arguments_and_invalid_input_is_provided_for_the_first_one_then_the_error_is_informative()
         {
-            var command = new CliCommand("set")
+            var command = new Command("set")
             {
                 CreateArgumentWithAcceptOnlyFromAmong(name : "key", "key1", "key2"),
                 CreateArgumentWithAcceptOnlyFromAmong(name : "value", "value1", "value2")
@@ -132,10 +132,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_FromAmong_is_used_multiple_times_only_the_most_recently_provided_values_are_taken_into_account()
         {
-            CliArgument<string> argument = new("key");
+            Argument<string> argument = new("key");
             argument.AcceptOnlyFromAmong("key1");
 
-            var command = new CliCommand("set")
+            var command = new Command("set")
             {
                 argument
             };
@@ -160,7 +160,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_FromAmong_is_used_for_multiple_arguments_and_invalid_input_is_provided_for_the_second_one_then_the_error_is_informative()
         {
-            var command = new CliCommand("set")
+            var command = new Command("set")
             {
                 CreateArgumentWithAcceptOnlyFromAmong(name : "key", "key1", "key2"),
                 CreateArgumentWithAcceptOnlyFromAmong(name : "value", "value1", "value2")
@@ -180,12 +180,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_FromAmong_is_used_and_multiple_invalid_inputs_are_provided_the_errors_mention_all_invalid_arguments()
         {
-            CliOption<string[]> option = new("--columns");
+            Option<string[]> option = new("--columns");
             option.AcceptOnlyFromAmong("author", "language", "tags", "type");
             option.Arity = new ArgumentArity(1, 4);
             option.AllowMultipleArgumentsPerToken = true;
 
-            var command = new CliCommand("list")
+            var command = new Command("list")
             {
                 option
             };
@@ -208,9 +208,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_required_argument_is_not_supplied_then_an_error_is_returned()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
 
-            var result = new CliRootCommand { option }.Parse("-x");
+            var result = new RootCommand { option }.Parse("-x");
 
             result.Errors
                   .Should()
@@ -222,9 +222,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_required_option_is_not_supplied_then_an_error_is_returned()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliOption<string>("-x")
+                new Option<string>("-x")
                 {
                     Required = true
                 }
@@ -246,9 +246,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_a_required_option_has_multiple_aliases_the_error_message_uses_the_name()
         {
-            var command = new CliCommand("command")
+            var command = new Command("command")
             {
-                new CliOption<string>("--xray", "-x")
+                new Option<string>("--xray", "-x")
                 {
                     Required = true
                 }
@@ -272,15 +272,15 @@ namespace System.CommandLine.Tests
         [InlineData("-x arg subcommand")]
         public void When_a_required_option_is_allowed_at_more_than_one_position_it_only_needs_to_be_satisfied_in_one(string commandLine)
         {
-            var option = new CliOption<string>("-x")
+            var option = new Option<string>("-x")
             {
                 Required = true
             };
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 option,
-                new CliCommand("subcommand")
+                new Command("subcommand")
                 {
                     option
                 }
@@ -294,11 +294,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Required_options_on_parent_commands_do_not_create_parse_errors_when_an_inner_command_is_specified()
         {
-            var child = new CliCommand("child");
+            var child = new Command("child");
 
-            var parent = new CliCommand("parent")
+            var parent = new Command("parent")
             {
-                new CliOption<string>("-x") { Required = true },
+                new Option<string>("-x") { Required = true },
                 child
             };
 
@@ -311,9 +311,9 @@ namespace System.CommandLine.Tests
         public void When_no_option_accepts_arguments_but_one_is_supplied_then_an_error_is_returned()
         {
             var command =
-                new CliCommand("the-command")
+                new Command("the-command")
                 {
-                    new CliOption<bool>("-x")
+                    new Option<bool>("-x")
                     {
                         Arity = ArgumentArity.Zero
                     }
@@ -334,10 +334,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void A_custom_validator_can_be_added_to_a_command()
         {
-            var command = new CliCommand("the-command")
+            var command = new Command("the-command")
             {
-                new CliOption<bool>("--one"),
-                new CliOption<bool>("--two")
+                new Option<bool>("--one"),
+                new Option<bool>("--two")
             };
 
             command.Validators.Add(commandResult =>
@@ -363,7 +363,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void A_custom_validator_can_be_added_to_an_option()
         {
-            var option = new CliOption<int>("-x");
+            var option = new Option<int>("-x");
 
             option.Validators.Add(r =>
             {
@@ -372,7 +372,7 @@ namespace System.CommandLine.Tests
                 r.AddError($"Option {r.IdentifierToken.Value} cannot be set to {value}");
             });
 
-            var command = new CliRootCommand { option };
+            var command = new RootCommand { option };
 
             var result = command.Parse("-x 123");
 
@@ -390,7 +390,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void A_custom_validator_can_be_added_to_an_argument()
         {
-            var argument = new CliArgument<int>("x");
+            var argument = new Argument<int>("x");
 
             argument.Validators.Add(r =>
             {
@@ -399,7 +399,7 @@ namespace System.CommandLine.Tests
                 r.AddError($"Argument {r.Argument.Name} cannot be set to {value}");
             });
 
-            var command = new CliRootCommand { argument };
+            var command = new RootCommand { argument };
 
             var result = command.Parse("123");
 
@@ -423,19 +423,19 @@ namespace System.CommandLine.Tests
             var optionValidatorWasCalled = false;
             var argumentValidatorWasCalled = false;
 
-            var option = new CliOption<string>("-o");
+            var option = new Option<string>("-o");
             option.Validators.Add(_ =>
             {
                 optionValidatorWasCalled = true;
             });
 
-            var argument = new CliArgument<string>("the-arg");
+            var argument = new Argument<string>("the-arg");
             argument.Validators.Add(_ =>
             {
                 argumentValidatorWasCalled = true;
             });
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 option,
                 argument
@@ -457,14 +457,14 @@ namespace System.CommandLine.Tests
         [InlineData("subcommand --file \"Foo\"")]
         public void Validators_on_global_options_are_executed_when_invoking_a_subcommand(string commandLine)
         {
-            var option = new CliOption<FileInfo>("--file") { Recursive = true };
+            var option = new Option<FileInfo>("--file") { Recursive = true };
             option.Validators.Add(r =>
             {
                 r.AddError("Invoked validator");
             });
 
-            var subCommand = new CliCommand("subcommand");
-            var rootCommand = new CliRootCommand 
+            var subCommand = new Command("subcommand");
+            var rootCommand = new RootCommand 
             {
                 subCommand
             };
@@ -494,20 +494,20 @@ namespace System.CommandLine.Tests
         {
             var handlerWasCalled = false;
 
-            var globalOption = new CliOption<int>("--value")
+            var globalOption = new Option<int>("--value")
             { 
                 Recursive = true
             };
 
             globalOption.Validators.Add(r => r.AddError("oops!"));
 
-            var grandchildCommand = new CliCommand("grandchild");
+            var grandchildCommand = new Command("grandchild");
 
-            var childCommand = new CliCommand("child")
+            var childCommand = new Command("child")
             {
                 grandchildCommand
             };
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 childCommand
             };
@@ -528,10 +528,10 @@ namespace System.CommandLine.Tests
         public void Custom_validator_error_messages_are_not_repeated()
         {
             var errorMessage = "that's not right...";
-            var argument = new CliArgument<string>("arg");
+            var argument = new Argument<string>("arg");
             argument.Validators.Add(r => r.AddError(errorMessage));
 
-            var cmd = new CliCommand("get")
+            var cmd = new Command("get")
             {
                 argument
             };
@@ -548,7 +548,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void The_parsed_value_of_an_argument_is_available_within_a_validator()
         {
-            var argument = new CliArgument<int>("arg");
+            var argument = new Argument<int>("arg");
             var errorMessage = "The value of option '-x' must be between 1 and 100.";
             argument.Validators.Add(result =>
             {
@@ -560,7 +560,7 @@ namespace System.CommandLine.Tests
                 }
             });
 
-            var result = new CliRootCommand() { argument }.Parse("-1");
+            var result = new RootCommand() { argument }.Parse("-1");
 
             result.Errors
                   .Should()
@@ -572,7 +572,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public void The_parsed_value_of_an_option_is_available_within_a_validator()
         {
-            var option = new CliOption<int>("-x");
+            var option = new Option<int>("-x");
             var errorMessage = "The value of option '-x' must be between 1 and 100.";
             option.Validators.Add(result =>
             {
@@ -584,7 +584,7 @@ namespace System.CommandLine.Tests
                 }
             });
 
-            var result = new CliRootCommand { option }.Parse("-x -1");
+            var result = new RootCommand { option }.Parse("-x -1");
 
             result.Errors
                   .Should()
@@ -598,9 +598,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFilePathsOnly_rejects_command_arguments_containing_invalid_path_characters()
             {
-                CliArgument<string> argument = new("arg");
+                Argument<string> argument = new("arg");
                 argument.AcceptLegalFilePathsOnly();
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     argument
                 };
@@ -620,9 +620,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFilePathsOnly_rejects_option_arguments_containing_invalid_path_characters()
             {
-                CliOption<string> option = new ("-x");
+                Option<string> option = new ("-x");
                 option.AcceptLegalFilePathsOnly();
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     option
                 };
@@ -642,9 +642,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFilePathsOnly_accepts_command_arguments_containing_valid_path_characters()
             {
-                CliArgument<string[]> argument = new ("arg");
+                Argument<string[]> argument = new ("arg");
                 argument.AcceptLegalFilePathsOnly();
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     argument
                 };
@@ -660,10 +660,10 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFilePathsOnly_accepts_option_arguments_containing_valid_path_characters()
             {
-                CliOption<string[]> option = new ("-x");
+                Option<string[]> option = new ("-x");
                 option.AcceptLegalFilePathsOnly();
 
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     option
                 };
@@ -682,10 +682,10 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFileNamesOnly_rejects_command_arguments_containing_invalid_file_name_characters()
             {
-                CliArgument<string> argument = new("arg");
+                Argument<string> argument = new("arg");
                 argument.AcceptLegalFileNamesOnly();
 
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     argument
                 };
@@ -705,10 +705,10 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFileNamesOnly_rejects_option_arguments_containing_invalid_file_name_characters()
             {
-                CliOption<string> option = new("-x");
+                Option<string> option = new("-x");
                 option.AcceptLegalFileNamesOnly();
 
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     option
                 };
@@ -728,10 +728,10 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFileNamesOnly_accepts_command_arguments_containing_valid_file_name_characters()
             {
-                CliArgument<string[]> argument = new ("arg");
+                Argument<string[]> argument = new ("arg");
                 argument.AcceptLegalFileNamesOnly();
 
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     argument
                 };
@@ -747,10 +747,10 @@ namespace System.CommandLine.Tests
             [Fact]
             public void LegalFileNamesOnly_accepts_option_arguments_containing_valid_file_name_characters()
             {
-                CliOption<string[]> option = new("-x");
+                Option<string[]> option = new("-x");
                 option.AcceptLegalFileNamesOnly();
 
-                var command = new CliCommand("the-command")
+                var command = new Command("the-command")
                 {
                     option
                 };
@@ -769,9 +769,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void A_command_argument_can_be_invalid_based_on_file_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<FileInfo>("to").AcceptExistingOnly()
+                    new Argument<FileInfo>("to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -788,9 +788,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void An_option_argument_can_be_invalid_based_on_file_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<FileInfo>("--to").AcceptExistingOnly()
+                    new Option<FileInfo>("--to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -807,9 +807,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void A_command_argument_can_be_invalid_based_on_directory_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<DirectoryInfo>("to").AcceptExistingOnly()
+                    new Argument<DirectoryInfo>("to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -826,9 +826,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void An_option_argument_can_be_invalid_based_on_directory_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<DirectoryInfo>("--to").AcceptExistingOnly()
+                    new Option<DirectoryInfo>("--to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -845,9 +845,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void A_command_argument_can_be_invalid_based_on_file_or_directory_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<FileSystemInfo>("arg").AcceptExistingOnly()
+                    new Argument<FileSystemInfo>("arg").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -864,9 +864,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void An_option_argument_can_be_invalid_based_on_file_or_directory_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<FileSystemInfo>("--to").AcceptExistingOnly()
+                    new Option<FileSystemInfo>("--to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -883,9 +883,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void A_command_argument_with_multiple_files_can_be_invalid_based_on_file_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<IEnumerable<FileInfo>>("to").AcceptExistingOnly()
+                    new Argument<IEnumerable<FileInfo>>("to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -902,9 +902,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void An_option_argument_with_multiple_files_can_be_invalid_based_on_file_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<IEnumerable<FileInfo>>("--to").AcceptExistingOnly()
+                    new Option<IEnumerable<FileInfo>>("--to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -921,9 +921,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void A_command_argument_with_multiple_directories_can_be_invalid_based_on_directory_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<List<DirectoryInfo>>("to").AcceptExistingOnly()
+                    new Argument<List<DirectoryInfo>>("to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -940,9 +940,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void An_option_argument_with_multiple_directories_can_be_invalid_based_on_directory_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<DirectoryInfo[]>("--to").AcceptExistingOnly()
+                    new Option<DirectoryInfo[]>("--to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -959,13 +959,13 @@ namespace System.CommandLine.Tests
             [Fact]
             public void A_command_argument_with_multiple_FileSystemInfos_can_be_invalid_based_on_file_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<FileSystemInfo[]>("to")
+                    new Argument<FileSystemInfo[]>("to")
                     {
                         Arity = ArgumentArity.ZeroOrMore
                     }.AcceptExistingOnly(),
-                    new CliOption<string>("--to")
+                    new Option<string>("--to")
                 };
 
                 var path = NonexistentPath();
@@ -980,9 +980,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void An_option_argument_with_multiple_FileSystemInfos_can_be_invalid_based_on_file_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<FileSystemInfo[]>("--to").AcceptExistingOnly()
+                    new Option<FileSystemInfo[]>("--to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -999,9 +999,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void A_command_argument_with_multiple_FileSystemInfos_can_be_invalid_based_on_directory_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<FileSystemInfo>("to").AcceptExistingOnly()
+                    new Argument<FileSystemInfo>("to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -1018,9 +1018,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void An_option_argument_with_multiple_FileSystemInfos_can_be_invalid_based_on_directory_existence()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<FileSystemInfo[]>("--to").AcceptExistingOnly()
+                    new Option<FileSystemInfo[]>("--to").AcceptExistingOnly()
                 };
 
                 var path = NonexistentPath();
@@ -1037,9 +1037,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Command_argument_does_not_return_errors_when_file_exists()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<FileInfo>("arg").AcceptExistingOnly()
+                    new Argument<FileInfo>("arg").AcceptExistingOnly()
                 };
 
                 var path = ExistingFile();
@@ -1051,9 +1051,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Option_argument_does_not_return_errors_when_file_exists()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<FileInfo>("--to").AcceptExistingOnly()
+                    new Option<FileInfo>("--to").AcceptExistingOnly()
                 };
 
                 var path = ExistingFile();
@@ -1065,9 +1065,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Command_argument_does_not_return_errors_when_Directory_exists()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliArgument<DirectoryInfo>("arg").AcceptExistingOnly()
+                    new Argument<DirectoryInfo>("arg").AcceptExistingOnly()
                 };
 
                 var path = ExistingDirectory();
@@ -1079,9 +1079,9 @@ namespace System.CommandLine.Tests
             [Fact]
             public void Option_argument_does_not_return_errors_when_Directory_exists()
             {
-                var command = new CliCommand("move")
+                var command = new Command("move")
                 {
-                    new CliOption<DirectoryInfo>("--to").AcceptExistingOnly()
+                    new Option<DirectoryInfo>("--to").AcceptExistingOnly()
                 };
 
                 var path = ExistingDirectory();
@@ -1109,11 +1109,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public void A_command_with_subcommands_is_invalid_to_invoke_if_it_has_no_handler()
         {
-            var outer = new CliCommand("outer")
+            var outer = new Command("outer")
             {
-                new CliCommand("inner")
+                new Command("inner")
                 {
-                    new CliCommand("inner-er")
+                    new Command("inner-er")
                 }
             };
 
@@ -1129,8 +1129,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void A_root_command_with_subcommands_is_invalid_to_invoke_if_it_has_no_handler()
         {
-            var rootCommand = new CliRootCommand();
-            var inner = new CliCommand("inner");
+            var rootCommand = new RootCommand();
+            var inner = new Command("inner");
             rootCommand.Add(inner);
 
             var result = rootCommand.Parse("");
@@ -1145,10 +1145,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void A_command_with_subcommands_is_valid_to_invoke_if_it_has_a_handler()
         {
-            var outer = new CliCommand("outer");
-            var inner = new CliCommand("inner");
+            var outer = new Command("outer");
+            var inner = new Command("inner");
             inner.SetAction((_) => { });
-            var innerer = new CliCommand("inner-er");
+            var innerer = new Command("inner-er");
             outer.Subcommands.Add(inner);
             inner.Subcommands.Add(innerer);
 
@@ -1161,9 +1161,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_a_default_value_it_is_not_valid_to_specify_the_option_without_an_argument()
         {
-            var option = new CliOption<int>("-x") { DefaultValueFactory = (_) => 123 };
+            var option = new Option<int>("-x") { DefaultValueFactory = (_) => 123 };
 
-            var result = new CliRootCommand { option }.Parse("-x");
+            var result = new RootCommand { option }.Parse("-x");
 
             result.Errors
                   .Select(e => e.Message)
@@ -1174,10 +1174,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_an_option_has_a_default_value_then_the_default_should_apply_if_not_specified()
         {
-            var optionX = new CliOption<int>("-x") { DefaultValueFactory = (_) => 123 };
-            var optionY = new CliOption<int>("-y") { DefaultValueFactory = (_) => 456 };
+            var optionX = new Option<int>("-x") { DefaultValueFactory = (_) => 123 };
+            var optionY = new Option<int>("-y") { DefaultValueFactory = (_) => 456 };
 
-            var parser = new CliRootCommand
+            var parser = new RootCommand
             {
                 optionX,
                 optionY
@@ -1193,9 +1193,9 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1505
         public void Arity_failures_are_not_reported_for_both_an_argument_and_its_parent_option()
         {
-            var newCommand = new CliCommand("test")
+            var newCommand = new Command("test")
             {
-                new CliOption<string>("--opt")
+                new Option<string>("--opt")
             };
 
             var parseResult = newCommand.Parse("test --opt");
@@ -1212,7 +1212,7 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1573
         public void Multiple_validators_on_the_same_command_do_not_report_duplicate_errors()
         {
-            var command = new CliRootCommand();
+            var command = new RootCommand();
             command.Validators.Add(result => result.AddError("Wrong"));
             command.Validators.Add(_ => { });
 
@@ -1230,11 +1230,11 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1573
         public void Multiple_validators_on_the_same_option_do_not_report_duplicate_errors()
         {
-            var option = new CliOption<string>("-x");
+            var option = new Option<string>("-x");
             option.Validators.Add(result => result.AddError("Wrong"));
             option.Validators.Add(_ => { });
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 option
             };
@@ -1253,11 +1253,11 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1573
         public void Multiple_validators_on_the_same_argument_do_not_report_duplicate_errors()
         {
-            var argument = new CliArgument<string>("arg");
+            var argument = new Argument<string>("arg");
             argument.Validators.Add(result => result.AddError("Wrong"));
             argument.Validators.Add(_ => { });
 
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
                 argument
             };
@@ -1276,13 +1276,13 @@ namespace System.CommandLine.Tests
         [Fact] // https://github.com/dotnet/command-line-api/issues/1609
         internal void When_there_is_an_arity_error_then_further_errors_are_not_reported()
         {
-            var option = new CliOption<string>("-o");
+            var option = new Option<string>("-o");
             option.Validators.Add(result =>
             {
                 result.AddError("OOPS");
             }); //all good;
 
-            var command = new CliCommand("comm")
+            var command = new Command("comm")
             {
                 option
             };
@@ -1298,9 +1298,9 @@ namespace System.CommandLine.Tests
                        .Be("Required argument missing for option: '-o'.");
         }
         
-        private CliArgument<string> CreateArgumentWithAcceptOnlyFromAmong(string name, params string[] values)
+        private Argument<string> CreateArgumentWithAcceptOnlyFromAmong(string name, params string[] values)
         {
-            CliArgument<string> argument = new(name);
+            Argument<string> argument = new(name);
             argument.AcceptOnlyFromAmong(values);
             return argument;
         }

--- a/src/System.CommandLine.Tests/ResponseFileTests.cs
+++ b/src/System.CommandLine.Tests/ResponseFileTests.cs
@@ -43,9 +43,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_response_file_specified_it_loads_options_from_response_file()
         {
-            var option = new CliOption<bool>("--flag");
+            var option = new Option<bool>("--flag");
 
-            var result = new CliRootCommand { option }.Parse($"@{CreateResponseFile("--flag")}");
+            var result = new RootCommand { option }.Parse($"@{CreateResponseFile("--flag")}");
 
             result.GetResult(option).Should().NotBeNull();
         }
@@ -58,10 +58,10 @@ namespace System.CommandLine.Tests
                 "--flag2",
                 "123");
 
-            var optionOne = new CliOption<bool>("--flag");
+            var optionOne = new Option<bool>("--flag");
 
-            var optionTwo = new CliOption<int>("--flag2");
-            var result = new CliRootCommand
+            var optionTwo = new Option<int>("--flag2");
+            var result = new RootCommand
                          {
                              optionOne,
                              optionTwo
@@ -81,9 +81,9 @@ namespace System.CommandLine.Tests
                 "two",
                 "three");
 
-            var result = new CliRootCommand
+            var result = new RootCommand
             {
-                new CliArgument<string[]>("arg")
+                new Argument<string[]>("arg")
             }
             .Parse($"@{responseFile}");
 
@@ -102,11 +102,11 @@ namespace System.CommandLine.Tests
                 "two",
                 "three");
 
-            var result = new CliRootCommand
+            var result = new RootCommand
                          {
-                             new CliCommand("subcommand")
+                             new Command("subcommand")
                              {
-                                 new CliArgument<string[]>("arg")
+                                 new Argument<string[]>("arg")
                              }
                          }
                 .Parse($"subcommand @{responseFile}");
@@ -123,11 +123,11 @@ namespace System.CommandLine.Tests
         {
             var responseFile = CreateResponseFile("subcommand");
 
-            var result = new CliRootCommand
+            var result = new RootCommand
                          {
-                             new CliCommand("subcommand")
+                             new Command("subcommand")
                              {
-                                 new CliArgument<string[]>("arg")
+                                 new Argument<string[]>("arg")
                              }
                          }
                 .Parse($"@{responseFile} one two three");
@@ -147,11 +147,11 @@ namespace System.CommandLine.Tests
                 "two",
                 "three");
 
-            var result = new CliRootCommand
+            var result = new RootCommand
                          {
-                             new CliCommand("subcommand")
+                             new Command("subcommand")
                              {
-                                 new CliArgument<string[]>("arg")
+                                 new Argument<string[]>("arg")
                              }
                          }
                 .Parse($"subcommand @{responseFile}");
@@ -171,9 +171,9 @@ namespace System.CommandLine.Tests
                 "",
                 "123");
 
-            var option = new CliOption<int>("--flag");
+            var option = new Option<int>("--flag");
 
-            var result = new CliRootCommand
+            var result = new RootCommand
                 {
                     option
                 }
@@ -186,8 +186,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Response_file_can_contain_comments_which_are_ignored_when_loaded()
         {
-            var optionOne = new CliOption<bool>("--flag");
-            var optionTwo = new CliOption<bool>("--flag2");
+            var optionOne = new Option<bool>("--flag");
+            var optionTwo = new Option<bool>("--flag2");
 
             var responseFile = CreateResponseFile(
                 "# comment one",
@@ -197,7 +197,7 @@ namespace System.CommandLine.Tests
                 " # comment two",
                 "--flag2");
 
-            var result = new CliRootCommand
+            var result = new RootCommand
             {
                 optionOne,
                 optionTwo
@@ -211,10 +211,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_response_file_does_not_exist_then_error_is_returned()
         {
-            var optionOne = new CliOption<bool>("--flag");
-            var optionTwo = new CliOption<bool>("--flag2");
+            var optionOne = new Option<bool>("--flag");
+            var optionTwo = new Option<bool>("--flag2");
 
-            var result = new CliRootCommand
+            var result = new RootCommand
                          {
                              optionOne,
                              optionTwo
@@ -229,10 +229,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_response_filepath_is_not_specified_then_error_is_returned()
         {
-            var optionOne = new CliOption<bool>("--flag");
-            var optionTwo = new CliOption<bool>("--flag2");
+            var optionOne = new Option<bool>("--flag");
+            var optionTwo = new Option<bool>("--flag2");
 
-            var result = new CliRootCommand
+            var result = new RootCommand
                          {
                              optionOne,
                              optionTwo
@@ -253,12 +253,12 @@ namespace System.CommandLine.Tests
         public void When_response_file_cannot_be_read_then_specified_error_is_returned()
         {
             var nonexistent = Path.GetTempFileName();
-            var optionOne = new CliOption<bool>("--flag");
-            var optionTwo = new CliOption<bool>("--flag2");
+            var optionOne = new Option<bool>("--flag");
+            var optionTwo = new Option<bool>("--flag2");
 
             using (File.Open(nonexistent, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
             {
-                var result = new CliRootCommand
+                var result = new RootCommand
                              {
                                  optionOne,
                                  optionTwo
@@ -279,15 +279,15 @@ namespace System.CommandLine.Tests
         {
             var responseFile = CreateResponseFile(input);
 
-            var optionOne = new CliOption<string>("--flag");
-            var optionTwo = new CliOption<int>("--flag2");
+            var optionOne = new Option<string>("--flag");
+            var optionTwo = new Option<int>("--flag2");
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 optionOne,
                 optionTwo
             };
-            CliConfiguration config = new (rootCommand);
+            CommandLineConfiguration config = new (rootCommand);
 
             var result = rootCommand.Parse($"@{responseFile}", config);
 
@@ -298,21 +298,21 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_response_file_processing_is_disabled_then_it_returns_response_file_name_as_argument()
         {
-            CliRootCommand command = new ()
+            RootCommand command = new ()
             {
-                new CliArgument<List<string>>("arg")
+                new Argument<List<string>>("arg")
             };
-            CliConfiguration configuration = new(command)
+            CommandLineConfiguration configuration = new(command)
             {
                 ResponseFileTokenReplacer = null
             };
 
-            var result = CliParser.Parse(command, "@file.rsp", configuration);
+            var result = CommandLineParser.Parse(command, "@file.rsp", configuration);
 
             result.Tokens
                   .Should()
                   .Contain(t => t.Value == "@file.rsp" && 
-                                t.Type == CliTokenType.Argument);
+                                t.Type == TokenType.Argument);
             result.Errors.Should().HaveCount(0);
         }
 
@@ -323,11 +323,11 @@ namespace System.CommandLine.Tests
             var file2 = CreateResponseFile($"@{file3}", "--two", "2");
             var file1 = CreateResponseFile("--one", "1", $"@{file2}");
 
-            var option1 = new CliOption<int>("--one");
-            var option2 = new CliOption<int>("--two");
-            var option3 = new CliOption<int>("--three");
+            var option1 = new Option<int>("--one");
+            var option2 = new Option<int>("--two");
+            var option3 = new Option<int>("--three");
 
-            var command = new CliRootCommand
+            var command = new RootCommand
                           {
                               option1,
                               option2,
@@ -348,10 +348,10 @@ namespace System.CommandLine.Tests
         {
             var responseFile = CreateResponseFile("--option1 ", "value1 ", "--option2\t", "2\t");
 
-            var option1 = new CliOption<string>("--option1");
-            var option2 = new CliOption<int>("--option2");
+            var option1 = new Option<string>("--option1");
+            var option2 = new Option<int>("--option2");
 
-            var result = new CliRootCommand { option1, option2 }.Parse($"@{responseFile}");
+            var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
             result.GetValue(option1).Should().Be("value1");
             result.GetValue(option2).Should().Be(2);
         }
@@ -361,10 +361,10 @@ namespace System.CommandLine.Tests
         {
             var responseFile = CreateResponseFile(" --option1", " value1", "\t--option2", "\t2");
 
-            var option1 = new CliOption<string>("--option1");
-            var option2 = new CliOption<int>("--option2");
+            var option1 = new Option<string>("--option1");
+            var option2 = new Option<int>("--option2");
 
-            var result = new CliRootCommand { option1, option2 }.Parse($"@{responseFile}");
+            var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
             result.GetValue(option1).Should().Be("value1");
             result.GetValue(option2).Should().Be(2);
             result.Errors.Should().BeEmpty();
@@ -375,10 +375,10 @@ namespace System.CommandLine.Tests
         {
             var responseFile = CreateResponseFile(" --option1 ", " value1 ", "\t--option2\t", "\t2\t");
 
-            var option1 = new CliOption<string>("--option1");
-            var option2 = new CliOption<int>("--option2");
+            var option1 = new Option<string>("--option1");
+            var option2 = new Option<int>("--option2");
 
-            var result = new CliRootCommand { option1, option2 }.Parse($"@{responseFile}");
+            var result = new RootCommand { option1, option2 }.Parse($"@{responseFile}");
             result.GetValue(option1).Should().Be("value1");
             result.GetValue(option2).Should().Be(2);
             result.Errors.Should().BeEmpty();

--- a/src/System.CommandLine.Tests/RootCommandTests.cs
+++ b/src/System.CommandLine.Tests/RootCommandTests.cs
@@ -11,9 +11,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Root_command_name_defaults_to_executable_name()
         {
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
 
-            rootCommand.Name.Should().Be(CliRootCommand.ExecutableName);
+            rootCommand.Name.Should().Be(RootCommand.ExecutableName);
         }
     }
 }

--- a/src/System.CommandLine.Tests/SplitCommandLineTests.cs
+++ b/src/System.CommandLine.Tests/SplitCommandLineTests.cs
@@ -24,7 +24,7 @@ namespace System.CommandLine.Tests
         {
             var commandLine = "one two\tthree   four ";
 
-            CliParser
+            CommandLineParser
                 .SplitCommandLine(commandLine)
                 .Should()
                 .BeEquivalentSequenceTo("one", "two", "three", "four");
@@ -35,7 +35,7 @@ namespace System.CommandLine.Tests
         {
             var commandLine = @"rm -r ""c:\temp files\""";
 
-            CliParser
+            CommandLineParser
                 .SplitCommandLine(commandLine)
                 .Should()
                 .BeEquivalentSequenceTo("rm", "-r", @"c:\temp files\");
@@ -56,7 +56,7 @@ namespace System.CommandLine.Tests
 
             var commandLine = $"the-command {optionAndArgument}";
 
-            CliParser
+            CommandLineParser
                 .SplitCommandLine(commandLine)
                 .Should()
                 .BeEquivalentSequenceTo("the-command", optionAndArgument.Replace("\"", ""));
@@ -70,7 +70,7 @@ namespace System.CommandLine.Tests
 
             var commandLine = $"move --from \"{source}\" --to \"{destination}\"";
 
-            var tokenized = CliParser.SplitCommandLine(commandLine);
+            var tokenized = CommandLineParser.SplitCommandLine(commandLine);
 
             _output.WriteLine(commandLine);
 

--- a/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
+++ b/src/System.CommandLine.Tests/SuggestDirectiveTests.cs
@@ -13,21 +13,21 @@ namespace System.CommandLine.Tests
 {
     public class SuggestDirectiveTests
     {
-        protected CliOption _fruitOption;
+        protected Option _fruitOption;
 
-        protected CliOption _vegetableOption;
+        protected Option _vegetableOption;
 
-        private readonly CliCommand _eatCommand;
+        private readonly Command _eatCommand;
 
         public SuggestDirectiveTests()
         {
-            _fruitOption = new CliOption<string>("--fruit");
+            _fruitOption = new Option<string>("--fruit");
             _fruitOption.CompletionSources.Add("apple", "banana", "cherry");
 
-            _vegetableOption = new CliOption<string>("--vegetable");
+            _vegetableOption = new Option<string>("--vegetable");
             _vegetableOption.CompletionSources.Add(_ => new[] { "asparagus", "broccoli", "carrot" });
 
-            _eatCommand = new CliCommand("eat")
+            _eatCommand = new Command("eat")
             {
                 _fruitOption,
                 _vegetableOption
@@ -37,12 +37,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_writes_suggestions_for_option_arguments_when_under_subcommand()
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
                 _eatCommand,
                 new SuggestDirective()
             };
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -60,12 +60,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_writes_suggestions_for_option_arguments_when_under_root_command()
         {
-            CliRootCommand rootCommand = new ()
+            RootCommand rootCommand = new ()
             {
                 _fruitOption,
                 _vegetableOption
             };
-            CliConfiguration config = new (rootCommand)
+            CommandLineConfiguration config = new (rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -85,8 +85,8 @@ namespace System.CommandLine.Tests
         [InlineData("[suggest:6] \"eat --\"", new[] { "--fruit", "--help", "--vegetable" })]
         public async Task It_writes_suggestions_for_option_aliases_under_subcommand(string commandLine, string[] expectedCompletions)
         {
-            CliRootCommand rootCommand = new() { _eatCommand };
-            CliConfiguration config = new(rootCommand)
+            RootCommand rootCommand = new() { _eatCommand };
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -110,12 +110,12 @@ namespace System.CommandLine.Tests
         [InlineData("[suggest:0] ")]
         public async Task It_writes_suggestions_for_option_aliases_under_root_command(string input)
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
                 _vegetableOption,
                 _fruitOption
             };
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -132,11 +132,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_writes_suggestions_for_subcommand_aliases_under_root_command()
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
                 _eatCommand
             };
-            CliConfiguration config = new(rootCommand)
+            CommandLineConfiguration config = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -153,12 +153,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_writes_suggestions_for_partial_option_aliases_under_root_command()
         {
-            CliRootCommand rootCommand = new()
+            RootCommand rootCommand = new()
             {
                 _fruitOption,
                 _vegetableOption
             };
-            CliConfiguration config = new (rootCommand)
+            CommandLineConfiguration config = new (rootCommand)
             {
                 Output = new StringWriter(),
             };
@@ -176,12 +176,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_writes_suggestions_for_partial_subcommand_aliases_under_root_command()
         {
-            CliRootCommand rootCommand = new ()
+            RootCommand rootCommand = new ()
             {
                 _eatCommand,
-                new CliCommand("wash-dishes")
+                new Command("wash-dishes")
             };
-            CliConfiguration config = new (rootCommand)
+            CommandLineConfiguration config = new (rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -199,12 +199,12 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_writes_suggestions_for_partial_option_and_subcommand_aliases_under_root_command()
         {
-            CliRootCommand rootCommand = new ()
+            RootCommand rootCommand = new ()
             {
                 _eatCommand,
-                new CliCommand("wash-dishes"),
+                new Command("wash-dishes"),
             };
-            CliConfiguration config = new (rootCommand)
+            CommandLineConfiguration config = new (rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -222,14 +222,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_writes_suggestions_for_partial_option_and_subcommand_aliases_under_root_command_with_an_argument()
         {
-            CliRootCommand command = new("parent")
+            RootCommand command = new("parent")
             {
-                new CliCommand("child"),
-                new CliOption<bool>("--option1"),
-                new CliOption<bool>("--option2"),
-                new CliArgument<string>("arg")
+                new Command("child"),
+                new Option<bool>("--option1"),
+                new Option<bool>("--option2"),
+                new Argument<string>("arg")
             };
-            CliConfiguration config = new (command)
+            CommandLineConfiguration config = new (command)
             {
                 Output = new StringWriter()
             };
@@ -245,11 +245,11 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task It_does_not_repeat_suggestion_for_already_specified_bool_option()
         {
-            var command = new CliRootCommand
+            var command = new RootCommand
             {
-                new CliOption<bool>("--bool-option")
+                new Option<bool>("--bool-option")
             };
-            CliConfiguration config = new (command)
+            CommandLineConfiguration config = new (command)
             {
                 Output = new StringWriter()
             };

--- a/src/System.CommandLine.Tests/TestApps/NativeAOT/Program.cs
+++ b/src/System.CommandLine.Tests/TestApps/NativeAOT/Program.cs
@@ -6,10 +6,10 @@ public class Program
 {
     private static int Main(string[] args)
     {
-        CliOption<bool> boolOption = new ("--bool", "-b") { Description = "Bool option" };
-        CliOption<string> stringOption = new ("--string", "-s") { Description = "String option" };
+        Option<bool> boolOption = new ("--bool", "-b") { Description = "Bool option" };
+        Option<string> stringOption = new ("--string", "-s") { Description = "String option" };
 
-        CliRootCommand command = new ()
+        RootCommand command = new ()
         {
             boolOption,
             stringOption
@@ -17,7 +17,7 @@ public class Program
 
         command.SetAction(Run);
 
-        return new CliConfiguration(command).Invoke(args);
+        return new CommandLineConfiguration(command).Invoke(args);
 
         void Run(ParseResult parseResult)
         {

--- a/src/System.CommandLine.Tests/TestApps/Trimming/Program.cs
+++ b/src/System.CommandLine.Tests/TestApps/Trimming/Program.cs
@@ -1,10 +1,10 @@
 ﻿using System.CommandLine;
 using System.CommandLine.Invocation;
 
-CliArgument<FileInfo> fileArgument = new ("file");
+Argument<FileInfo> fileArgument = new ("file");
 fileArgument.AcceptLegalFileNamesOnly();
 
-CliRootCommand command = new ()
+RootCommand command = new ()
 {
     fileArgument
 };

--- a/src/System.CommandLine.Tests/TestCliActions.cs
+++ b/src/System.CommandLine.Tests/TestCliActions.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.CommandLine.Tests;
 
-public class SynchronousTestAction : SynchronousCliAction
+public class SynchronousTestAction : SynchronousCommandLineAction
 {
     private readonly Action<ParseResult> _invoke;
 
@@ -24,7 +24,7 @@ public class SynchronousTestAction : SynchronousCliAction
     }
 }
 
-public class AsynchronousTestAction : AsynchronousCliAction
+public class AsynchronousTestAction : AsynchronousCommandLineAction
 {
     private readonly Action<ParseResult> _invoke;
 

--- a/src/System.CommandLine.Tests/TokenReplacementTests.cs
+++ b/src/System.CommandLine.Tests/TokenReplacementTests.cs
@@ -12,13 +12,13 @@ public class TokenReplacementTests
     [Fact]
     public void Token_replacer_receives_the_token_from_the_command_line_with_the_leading_at_symbol_removed()
     {
-        var argument = new CliArgument<int>("arg");
+        var argument = new Argument<int>("arg");
 
-        var command = new CliRootCommand { argument };
+        var command = new RootCommand { argument };
 
         string receivedToken = null;
 
-        CliConfiguration config = new (command)
+        CommandLineConfiguration config = new (command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {
@@ -37,11 +37,11 @@ public class TokenReplacementTests
     [Fact]
     public void Token_replacer_can_expand_argument_values()
     {
-        var argument = new CliArgument<int>("arg");
+        var argument = new Argument<int>("arg");
 
-        var command = new CliRootCommand { argument };
+        var command = new RootCommand { argument };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {
@@ -61,11 +61,11 @@ public class TokenReplacementTests
     [Fact]
     public void Custom_token_replacer_can_expand_option_argument_values()
     {
-        var option = new CliOption<int>("-x");
+        var option = new Option<int>("-x");
 
-        var command = new CliRootCommand { option };
+        var command = new RootCommand { option };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {
@@ -85,11 +85,11 @@ public class TokenReplacementTests
     [Fact]
     public void Custom_token_replacer_can_expand_subcommands_and_options_and_argument()
     {
-        var option = new CliOption<int>("-x");
+        var option = new Option<int>("-x");
 
-        var command = new CliRootCommand { new CliCommand("subcommand") { option } };
+        var command = new RootCommand { new Command("subcommand") { option } };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {
@@ -109,11 +109,11 @@ public class TokenReplacementTests
     [Fact]
     public void Expanded_tokens_containing_whitespace_are_parsed_as_single_tokens()
     {
-        var argument = new CliArgument<string>("arg");
+        var argument = new Argument<string>("arg");
 
-        var command = new CliRootCommand { argument };
+        var command = new RootCommand { argument };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {
@@ -131,11 +131,11 @@ public class TokenReplacementTests
     [Fact]
     public void Token_replacer_can_set_a_custom_error_message()
     {
-        var argument = new CliArgument<string>("arg");
+        var argument = new Argument<string>("arg");
 
-        var command = new CliRootCommand { argument };
+        var command = new RootCommand { argument };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {
@@ -155,11 +155,11 @@ public class TokenReplacementTests
     [Fact]
     public void When_token_replacer_returns_false_without_setting_an_error_message_then_the_command_line_is_unchanged_and_no_parse_error_is_produced()
     {
-        var argument = new CliArgument<string>("arg");
+        var argument = new Argument<string>("arg");
 
-        var command = new CliRootCommand { argument };
+        var command = new RootCommand { argument };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {
@@ -179,11 +179,11 @@ public class TokenReplacementTests
     [Fact]
     public void Token_replacer_will_delete_token_when_delegate_returns_true_and_sets_tokens_to_null()
     {
-        var argument = new CliArgument<string[]>("arg");
+        var argument = new Argument<string[]>("arg");
 
-        var command = new CliRootCommand { argument };
+        var command = new RootCommand { argument };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {
@@ -203,11 +203,11 @@ public class TokenReplacementTests
     [Fact]
     public void Token_replacer_will_delete_token_when_delegate_returns_true_and_sets_tokens_to_empty_array()
     {
-        var argument = new CliArgument<string[]>("arg");
+        var argument = new Argument<string[]>("arg");
 
-        var command = new CliRootCommand { argument };
+        var command = new RootCommand { argument };
 
-        CliConfiguration config = new(command)
+        CommandLineConfiguration config = new(command)
         {
             ResponseFileTokenReplacer = (string tokenToReplace, out IReadOnlyList<string> tokens, out string message) =>
             {

--- a/src/System.CommandLine.Tests/UseExceptionHandlerTests.cs
+++ b/src/System.CommandLine.Tests/UseExceptionHandlerTests.cs
@@ -13,10 +13,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task UseExceptionHandler_catches_command_handler_exceptions_and_sets_result_code_to_1()
         {
-            var command = new CliCommand("the-command");
+            var command = new Command("the-command");
             command.SetAction((_, __) => Task.FromException<int>(new Exception("oops!")));
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Error = new StringWriter(),
             };
@@ -29,10 +29,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task UseExceptionHandler_catches_command_handler_exceptions_and_writes_details_to_standard_error()
         {
-            var command = new CliCommand("the-command");
+            var command = new Command("the-command");
             command.SetAction((_, __) => Task.FromException<int>(new Exception("oops!")));
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Error = new StringWriter(),
             };
@@ -45,10 +45,10 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_thrown_exception_is_from_cancelation_no_output_is_generated()
         {
-            CliCommand command = new("the-command");
+            Command command = new("the-command");
             command.SetAction((_, __) => throw new OperationCanceledException());
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Output = new StringWriter(),
                 Error = new StringWriter()
@@ -67,10 +67,10 @@ namespace System.CommandLine.Tests
         public async Task Exception_output_can_be_customized(bool async)
         {
             Exception expectedException = new ("oops!");
-            CliCommand command = new("the-command");
+            Command command = new("the-command");
             command.SetAction((_, __) => throw expectedException);
 
-            CliConfiguration config = new(command)
+            CommandLineConfiguration config = new(command)
             {
                 Error = new StringWriter(),
                 EnableDefaultExceptionHandler = false

--- a/src/System.CommandLine.Tests/Utility/ParseResultExtensions.cs
+++ b/src/System.CommandLine.Tests/Utility/ParseResultExtensions.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Tests
             try
             {
                 parseResult.Configuration.Output = new StringWriter();
-                ((SynchronousCliAction)new DiagramDirective().Action!).Invoke(parseResult);
+                ((SynchronousCommandLineAction)new DiagramDirective().Action!).Invoke(parseResult);
                 return parseResult.Configuration.Output.ToString()
                     .TrimEnd(); // the directive adds a new line, tests that used to rely on Diagram extension method don't expect it
             }

--- a/src/System.CommandLine.Tests/VersionOptionTests.cs
+++ b/src/System.CommandLine.Tests/VersionOptionTests.cs
@@ -21,7 +21,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_the_version_option_is_specified_then_the_version_is_written_to_standard_out()
         {
-            CliConfiguration configuration = new(new CliRootCommand())
+            CommandLineConfiguration configuration = new(new RootCommand())
             {
                 Output = new StringWriter()
             };
@@ -35,10 +35,10 @@ namespace System.CommandLine.Tests
         public async Task When_the_version_option_is_specified_then_invocation_is_short_circuited()
         {
             var wasCalled = false;
-            var rootCommand = new CliRootCommand();
+            var rootCommand = new RootCommand();
             rootCommand.SetAction((_) => wasCalled = true);
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -51,7 +51,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task Version_option_appears_in_help()
         {
-            CliConfiguration configuration = new(new CliRootCommand())
+            CommandLineConfiguration configuration = new(new RootCommand())
             {
                 Output = new StringWriter()
             };
@@ -67,16 +67,16 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_the_version_option_is_specified_and_there_are_default_options_then_the_version_is_written_to_standard_out()
         {
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
-                new CliOption<bool>("-x")
+                new Option<bool>("-x")
                 {
                     DefaultValueFactory = (_) => true
                 },
             };
             rootCommand.SetAction((_) => { });
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -89,13 +89,13 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task When_the_version_option_is_specified_and_there_are_default_arguments_then_the_version_is_written_to_standard_out()
         {
-            CliRootCommand rootCommand = new ()
+            RootCommand rootCommand = new ()
             {
-                new CliArgument<bool>("x") { DefaultValueFactory =(_) => true },
+                new Argument<bool>("x") { DefaultValueFactory =(_) => true },
             };
             rootCommand.SetAction((_) => { });
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -110,16 +110,16 @@ namespace System.CommandLine.Tests
         [InlineData("--version subcommand")]
         public void Version_is_not_valid_with_other_tokens(string commandLine)
         {
-            var subcommand = new CliCommand("subcommand");
+            var subcommand = new Command("subcommand");
             subcommand.SetAction(_ => { });
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 subcommand,
-                new CliOption<bool>("-x")
+                new Option<bool>("-x")
             };
             rootCommand.SetAction(_ => { });
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -132,16 +132,16 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Version_option_is_not_added_to_subcommands()
         {
-            var childCommand = new CliCommand("subcommand");
+            var childCommand = new Command("subcommand");
             childCommand.SetAction(_ => { });
 
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 childCommand
             };
             rootCommand.SetAction(_ => { });
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -158,7 +158,7 @@ namespace System.CommandLine.Tests
         [Fact]
         public async Task Version_can_specify_additional_alias()
         {
-            CliRootCommand rootCommand = new();
+            RootCommand rootCommand = new();
 
             for (int i = 0; i < rootCommand.Options.Count; i++)
             {
@@ -166,7 +166,7 @@ namespace System.CommandLine.Tests
                     rootCommand.Options[i] = new VersionOption("-v", "-version");
             }
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
@@ -182,9 +182,9 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Version_is_not_valid_with_other_tokens_uses_custom_alias()
         {
-            var childCommand = new CliCommand("subcommand");
+            var childCommand = new Command("subcommand");
             childCommand.SetAction((_) => { });
-            var rootCommand = new CliRootCommand
+            var rootCommand = new RootCommand
             {
                 childCommand
             };
@@ -193,7 +193,7 @@ namespace System.CommandLine.Tests
 
             rootCommand.SetAction((_) => { });
 
-            CliConfiguration configuration = new(rootCommand)
+            CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };

--- a/src/System.CommandLine/AliasSet.cs
+++ b/src/System.CommandLine/AliasSet.cs
@@ -14,7 +14,7 @@ namespace System.CommandLine
         {
             foreach (string alias in aliases)
             {
-                CliSymbol.ThrowIfEmptyOrWithWhitespaces(alias, nameof(alias));
+                Symbol.ThrowIfEmptyOrWithWhitespaces(alias, nameof(alias));
             }
 
             _aliases = new(aliases, StringComparer.Ordinal);
@@ -25,7 +25,7 @@ namespace System.CommandLine
         public bool IsReadOnly => false;
 
         public void Add(string item)
-            => _aliases.Add(CliSymbol.ThrowIfEmptyOrWithWhitespaces(item, nameof(item)));
+            => _aliases.Add(Symbol.ThrowIfEmptyOrWithWhitespaces(item, nameof(item)));
 
         internal bool Overlaps(AliasSet other) => _aliases.Overlaps(other._aliases);
 

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -10,16 +10,16 @@ using System.Linq;
 namespace System.CommandLine
 {
     /// <summary>
-    /// A symbol defining a value that can be passed on the command line to a <see cref="CliCommand">command</see> or <see cref="CliOption">option</see>.
+    /// A symbol defining a value that can be passed on the command line to a <see cref="Command">command</see> or <see cref="Option">option</see>.
     /// </summary>
-    public abstract class CliArgument : CliSymbol
+    public abstract class Argument : Symbol
     {
         private ArgumentArity _arity;
         private TryConvertArgument? _convertArguments;
         private List<Func<CompletionContext, IEnumerable<CompletionItem>>>? _completionSources = null;
         private List<Action<ArgumentResult>>? _validators = null;
 
-        private protected CliArgument(string name) : base(name, allowWhitespace: true)
+        private protected Argument(string name) : base(name, allowWhitespace: true)
         {
         }
 
@@ -128,7 +128,7 @@ namespace System.CommandLine
         }
 
         /// <inheritdoc />
-        public override string ToString() => $"{nameof(CliArgument)}: {Name}";
+        public override string ToString() => $"{nameof(Argument)}: {Name}";
 
         internal bool IsBoolean() => ValueType == typeof(bool) || ValueType == typeof(bool?);
     }

--- a/src/System.CommandLine/ArgumentArity.cs
+++ b/src/System.CommandLine/ArgumentArity.cs
@@ -49,12 +49,12 @@ namespace System.CommandLine
         }
 
         /// <summary>
-        /// Gets the minimum number of values required for an <see cref="CliArgument">argument</see>.
+        /// Gets the minimum number of values required for an <see cref="Argument">argument</see>.
         /// </summary>
         public int MinimumNumberOfValues { get; }
 
         /// <summary>
-        /// Gets the maximum number of values allowed for an <see cref="CliArgument">argument</see>.
+        /// Gets the maximum number of values allowed for an <see cref="Argument">argument</see>.
         /// </summary>
         public int MaximumNumberOfValues { get; }
 
@@ -137,7 +137,7 @@ namespace System.CommandLine
         /// </summary>
         public static ArgumentArity OneOrMore => new(1, MaximumArity);
 
-        internal static ArgumentArity Default(CliArgument argument, SymbolNode? firstParent)
+        internal static ArgumentArity Default(Argument argument, SymbolNode? firstParent)
         {
             if (argument.IsBoolean())
             {
@@ -149,12 +149,12 @@ namespace System.CommandLine
 
             if (type != typeof(string) && typeof(IEnumerable).IsAssignableFrom(type))
             {
-                return parent is CliCommand
+                return parent is Command
                            ? ZeroOrMore
                            : OneOrMore;
             }
 
-            if (parent is CliCommand &&
+            if (parent is Command &&
                 (argument.HasDefaultValue ||
                  type.IsNullable()))
             {

--- a/src/System.CommandLine/ArgumentValidation.cs
+++ b/src/System.CommandLine/ArgumentValidation.cs
@@ -8,7 +8,7 @@ using System.IO;
 namespace System.CommandLine
 {
     /// <summary>
-    /// Provides extension methods for <see cref="CliArgument" />.
+    /// Provides extension methods for <see cref="Argument" />.
     /// </summary>
     public static class ArgumentValidation
     {
@@ -17,7 +17,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="argument">The argument to configure.</param>
         /// <returns>The configured argument.</returns>
-        public static CliArgument<FileInfo> AcceptExistingOnly(this CliArgument<FileInfo> argument)
+        public static Argument<FileInfo> AcceptExistingOnly(this Argument<FileInfo> argument)
         {
             argument.Validators.Add(FileOrDirectoryExists<FileInfo>);
             return argument;
@@ -28,7 +28,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="argument">The argument to configure.</param>
         /// <returns>The configured argument.</returns>
-        public static CliArgument<DirectoryInfo> AcceptExistingOnly(this CliArgument<DirectoryInfo> argument)
+        public static Argument<DirectoryInfo> AcceptExistingOnly(this Argument<DirectoryInfo> argument)
         {
             argument.Validators.Add(FileOrDirectoryExists<DirectoryInfo>);
             return argument;
@@ -39,7 +39,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="argument">The argument to configure.</param>
         /// <returns>The configured argument.</returns>
-        public static CliArgument<FileSystemInfo> AcceptExistingOnly(this CliArgument<FileSystemInfo> argument)
+        public static Argument<FileSystemInfo> AcceptExistingOnly(this Argument<FileSystemInfo> argument)
         {
             argument.Validators.Add(FileOrDirectoryExists<FileSystemInfo>);
             return argument;
@@ -50,7 +50,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="argument">The argument to configure.</param>
         /// <returns>The configured argument.</returns>
-        public static CliArgument<T> AcceptExistingOnly<T>(this CliArgument<T> argument)
+        public static Argument<T> AcceptExistingOnly<T>(this Argument<T> argument)
             where T : IEnumerable<FileSystemInfo>
         {
             if (typeof(IEnumerable<FileInfo>).IsAssignableFrom(typeof(T)))

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -8,8 +8,8 @@ using System.IO;
 
 namespace System.CommandLine
 {
-    /// <inheritdoc cref="CliArgument" />
-    public class CliArgument<T> : CliArgument
+    /// <inheritdoc cref="Argument" />
+    public class Argument<T> : Argument
     {
         private Func<ArgumentResult, T?>? _customParser;
 
@@ -17,7 +17,7 @@ namespace System.CommandLine
         /// Initializes a new instance of the Argument class.
         /// </summary>
         /// <param name="name">The name of the argument. It's not used for parsing, only when displaying Help or creating parse errors.</param>>
-        public CliArgument(string name) : base(name)
+        public Argument(string name) : base(name)
         {
         }
 

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -16,10 +16,10 @@ namespace System.CommandLine.Binding
         {
             switch (value)
             {
-                case CliToken singleValue:
+                case Token singleValue:
                     return ConvertToken(argumentResult, type, singleValue);
 
-                case IReadOnlyList<CliToken> manyValues:
+                case IReadOnlyList<Token> manyValues:
                     return ConvertTokens(argumentResult, type, manyValues);
 
                 default:
@@ -38,7 +38,7 @@ namespace System.CommandLine.Binding
         private static ArgumentConversionResult ConvertToken(
             ArgumentResult argumentResult,
             Type type,
-            CliToken token)
+            Token token)
         {
             var value = token.Value;
 
@@ -83,7 +83,7 @@ namespace System.CommandLine.Binding
         private static ArgumentConversionResult ConvertTokens(
             ArgumentResult argumentResult,
             Type type,
-            IReadOnlyList<CliToken> tokens)
+            IReadOnlyList<Token> tokens)
         {
             var itemType = type.GetElementTypeIfEnumerable() ?? typeof(string);
             var values = CreateEnumerable(type, itemType, tokens.Count);
@@ -125,7 +125,7 @@ namespace System.CommandLine.Binding
             return Success(argumentResult, values);
         }
 
-        internal static TryConvertArgument? GetConverter(CliArgument argument)
+        internal static TryConvertArgument? GetConverter(Argument argument)
         {
             if (argument.Arity is { MaximumNumberOfValues: 1, MinimumNumberOfValues: 1 })
             {

--- a/src/System.CommandLine/ChildSymbolList{T}.cs
+++ b/src/System.CommandLine/ChildSymbolList{T}.cs
@@ -9,12 +9,12 @@ namespace System.CommandLine
     /// <summary>
     /// a wrapper of List<typeparamref name="T"/> that sets parent for every added element
     /// </summary>
-    internal sealed class ChildSymbolList<T> : IList<T> where T : CliSymbol
+    internal sealed class ChildSymbolList<T> : IList<T> where T : Symbol
     {
         private readonly List<T> _children;
-        private readonly CliCommand _parent;
+        private readonly Command _parent;
 
-        public ChildSymbolList(CliCommand parent)
+        public ChildSymbolList(Command parent)
         {
             _parent = parent;
             _children = new();

--- a/src/System.CommandLine/CommandLineConfigurationException.cs
+++ b/src/System.CommandLine/CommandLineConfigurationException.cs
@@ -6,10 +6,10 @@ namespace System.CommandLine;
 /// <summary>
 /// Indicates that a command line configuration is invalid.
 /// </summary>
-public class CliConfigurationException : Exception
+public class CommandLineConfigurationException : Exception
 {
     /// <inheritdoc />
-    public CliConfigurationException(string message) : base(message)
+    public CommandLineConfigurationException(string message) : base(message)
     {
     }
 }

--- a/src/System.CommandLine/Completions/CompletionAction.cs
+++ b/src/System.CommandLine/Completions/CompletionAction.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.Completions;
 /// <summary>
 /// Implements the action for the <c>[suggest]</c> directive, which when specified on the command line will short circuit normal command handling and display a diagram explaining the parse result for the command line input.
 /// </summary>
-internal sealed class CompletionAction : SynchronousCliAction
+internal sealed class CompletionAction : SynchronousCommandLineAction
 {
     private readonly SuggestDirective _directive;
 
@@ -24,7 +24,7 @@ internal sealed class CompletionAction : SynchronousCliAction
 
         int position = !string.IsNullOrEmpty(parsedValues) ? int.Parse(parsedValues) : rawInput?.Length ?? 0;
 
-        var commandLineToComplete = parseResult.Tokens.LastOrDefault(t => t.Type != CliTokenType.Directive)?.Value ?? "";
+        var commandLineToComplete = parseResult.Tokens.LastOrDefault(t => t.Type != TokenType.Directive)?.Value ?? "";
 
         var completionParseResult = parseResult.RootCommandResult.Command.Parse(commandLineToComplete, parseResult.Configuration);
 

--- a/src/System.CommandLine/Completions/CompletionContext.cs
+++ b/src/System.CommandLine/Completions/CompletionContext.cs
@@ -47,7 +47,7 @@ namespace System.CommandLine.Completions
             ParseResult parseResult,
             int? position = null)
         {
-            CliToken? lastToken = parseResult.Tokens.LastOrDefault(t => t.Type != CliTokenType.Directive);
+            Token? lastToken = parseResult.Tokens.LastOrDefault(t => t.Type != TokenType.Directive);
 
             string? textToMatch = null;
             string? rawInput = parseResult.CommandLineText;
@@ -76,7 +76,7 @@ namespace System.CommandLine.Completions
             if (string.IsNullOrWhiteSpace(rawInput))
             {
                 if (parseResult.UnmatchedTokens.Count > 0 ||
-                    lastToken?.Type == CliTokenType.Argument)
+                    lastToken?.Type == TokenType.Argument)
                 {
                     return textToMatch ?? "";
                 }

--- a/src/System.CommandLine/Completions/SuggestDirective.cs
+++ b/src/System.CommandLine/Completions/SuggestDirective.cs
@@ -6,9 +6,9 @@ namespace System.CommandLine.Completions;
 /// Enables the use of the <c>[suggest]</c> directive which when specified in command line input short circuits normal command handling and writes a newline-delimited list of suggestions suitable for use by most shells to provide command line completions.
 /// </summary>
 /// <remarks>The <c>dotnet-suggest</c> tool requires the suggest directive to be enabled for an application to provide completions.</remarks>
-public sealed class SuggestDirective : CliDirective
+public sealed class SuggestDirective : Directive
 {
-    private CliAction? _action;
+    private CommandLineAction? _action;
 
     /// <inheritdoc />
     public SuggestDirective() : base("suggest")
@@ -16,7 +16,7 @@ public sealed class SuggestDirective : CliDirective
     }
 
     /// <inheritdoc />
-    public override CliAction? Action
+    public override CommandLineAction? Action
     {
         get => _action ??= new CompletionAction(this);
         set => _action = value ?? throw new ArgumentNullException(nameof(value));

--- a/src/System.CommandLine/Directive.cs
+++ b/src/System.CommandLine/Directive.cs
@@ -16,22 +16,22 @@ namespace System.CommandLine
     /// * It's enclosed in square brackets.
     /// * It doesn't contain spaces.
     /// </summary>
-    public class CliDirective : CliSymbol
+    public class Directive : Symbol
     {
         /// <summary>
         /// Initializes a new instance of the Directive class.
         /// </summary>
         /// <param name="name">The name of the directive. It can't contain whitespaces.</param>
-        public CliDirective(string name)
+        public Directive(string name)
             : base(name)
         {
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="CliAction"/> for the Directive. The handler represents the action
+        /// Gets or sets the <see cref="CommandLineAction"/> for the Directive. The handler represents the action
         /// that will be performed when the Directive is invoked.
         /// </summary>
-        public virtual CliAction? Action { get; set; }
+        public virtual CommandLineAction? Action { get; set; }
 
         /// <inheritdoc />
         public override IEnumerable<CompletionItem> GetCompletions(CompletionContext context)

--- a/src/System.CommandLine/EnvironmentVariablesDirective.cs
+++ b/src/System.CommandLine/EnvironmentVariablesDirective.cs
@@ -9,9 +9,9 @@ namespace System.CommandLine
     /// <summary>
     /// Enables the use of the <c>[env:key=value]</c> directive, allowing environment variables to be set from the command line during invocation.
     /// </summary>
-    public sealed class EnvironmentVariablesDirective : CliDirective
+    public sealed class EnvironmentVariablesDirective : Directive
     {
-        private CliAction? _action;
+        private CommandLineAction? _action;
 
         /// <inheritdoc />
         public EnvironmentVariablesDirective() : base("env")
@@ -19,13 +19,13 @@ namespace System.CommandLine
         }
 
         /// <inheritdoc />
-        public override CliAction? Action
+        public override CommandLineAction? Action
         {
             get => _action ??= new EnvironmentVariablesDirectiveAction(this);
             set => _action = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        private sealed class EnvironmentVariablesDirectiveAction : SynchronousCliAction
+        private sealed class EnvironmentVariablesDirectiveAction : SynchronousCommandLineAction
         {
             private readonly EnvironmentVariablesDirective _directive;
 

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -20,7 +20,7 @@ public partial class HelpBuilder
         /// Gets an argument's default value to be displayed in help.
         /// </summary>
         /// <param name="argument">The argument to get the default value for.</param>
-        public static string GetArgumentDefaultValue(CliArgument argument)
+        public static string GetArgumentDefaultValue(Argument argument)
         {
             if (argument.HasDefaultValue)
             {
@@ -43,12 +43,12 @@ public partial class HelpBuilder
         /// <summary>
         /// Gets the description for an argument (typically used in the second column text in the arguments section).
         /// </summary>
-        public static string GetArgumentDescription(CliArgument argument) => argument.Description ?? string.Empty;
+        public static string GetArgumentDescription(Argument argument) => argument.Description ?? string.Empty;
 
         /// <summary>
         /// Gets the usage title for an argument (for example: <c>&lt;value&gt;</c>, typically used in the first column text in the arguments usage section, or within the synopsis.
         /// </summary>
-        public static string GetArgumentUsageLabel(CliArgument argument)
+        public static string GetArgumentUsageLabel(Argument argument)
         {
             // Argument.HelpName is always first choice
             if (!string.IsNullOrWhiteSpace(argument.HelpName))
@@ -70,7 +70,7 @@ public partial class HelpBuilder
             }
 
             // By default Option.Name == Argument.Name, don't repeat it
-            return argument.FirstParent?.Symbol is not CliOption ? $"<{argument.Name}>" : "";
+            return argument.FirstParent?.Symbol is not Option ? $"<{argument.Name}>" : "";
         }
 
         /// <summary>
@@ -78,14 +78,14 @@ public partial class HelpBuilder
         /// </summary>
         /// <param name="symbol">The symbol to get a help item for.</param>
         /// <returns>Text to display.</returns>
-        public static string GetCommandUsageLabel(CliCommand symbol)
+        public static string GetCommandUsageLabel(Command symbol)
             => GetIdentifierSymbolUsageLabel(symbol, symbol._aliases);
 
-        /// <inheritdoc cref="GetCommandUsageLabel(CliCommand)"/>
-        public static string GetOptionUsageLabel(CliOption symbol)
+        /// <inheritdoc cref="GetCommandUsageLabel(Command)"/>
+        public static string GetOptionUsageLabel(Option symbol)
             => GetIdentifierSymbolUsageLabel(symbol, symbol._aliases);
 
-        private static string GetIdentifierSymbolUsageLabel(CliSymbol symbol, AliasSet? aliasSet)
+        private static string GetIdentifierSymbolUsageLabel(Symbol symbol, AliasSet? aliasSet)
         {
             var aliases =  aliasSet is null
                 ? new [] { symbol.Name }
@@ -112,7 +112,7 @@ public partial class HelpBuilder
                 }
             }
 
-            if (symbol is CliOption { Required: true })
+            if (symbol is Option { Required: true })
             {
                 firstColumnText += $" {LocalizationResources.HelpOptionsRequiredLabel()}";
             }
@@ -188,7 +188,7 @@ public partial class HelpBuilder
 
                 if (ctx.Command.HasOptions)
                 {
-                    foreach (CliOption option in ctx.Command.Options)
+                    foreach (Option option in ctx.Command.Options)
                     {
                         if (!option.Hidden)
                         {
@@ -201,14 +201,14 @@ public partial class HelpBuilder
                     }
                 }
 
-                CliCommand? current = ctx.Command;
+                Command? current = ctx.Command;
                 while (current is not null)
                 {
-                    CliCommand? parentCommand = null;
+                    Command? parentCommand = null;
                     SymbolNode? parent = current.FirstParent;
                     while (parent is not null)
                     {
-                        if ((parentCommand = parent.Symbol as CliCommand) is not null)
+                        if ((parentCommand = parent.Symbol as Command) is not null)
                         {
                             if (parentCommand.HasOptions)
                             {
@@ -243,7 +243,7 @@ public partial class HelpBuilder
             };
 
         ///  <summary>
-        /// Writes a help section describing a command's additional arguments, typically shown only when <see cref="CliCommand.TreatUnmatchedTokensAsErrors"/> is set to <see langword="true"/>.
+        /// Writes a help section describing a command's additional arguments, typically shown only when <see cref="Command.TreatUnmatchedTokensAsErrors"/> is set to <see langword="true"/>.
         ///  </summary>
         public static Func<HelpContext, bool> AdditionalArgumentsSection() =>
             ctx => ctx.HelpBuilder.WriteAdditionalArguments(ctx);

--- a/src/System.CommandLine/Help/HelpBuilderExtensions.cs
+++ b/src/System.CommandLine/Help/HelpBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Help
         /// <param name="secondColumnText">A delegate to display second help column (typically the description).</param>
         /// <param name="defaultValue">The displayed default value for the symbol.</param>
         public void CustomizeSymbol(
-            CliSymbol symbol,
+            Symbol symbol,
             string? firstColumnText = null,
             string? secondColumnText = null,
             string? defaultValue = null)
@@ -26,7 +26,7 @@ namespace System.CommandLine.Help
         /// <summary>
         /// Writes help output for the specified command.
         /// </summary>
-        public void Write(CliCommand command, TextWriter writer)
+        public void Write(Command command, TextWriter writer)
         {
             Write(new HelpContext(this, command, writer));
         }

--- a/src/System.CommandLine/Help/HelpContext.cs
+++ b/src/System.CommandLine/Help/HelpContext.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine.Help
         /// <param name="parseResult">The result of the current parse operation.</param>
         public HelpContext(
             HelpBuilder helpBuilder,
-            CliCommand command,
+            Command command,
             TextWriter output,
             ParseResult? parseResult = null)
         {
@@ -39,7 +39,7 @@ namespace System.CommandLine.Help
         /// <summary>
         /// The command for which help is being formatted.
         /// </summary>
-        public CliCommand Command { get; }
+        public Command Command { get; }
 
         /// <summary>
         /// A text writer to write output to.

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -8,12 +8,12 @@ namespace System.CommandLine.Help
     /// <summary>
     /// A standard option that indicates that command line help should be displayed.
     /// </summary>
-    public sealed class HelpOption : CliOption<bool>
+    public sealed class HelpOption : Option<bool>
     {
-        private CliAction? _action;
+        private CommandLineAction? _action;
 
         /// <summary>
-        /// When added to a <see cref="CliCommand"/>, it configures the application to show help when one of the following options are specified on the command line:
+        /// When added to a <see cref="Command"/>, it configures the application to show help when one of the following options are specified on the command line:
         /// <code>
         ///    -h
         ///    /h
@@ -27,17 +27,17 @@ namespace System.CommandLine.Help
         }
 
         /// <summary>
-        /// When added to a <see cref="CliCommand"/>, it configures the application to show help when given name or one of the aliases are specified on the command line.
+        /// When added to a <see cref="Command"/>, it configures the application to show help when given name or one of the aliases are specified on the command line.
         /// </summary>
         public HelpOption(string name, params string[] aliases)
-            : base(name, aliases, new CliArgument<bool>(name) { Arity = ArgumentArity.Zero })
+            : base(name, aliases, new Argument<bool>(name) { Arity = ArgumentArity.Zero })
         {
             Recursive = true;
             Description = LocalizationResources.HelpOptionDescription();
         }
 
         /// <inheritdoc />
-        public override CliAction? Action 
+        public override CommandLineAction? Action 
         { 
             get => _action ??= new HelpAction(); 
             set => _action = value ?? throw new ArgumentNullException(nameof(value));

--- a/src/System.CommandLine/Help/HelpOptionAction.cs
+++ b/src/System.CommandLine/Help/HelpOptionAction.cs
@@ -5,7 +5,7 @@ namespace System.CommandLine.Help
     /// <summary>
     /// Provides command line help.
     /// </summary>
-    public sealed class HelpAction : SynchronousCliAction
+    public sealed class HelpAction : SynchronousCommandLineAction
     {
         private HelpBuilder? _builder;
 

--- a/src/System.CommandLine/Invocation/AnonymousAsynchronousCommandLineAction.cs
+++ b/src/System.CommandLine/Invocation/AnonymousAsynchronousCommandLineAction.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 
 namespace System.CommandLine.Invocation;
 
-internal sealed class AnonymousAsynchronousCliAction : AsynchronousCliAction
+internal sealed class AnonymousAsynchronousCommandLineAction : AsynchronousCommandLineAction
 {
     private readonly Func<ParseResult, CancellationToken, Task<int>> _asyncAction;
 
-    internal AnonymousAsynchronousCliAction(Func<ParseResult, CancellationToken, Task<int>> action)
+    internal AnonymousAsynchronousCommandLineAction(Func<ParseResult, CancellationToken, Task<int>> action)
         => _asyncAction = action;
 
     /// <inheritdoc />

--- a/src/System.CommandLine/Invocation/AnonymousSynchronousCommandLineAction.cs
+++ b/src/System.CommandLine/Invocation/AnonymousSynchronousCommandLineAction.cs
@@ -3,11 +3,11 @@
 
 namespace System.CommandLine.Invocation;
 
-internal sealed class AnonymousSynchronousCliAction : SynchronousCliAction
+internal sealed class AnonymousSynchronousCommandLineAction : SynchronousCommandLineAction
 {
     private readonly Func<ParseResult, int> _syncAction;
 
-    internal AnonymousSynchronousCliAction(Func<ParseResult, int> action)
+    internal AnonymousSynchronousCommandLineAction(Func<ParseResult, int> action)
         => _syncAction = action;
 
     /// <inheritdoc />

--- a/src/System.CommandLine/Invocation/AsynchronousCommandLineAction.cs
+++ b/src/System.CommandLine/Invocation/AsynchronousCommandLineAction.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace System.CommandLine.Invocation;
 
 /// Defines an asynchronous behavior associated with a command line symbol.
-public abstract class AsynchronousCliAction : CliAction
+public abstract class AsynchronousCommandLineAction : CommandLineAction
 {
     /// <summary>
     /// Performs an action when the associated symbol is invoked on the command line.

--- a/src/System.CommandLine/Invocation/CommandLineAction.cs
+++ b/src/System.CommandLine/Invocation/CommandLineAction.cs
@@ -6,9 +6,9 @@ namespace System.CommandLine.Invocation;
 /// <summary>
 /// Defines a behavior associated with a command line symbol.
 /// </summary>
-public abstract class CliAction
+public abstract class CommandLineAction
 {
-    private protected CliAction()
+    private protected CommandLineAction()
     {
     }
 

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -28,10 +28,10 @@ namespace System.CommandLine.Invocation
 
                         switch (action)
                         {
-                            case SynchronousCliAction syncAction:
+                            case SynchronousCommandLineAction syncAction:
                                 syncAction.Invoke(parseResult);
                                 break;
-                            case AsynchronousCliAction asyncAction:
+                            case AsynchronousCommandLineAction asyncAction:
                                 await asyncAction.InvokeAsync(parseResult, cts.Token);
                                 break;
                         }
@@ -40,10 +40,10 @@ namespace System.CommandLine.Invocation
 
                 switch (parseResult.Action)
                 {
-                    case SynchronousCliAction syncAction:
+                    case SynchronousCommandLineAction syncAction:
                         return syncAction.Invoke(parseResult);
 
-                    case AsynchronousCliAction asyncAction:
+                    case AsynchronousCommandLineAction asyncAction:
                         var startedInvocation = asyncAction.InvokeAsync(parseResult, cts.Token);
                         if (parseResult.Configuration.ProcessTerminationTimeout.HasValue)
                         {
@@ -84,7 +84,7 @@ namespace System.CommandLine.Invocation
                 case null:
                     return ReturnCodeForMissingAction(parseResult);
 
-                case SynchronousCliAction syncAction:
+                case SynchronousCommandLineAction syncAction:
                     try
                     {
                         if (parseResult.PreActions is not null)
@@ -94,18 +94,18 @@ namespace System.CommandLine.Invocation
                             {
                                 var action = parseResult.PreActions[i];
 
-                                if (action is not SynchronousCliAction)
+                                if (action is not SynchronousCommandLineAction)
                                 {
                                     parseResult.Configuration.EnableDefaultExceptionHandler = false;
                                     throw new Exception(
-                                        $"This should not happen. An instance of {nameof(AsynchronousCliAction)} ({action}) was called within {nameof(InvocationPipeline)}.{nameof(Invoke)}. This is supposed to be detected earlier resulting in a call to {nameof(InvocationPipeline)}{nameof(InvokeAsync)}");
+                                        $"This should not happen. An instance of {nameof(AsynchronousCommandLineAction)} ({action}) was called within {nameof(InvocationPipeline)}.{nameof(Invoke)}. This is supposed to be detected earlier resulting in a call to {nameof(InvocationPipeline)}{nameof(InvokeAsync)}");
                                 }
                             }
 #endif
 
                             for (var i = 0; i < parseResult.PreActions.Count; i++)
                             {
-                                if (parseResult.PreActions[i] is SynchronousCliAction syncPreAction)
+                                if (parseResult.PreActions[i] is SynchronousCommandLineAction syncPreAction)
                                 {
                                     syncPreAction.Invoke(parseResult);
                                 }
@@ -120,11 +120,11 @@ namespace System.CommandLine.Invocation
                     }
 
                 default:
-                    throw new InvalidOperationException($"{nameof(AsynchronousCliAction)} called within non-async invocation.");
+                    throw new InvalidOperationException($"{nameof(AsynchronousCommandLineAction)} called within non-async invocation.");
             }
         }
 
-        private static int DefaultExceptionHandler(Exception exception, CliConfiguration config)
+        private static int DefaultExceptionHandler(Exception exception, CommandLineConfiguration config)
         {
             if (exception is not OperationCanceledException)
             {

--- a/src/System.CommandLine/Invocation/ParseErrorAction.cs
+++ b/src/System.CommandLine/Invocation/ParseErrorAction.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Invocation;
 /// <summary>
 /// Provides command line output with error details in the case of a parsing error.
 /// </summary>
-public sealed class ParseErrorAction : SynchronousCliAction
+public sealed class ParseErrorAction : SynchronousCommandLineAction
 {
     /// <summary>
     /// Indicates whether to show help along with error details when an error is found during parsing.
@@ -72,11 +72,11 @@ public sealed class ParseErrorAction : SynchronousCliAction
         {
             switch (helpOption.Action)
             {
-                case SynchronousCliAction syncAction:
+                case SynchronousCommandLineAction syncAction:
                     syncAction.Invoke(parseResult);
                     break;
 
-                case AsynchronousCliAction asyncAction:
+                case AsynchronousCommandLineAction asyncAction:
                     asyncAction.InvokeAsync(parseResult, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
                     break;
             }
@@ -109,7 +109,7 @@ public sealed class ParseErrorAction : SynchronousCliAction
             parseResult.Configuration.Output.WriteLine();
         }
 
-        static IEnumerable<string> GetPossibleTokens(CliCommand targetSymbol, string token)
+        static IEnumerable<string> GetPossibleTokens(Command targetSymbol, string token)
         {
             if (targetSymbol is { HasOptions: false, HasSubcommands: false })
             {
@@ -118,10 +118,10 @@ public sealed class ParseErrorAction : SynchronousCliAction
 
             IEnumerable<string> possibleMatches = targetSymbol
                                                   .Children
-                                                  .Where(x => !x.Hidden && x is CliOption or CliCommand)
+                                                  .Where(x => !x.Hidden && x is Option or Command)
                                                   .Select(symbol =>
                                                   {
-                                                      AliasSet? aliasSet = symbol is CliOption option ? option._aliases : ((CliCommand)symbol)._aliases;
+                                                      AliasSet? aliasSet = symbol is Option option ? option._aliases : ((Command)symbol)._aliases;
 
                                                       if (aliasSet is null)
                                                       {

--- a/src/System.CommandLine/Invocation/SynchronousCommandLineAction.cs
+++ b/src/System.CommandLine/Invocation/SynchronousCommandLineAction.cs
@@ -6,7 +6,7 @@ namespace System.CommandLine.Invocation;
 /// <summary>
 /// Defines a synchronous behavior associated with a command line symbol.
 /// </summary>
-public abstract class SynchronousCliAction : CliAction
+public abstract class SynchronousCommandLineAction : CommandLineAction
 {
     /// <summary>
     /// Performs an action when the associated symbol is invoked on the command line.

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -12,12 +12,12 @@ namespace System.CommandLine
     /// <summary>
     /// A symbol defining a named parameter and a value for that parameter. 
     /// </summary>
-    public abstract class CliOption : CliSymbol
+    public abstract class Option : Symbol
     {
         internal AliasSet? _aliases;
         private List<Action<OptionResult>>? _validators;
 
-        private protected CliOption(string name, string[] aliases) : base(name)
+        private protected Option(string name, string[] aliases) : base(name)
         {
             if (aliases is { Length: > 0 }) 
             {
@@ -28,7 +28,7 @@ namespace System.CommandLine
         /// <summary>
         /// Gets the <see cref="Argument">argument</see> for the option.
         /// </summary>
-        internal abstract CliArgument Argument { get; }
+        internal abstract Argument Argument { get; }
 
         /// <summary>
         /// Specifies if a default value is defined for the option.
@@ -101,14 +101,14 @@ namespace System.CommandLine
         /// <summary>
         /// Gets the unique set of strings that can be used on the command line to specify the Option.
         /// </summary>
-        /// <remarks>The collection does not contain the <see cref="CliSymbol.Name"/> of the Option.</remarks>
+        /// <remarks>The collection does not contain the <see cref="Symbol.Name"/> of the Option.</remarks>
         public ICollection<string> Aliases => _aliases ??= new();
 
         /// <summary>
-        /// Gets or sets the <see cref="CliAction"/> for the Option. The handler represents the action
+        /// Gets or sets the <see cref="CommandLineAction"/> for the Option. The handler represents the action
         /// that will be performed when the Option is invoked.
         /// </summary>
-        public virtual CliAction? Action { get; set; }
+        public virtual CommandLineAction? Action { get; set; }
 
         /// <inheritdoc />
         public override IEnumerable<CompletionItem> GetCompletions(CompletionContext context)

--- a/src/System.CommandLine/OptionValidation.cs
+++ b/src/System.CommandLine/OptionValidation.cs
@@ -7,7 +7,7 @@ using System.IO;
 namespace System.CommandLine
 {
     /// <summary>
-    /// Provides extension methods for <see cref="CliOption" />.
+    /// Provides extension methods for <see cref="Option" />.
     /// </summary>
     public static class OptionValidation
     {
@@ -16,7 +16,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="option">The option to configure.</param>
         /// <returns>The option being extended.</returns>
-        public static CliOption<FileInfo> AcceptExistingOnly(this CliOption<FileInfo> option)
+        public static Option<FileInfo> AcceptExistingOnly(this Option<FileInfo> option)
         {
             option._argument.AcceptExistingOnly();
 
@@ -28,7 +28,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="option">The option to configure.</param>
         /// <returns>The option being extended.</returns>
-        public static CliOption<DirectoryInfo> AcceptExistingOnly(this CliOption<DirectoryInfo> option)
+        public static Option<DirectoryInfo> AcceptExistingOnly(this Option<DirectoryInfo> option)
         {
             option._argument.AcceptExistingOnly();
             return option;
@@ -39,7 +39,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="option">The option to configure.</param>
         /// <returns>The option being extended.</returns>
-        public static CliOption<FileSystemInfo> AcceptExistingOnly(this CliOption<FileSystemInfo> option)
+        public static Option<FileSystemInfo> AcceptExistingOnly(this Option<FileSystemInfo> option)
         {
             option._argument.AcceptExistingOnly();
             return option;
@@ -50,7 +50,7 @@ namespace System.CommandLine
         /// </summary>
         /// <param name="option">The option to configure.</param>
         /// <returns>The option being extended.</returns>
-        public static CliOption<T> AcceptExistingOnly<T>(this CliOption<T> option)
+        public static Option<T> AcceptExistingOnly<T>(this Option<T> option)
             where T : IEnumerable<FileSystemInfo>
         {
             option._argument.AcceptExistingOnly();

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -5,44 +5,44 @@ using System.CommandLine.Parsing;
 
 namespace System.CommandLine
 {
-    /// <inheritdoc cref="CliOption" />
+    /// <inheritdoc cref="Option" />
     /// <typeparam name="T">The <see cref="System.Type"/> that the option's arguments are expected to be parsed as.</typeparam>
-    public class CliOption<T> : CliOption
+    public class Option<T> : Option
     {
-        internal readonly CliArgument<T> _argument;
+        internal readonly Argument<T> _argument;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CliOption"/> class.
+        /// Initializes a new instance of the <see cref="Option"/> class.
         /// </summary>
         /// <param name="name">The name of the option. It's used for parsing, displaying Help and creating parse errors.</param>>
         /// <param name="aliases">Optional aliases. Used for parsing, suggestions and displayed in Help.</param>
-        public CliOption(string name, params string[] aliases) 
-            : this(name, aliases, new CliArgument<T>(name))
+        public Option(string name, params string[] aliases) 
+            : this(name, aliases, new Argument<T>(name))
         {
         }
 
-        private protected CliOption(string name, string[] aliases, CliArgument<T> argument)
+        private protected Option(string name, string[] aliases, Argument<T> argument)
             : base(name, aliases)
         {
             argument.AddParent(this);
             _argument = argument;
         }
 
-        /// <inheritdoc cref="CliArgument{T}.DefaultValueFactory" />
+        /// <inheritdoc cref="Argument{T}.DefaultValueFactory" />
         public Func<ArgumentResult, T>? DefaultValueFactory
         {
             get => _argument.DefaultValueFactory;
             set => _argument.DefaultValueFactory = value;
         }
 
-        /// <inheritdoc cref="CliArgument{T}.CustomParser" />
+        /// <inheritdoc cref="Argument{T}.CustomParser" />
         public Func<ArgumentResult, T?>? CustomParser
         {
             get => _argument.CustomParser;
             set => _argument.CustomParser = value;
         }
         
-        internal sealed override CliArgument Argument => _argument;
+        internal sealed override Argument Argument => _argument;
 
         /// <summary>
         /// Configures the option to accept only the specified values, and to suggest them as command line completions.

--- a/src/System.CommandLine/ParseDiagramDirective.cs
+++ b/src/System.CommandLine/ParseDiagramDirective.cs
@@ -7,9 +7,9 @@ namespace System.CommandLine
     /// Enables the use of the <c>[diagram]</c> directive, which when specified on the command line will short 
     /// circuit normal command handling and display a diagram explaining the parse result for the command line input.
     /// </summary>
-    public sealed class DiagramDirective : CliDirective
+    public sealed class DiagramDirective : Directive
     {
-        private CliAction? _action;
+        private CommandLineAction? _action;
 
         /// <summary>
         /// Writes a diagram of the parse result to the output.
@@ -19,7 +19,7 @@ namespace System.CommandLine
         }
 
         /// <inheritdoc />
-        public override CliAction? Action
+        public override CommandLineAction? Action
         {
             get => _action ??= new ParseDiagramAction(ParseErrorReturnValue);
             set => _action = value ?? throw new ArgumentNullException(nameof(value));

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Parsing
         private bool _onlyTakeHasBeenCalled;
 
         internal ArgumentResult(
-            CliArgument argument,
+            Argument argument,
             SymbolResultTree symbolResultTree,
             SymbolResult? parent) : base(symbolResultTree, parent)
         {
@@ -25,7 +25,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The argument to which the result applies.
         /// </summary>
-        public CliArgument Argument { get; }
+        public Argument Argument { get; }
 
         internal bool ArgumentLimitReached => Argument.Arity.MaximumNumberOfValues == (_tokens?.Count ?? 0);
 
@@ -62,7 +62,7 @@ namespace System.CommandLine.Parsing
 
             if (Parent is OptionResult)
             {
-                throw new NotSupportedException($"{nameof(OnlyTake)} is supported only for a {nameof(CliCommand)}-owned {nameof(ArgumentResult)}");
+                throw new NotSupportedException($"{nameof(OnlyTake)} is supported only for a {nameof(Command)}-owned {nameof(ArgumentResult)}");
             }
 
             _onlyTakeHasBeenCalled = true;
@@ -80,7 +80,7 @@ namespace System.CommandLine.Parsing
 
             while (tokensToPass > 0 && nextArgumentIndex < arguments.Count)
             {
-                CliArgument nextArgument = parent.Command.Arguments[nextArgumentIndex];
+                Argument nextArgument = parent.Command.Arguments[nextArgumentIndex];
                 ArgumentResult nextArgumentResult;
 
                 if (SymbolResultTree.TryGetValue(nextArgument, out SymbolResult? symbolResult))
@@ -96,7 +96,7 @@ namespace System.CommandLine.Parsing
 
                 while (!nextArgumentResult.ArgumentLimitReached && tokensToPass > 0)
                 {
-                    CliToken toPass = _tokens[numberOfTokens];
+                    Token toPass = _tokens[numberOfTokens];
                     _tokens.RemoveAt(numberOfTokens);
                     nextArgumentResult.AddToken(toPass);
                     --tokensToPass;
@@ -109,7 +109,7 @@ namespace System.CommandLine.Parsing
             // When_tokens_are_passed_on_by_custom_parser_on_last_argument_then_they_become_unmatched_tokens
             while (tokensToPass > 0)
             {
-                CliToken unmatched = _tokens[numberOfTokens];
+                Token unmatched = _tokens[numberOfTokens];
                 _tokens.RemoveAt(numberOfTokens);
                 SymbolResultTree.AddUnmatchedToken(unmatched, parent, rootCommand);
                 --tokensToPass;

--- a/src/System.CommandLine/Parsing/CommandLineParser.cs
+++ b/src/System.CommandLine/Parsing/CommandLineParser.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
     /// <summary>
     /// Parses command line input.
     /// </summary>
-    public static class CliParser
+    public static class CommandLineParser
     {
         /// <summary>
         /// Parses a list of arguments.
@@ -18,7 +18,7 @@ namespace System.CommandLine.Parsing
         /// <param name="args">The string array typically passed to a program's <c>Main</c> method.</param>
         /// <param name="configuration">The configuration on which the parser's grammar and behaviors are based.</param>
         /// <returns>A <see cref="ParseResult"/> providing details about the parse operation.</returns>
-        public static ParseResult Parse(CliCommand command, IReadOnlyList<string> args, CliConfiguration? configuration = null)
+        public static ParseResult Parse(Command command, IReadOnlyList<string> args, CommandLineConfiguration? configuration = null)
             => Parse(command, args, null, configuration);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace System.CommandLine.Parsing
         /// <param name="configuration">The configuration on which the parser's grammar and behaviors are based.</param>
         /// <remarks>The command line string input will be split into tokens as if it had been passed on the command line.</remarks>
         /// <returns>A <see cref="ParseResult"/> providing details about the parse operation.</returns>
-        public static ParseResult Parse(CliCommand command, string commandLine, CliConfiguration? configuration = null)
+        public static ParseResult Parse(Command command, string commandLine, CommandLineConfiguration? configuration = null)
             => Parse(command, SplitCommandLine(commandLine).ToArray(), commandLine, configuration);
 
         /// <summary>
@@ -136,22 +136,22 @@ namespace System.CommandLine.Parsing
         }
 
         private static ParseResult Parse(
-            CliCommand command,
+            Command command,
             IReadOnlyList<string> arguments,
             string? rawInput,
-            CliConfiguration? configuration)
+            CommandLineConfiguration? configuration)
         {
             if (arguments is null)
             {
                 throw new ArgumentNullException(nameof(arguments));
             }
 
-            configuration ??= new CliConfiguration(command);
+            configuration ??= new CommandLineConfiguration(command);
 
             arguments.Tokenize(
                 configuration,
                 inferRootCommand: rawInput is not null,
-                out List<CliToken> tokens,
+                out List<Token> tokens,
                 out List<string>? tokenizationErrors);
 
             var operation = new ParseOperation(

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -12,8 +12,8 @@ namespace System.CommandLine.Parsing
     public sealed class CommandResult : SymbolResult
     {
         internal CommandResult(
-            CliCommand command,
-            CliToken token,
+            Command command,
+            Token token,
             SymbolResultTree symbolResultTree,
             CommandResult? parent = null) :
             base(symbolResultTree, parent)
@@ -25,12 +25,12 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The command to which the result applies.
         /// </summary>
-        public CliCommand Command { get; }
+        public Command Command { get; }
 
         /// <summary>
         /// The token that was parsed to specify the command.
         /// </summary>
-        public CliToken IdentifierToken { get; }
+        public Token IdentifierToken { get; }
 
         /// <summary>
         /// Child symbol results in the parse tree.
@@ -153,7 +153,7 @@ namespace System.CommandLine.Parsing
             var arguments = Command.Arguments;
             for (var i = 0; i < arguments.Count; i++)
             {
-                CliArgument argument = arguments[i];
+                Argument argument = arguments[i];
 
                 if (!completeValidation && !argument.HasDefaultValue)
                 {

--- a/src/System.CommandLine/Parsing/DirectiveResult.cs
+++ b/src/System.CommandLine/Parsing/DirectiveResult.cs
@@ -9,7 +9,7 @@ namespace System.CommandLine.Parsing
     {
         private List<string>? _values;
 
-        internal DirectiveResult(CliDirective directive, CliToken token, SymbolResultTree symbolResultTree)
+        internal DirectiveResult(Directive directive, Token token, SymbolResultTree symbolResultTree)
             : base(symbolResultTree, null) // directives don't belong to any command
         {
             Directive = directive;
@@ -25,12 +25,12 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The directive to which the result applies.
         /// </summary>
-        public CliDirective Directive { get; }
+        public Directive Directive { get; }
 
         /// <summary>
         /// The token that was parsed to specify the directive.
         /// </summary>
-        public CliToken Token { get; }
+        public Token Token { get; }
 
         internal void AddValue(string value) => (_values ??= new()).Add(value);
     }

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -15,9 +15,9 @@ namespace System.CommandLine.Parsing
         private ArgumentConversionResult? _argumentConversionResult;
 
         internal OptionResult(
-            CliOption option,
+            Option option,
             SymbolResultTree symbolResultTree,
-            CliToken? token = null,
+            Token? token = null,
             CommandResult? parent = null) :
             base(symbolResultTree, parent)
         {
@@ -28,7 +28,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The option to which the result applies.
         /// </summary>
-        public CliOption Option { get; }
+        public Option Option { get; }
 
         /// <summary>
         /// Indicates whether the result was created implicitly and not due to the option being specified on the command line.
@@ -40,7 +40,7 @@ namespace System.CommandLine.Parsing
         /// The token that was parsed to specify the option.
         /// </summary>
         /// <remarks>An identifier token is a token that matches either the option's name or one of its aliases.</remarks>
-        public CliToken? IdentifierToken { get; }
+        public Token? IdentifierToken { get; }
 
         /// <summary>
         /// The number of occurrences of an identifier token matching the option.

--- a/src/System.CommandLine/Parsing/ParseDiagramAction.cs
+++ b/src/System.CommandLine/Parsing/ParseDiagramAction.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.Parsing
     /// <summary>
     /// Implements the <c>[diagram]</c> directive action, which when specified on the command line will short circuit normal command handling and display a diagram explaining the parse result for the command line input.
     /// </summary>
-    internal sealed class ParseDiagramAction : SynchronousCliAction
+    internal sealed class ParseDiagramAction : SynchronousCommandLineAction
     {
         private readonly int _parseErrorReturnValue;
 
@@ -69,7 +69,7 @@ namespace System.CommandLine.Parsing
                 case ArgumentResult argumentResult:
                 {
                     var includeArgumentName =
-                        argumentResult.Argument.FirstParent!.Symbol is CliCommand { HasArguments: true, Arguments.Count: > 1 };
+                        argumentResult.Argument.FirstParent!.Symbol is Command { HasArguments: true, Arguments.Count: > 1 };
 
                     if (includeArgumentName)
                     {

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -11,7 +11,7 @@ namespace System.CommandLine.Parsing
     public abstract class SymbolResult
     {
         internal readonly SymbolResultTree SymbolResultTree;
-        private protected List<CliToken>? _tokens;
+        private protected List<Token>? _tokens;
 
         private protected SymbolResult(SymbolResultTree symbolResultTree, SymbolResult? parent)
         {
@@ -52,9 +52,9 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The list of tokens associated with this symbol result during parsing.
         /// </summary>
-        public IReadOnlyList<CliToken> Tokens => _tokens is not null ? _tokens : Array.Empty<CliToken>();
+        public IReadOnlyList<Token> Tokens => _tokens is not null ? _tokens : Array.Empty<Token>();
 
-        internal void AddToken(CliToken token) => (_tokens ??= new()).Add(token);
+        internal void AddToken(Token token) => (_tokens ??= new()).Add(token);
 
         /// <summary>
         /// Adds an error message for this symbol result to it's parse tree.
@@ -67,28 +67,28 @@ namespace System.CommandLine.Parsing
         /// </summary>
         /// <param name="argument">The argument for which to find a result.</param>
         /// <returns>An argument result if the argument was matched by the parser or has a default value; otherwise, <c>null</c>.</returns>
-        public ArgumentResult? GetResult(CliArgument argument) => SymbolResultTree.GetResult(argument);
+        public ArgumentResult? GetResult(Argument argument) => SymbolResultTree.GetResult(argument);
 
         /// <summary>
         /// Finds a result for the specific command anywhere in the parse tree, including parent and child symbol results.
         /// </summary>
         /// <param name="command">The command for which to find a result.</param>
         /// <returns>An command result if the command was matched by the parser; otherwise, <c>null</c>.</returns>
-        public CommandResult? GetResult(CliCommand command) => SymbolResultTree.GetResult(command);
+        public CommandResult? GetResult(Command command) => SymbolResultTree.GetResult(command);
 
         /// <summary>
         /// Finds a result for the specific option anywhere in the parse tree, including parent and child symbol results.
         /// </summary>
         /// <param name="option">The option for which to find a result.</param>
         /// <returns>An option result if the option was matched by the parser or has a default value; otherwise, <c>null</c>.</returns>
-        public OptionResult? GetResult(CliOption option) => SymbolResultTree.GetResult(option);
+        public OptionResult? GetResult(Option option) => SymbolResultTree.GetResult(option);
 
         /// <summary>
         /// Finds a result for the specific directive anywhere in the parse tree.
         /// </summary>
         /// <param name="directive">The directive for which to find a result.</param>
         /// <returns>A directive result if the directive was matched by the parser, <c>null</c> otherwise.</returns>
-        public DirectiveResult? GetResult(CliDirective directive) => SymbolResultTree.GetResult(directive);
+        public DirectiveResult? GetResult(Directive directive) => SymbolResultTree.GetResult(directive);
 
         /// <summary>
         /// Finds a result for a symbol having the specified name anywhere in the parse tree.
@@ -98,8 +98,8 @@ namespace System.CommandLine.Parsing
         public SymbolResult? GetResult(string name) => 
             SymbolResultTree.GetResult(name);
 
-        /// <inheritdoc cref="ParseResult.GetValue{T}(CliArgument{T})"/>
-        public T? GetValue<T>(CliArgument<T> argument)
+        /// <inheritdoc cref="ParseResult.GetValue{T}(Argument{T})"/>
+        public T? GetValue<T>(Argument<T> argument)
         {
             if (GetResult(argument) is { } result &&
                 result.GetValueOrDefault<T>() is { } t)
@@ -107,11 +107,11 @@ namespace System.CommandLine.Parsing
                 return t;
             }
 
-            return CliArgument<T>.CreateDefaultValue();
+            return Argument<T>.CreateDefaultValue();
         }
 
-        /// <inheritdoc cref="ParseResult.GetValue{T}(CliOption{T})"/>
-        public T? GetValue<T>(CliOption<T> option)
+        /// <inheritdoc cref="ParseResult.GetValue{T}(Option{T})"/>
+        public T? GetValue<T>(Option<T> option)
         {
             if (GetResult(option) is { } result &&
                 result.GetValueOrDefault<T>() is { } t)
@@ -119,7 +119,7 @@ namespace System.CommandLine.Parsing
                 return t;
             }
 
-            return CliArgument<T>.CreateDefaultValue();
+            return Argument<T>.CreateDefaultValue();
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace System.CommandLine.Parsing
                 }
             }
 
-            return CliArgument<T>.CreateDefaultValue();
+            return Argument<T>.CreateDefaultValue();
         }
 
         internal virtual bool UseDefaultValueFor(ArgumentResult argumentResult) => false;

--- a/src/System.CommandLine/Parsing/SymbolResultTree.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultTree.cs
@@ -5,15 +5,15 @@ using System.Collections.Generic;
 
 namespace System.CommandLine.Parsing
 {
-    internal sealed class SymbolResultTree : Dictionary<CliSymbol, SymbolResult>
+    internal sealed class SymbolResultTree : Dictionary<Symbol, SymbolResult>
     {
-        private readonly CliCommand _rootCommand;
+        private readonly Command _rootCommand;
         internal List<ParseError>? Errors;
-        internal List<CliToken>? UnmatchedTokens;
+        internal List<Token>? UnmatchedTokens;
         private Dictionary<string, SymbolNode>? _symbolsByName;
 
         internal SymbolResultTree(
-            CliCommand rootCommand, 
+            Command rootCommand, 
             List<string>? tokenizeErrors)
         {
             _rootCommand = rootCommand;
@@ -31,23 +31,23 @@ namespace System.CommandLine.Parsing
 
         internal int ErrorCount => Errors?.Count ?? 0;
 
-        internal ArgumentResult? GetResult(CliArgument argument)
+        internal ArgumentResult? GetResult(Argument argument)
             => TryGetValue(argument, out SymbolResult? result) ? (ArgumentResult)result : default;
 
-        internal CommandResult? GetResult(CliCommand command)
+        internal CommandResult? GetResult(Command command)
             => TryGetValue(command, out var result) ? (CommandResult)result : default;
 
-        internal OptionResult? GetResult(CliOption option)
+        internal OptionResult? GetResult(Option option)
             => TryGetValue(option, out SymbolResult? result) ? (OptionResult)result : default;
 
-        internal DirectiveResult? GetResult(CliDirective directive)
+        internal DirectiveResult? GetResult(Directive directive)
             => TryGetValue(directive, out SymbolResult? result) ? (DirectiveResult)result : default;
 
         internal IEnumerable<SymbolResult> GetChildren(SymbolResult parent)
         {
             if (parent is not ArgumentResult)
             {
-                foreach (KeyValuePair<CliSymbol, SymbolResult> pair in this)
+                foreach (KeyValuePair<Symbol, SymbolResult> pair in this)
                 {
                     if (ReferenceEquals(parent, pair.Value.Parent))
                     {
@@ -61,7 +61,7 @@ namespace System.CommandLine.Parsing
 
         internal void InsertFirstError(ParseError parseError) => (Errors ??= new()).Insert(0, parseError);
 
-        internal void AddUnmatchedToken(CliToken token, CommandResult commandResult, CommandResult rootCommandResult)
+        internal void AddUnmatchedToken(Token token, CommandResult commandResult, CommandResult rootCommandResult)
         {
             (UnmatchedTokens ??= new()).Add(token);
 
@@ -102,7 +102,7 @@ namespace System.CommandLine.Parsing
             return null;
         }
 
-        private void PopulateSymbolsByName(CliCommand command)
+        private void PopulateSymbolsByName(Command command)
         {
             if (command.HasArguments)
             {
@@ -130,7 +130,7 @@ namespace System.CommandLine.Parsing
                 }
             }
 
-            void AddToSymbolsByName(CliSymbol symbol)
+            void AddToSymbolsByName(Symbol symbol)
             {
                 if (_symbolsByName!.TryGetValue(symbol.Name, out var node))
                 {

--- a/src/System.CommandLine/Parsing/Token.cs
+++ b/src/System.CommandLine/Parsing/Token.cs
@@ -6,14 +6,14 @@ namespace System.CommandLine.Parsing
     /// <summary>
     /// A unit of significant text on the command line.
     /// </summary>
-    public sealed class CliToken : IEquatable<CliToken>
+    public sealed class Token : IEquatable<Token>
     {
         internal const int ImplicitPosition = -1;
 
         /// <param name="value">The string value of the token.</param>
         /// <param name="type">The type of the token.</param>
         /// <param name="symbol">The symbol represented by the token</param>
-        public CliToken(string? value, CliTokenType type, CliSymbol symbol)
+        public Token(string? value, TokenType type, Symbol symbol)
         {
             Value = value ?? "";
             Type = type;
@@ -21,7 +21,7 @@ namespace System.CommandLine.Parsing
             Position = ImplicitPosition;
         }
        
-        internal CliToken(string? value, CliTokenType type, CliSymbol? symbol, int position)
+        internal Token(string? value, TokenType type, Symbol? symbol, int position)
         {
             Value = value ?? "";
             Type = type;
@@ -41,18 +41,18 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// The type of the token.
         /// </summary>
-        public CliTokenType Type { get; }
+        public TokenType Type { get; }
 
         /// <summary>
         /// The Symbol represented by the token (if any).
         /// </summary>
-        internal CliSymbol? Symbol { get; set; }
+        internal Symbol? Symbol { get; set; }
 
         /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as CliToken);
+        public override bool Equals(object? obj) => Equals(obj as Token);
 
         /// <inheritdoc />
-        public bool Equals(CliToken? other) => other is not null && Value == other.Value && Type == other.Type && ReferenceEquals(Symbol, other.Symbol);
+        public bool Equals(Token? other) => other is not null && Value == other.Value && Type == other.Type && ReferenceEquals(Symbol, other.Symbol);
 
         /// <inheritdoc />
         public override int GetHashCode() => Value.GetHashCode() ^ (int)Type;
@@ -61,19 +61,19 @@ namespace System.CommandLine.Parsing
         public override string ToString() => Value;
 
         /// <summary>
-        /// Checks if two specified <see cref="CliToken"/> instances have the same value.
+        /// Checks if two specified <see cref="Token"/> instances have the same value.
         /// </summary>
-        /// <param name="left">The first <see cref="CliToken"/>.</param>
-        /// <param name="right">The second <see cref="CliToken"/>.</param>
+        /// <param name="left">The first <see cref="Token"/>.</param>
+        /// <param name="right">The second <see cref="Token"/>.</param>
         /// <returns><see langword="true" /> if the objects are equal.</returns>
-        public static bool operator ==(CliToken? left, CliToken? right) => left is null ? right is null : left.Equals(right);
+        public static bool operator ==(Token? left, Token? right) => left is null ? right is null : left.Equals(right);
 
         /// <summary>
-        /// Checks if two specified <see cref="CliToken"/> instances have different values.
+        /// Checks if two specified <see cref="Token"/> instances have different values.
         /// </summary>
-        /// <param name="left">The first <see cref="CliToken"/>.</param>
-        /// <param name="right">The second <see cref="CliToken"/>.</param>
+        /// <param name="left">The first <see cref="Token"/>.</param>
+        /// <param name="right">The second <see cref="Token"/>.</param>
         /// <returns><see langword="true" /> if the objects are not equal.</returns>
-        public static bool operator !=(CliToken? left, CliToken? right) => left is null ? right is not null : !left.Equals(right);
+        public static bool operator !=(Token? left, Token? right) => left is null ? right is not null : !left.Equals(right);
     }
 }

--- a/src/System.CommandLine/Parsing/TokenType.cs
+++ b/src/System.CommandLine/Parsing/TokenType.cs
@@ -4,26 +4,26 @@
 namespace System.CommandLine.Parsing
 {
     /// <summary>
-    /// Identifies the type of a <see cref="CliToken"/>.
+    /// Identifies the type of a <see cref="Token"/>.
     /// </summary>
-    public enum CliTokenType
+    public enum TokenType
     {
         /// <summary>
         /// An argument token.
         /// </summary>
-        /// <see cref="CliArgument"/>
+        /// <see cref="CommandLine.Argument"/>
         Argument,
 
         /// <summary>
         /// A command token.
         /// </summary>
-        /// <see cref="CliCommand"/>
+        /// <see cref="CommandLine.Command"/>
         Command,
-        
+
         /// <summary>
         /// An option token.
         /// </summary>
-        /// <see cref="CliOption"/>
+        /// <see cref="CommandLine.Option"/>
         Option,
         
         /// <summary>
@@ -34,7 +34,7 @@ namespace System.CommandLine.Parsing
         /// <summary>
         /// A directive token.
         /// </summary>
-        /// <see cref="CliDirective"/>
+        /// <see cref="CommandLine.Directive"/>
         Directive
     }
 }

--- a/src/System.CommandLine/RootCommand.cs
+++ b/src/System.CommandLine/RootCommand.cs
@@ -15,9 +15,9 @@ namespace System.CommandLine
     /// <remarks>
     /// Use the RootCommand object without any subcommands for applications that perform one action. Add subcommands 
     /// to the root for applications that require actions identified by specific strings. For example, `dir` does not 
-    /// use any subcommands. See <see cref="CliCommand"/> for applications with multiple actions.
+    /// use any subcommands. See <see cref="Command"/> for applications with multiple actions.
     /// </remarks>
-    public class CliRootCommand : CliCommand
+    public class RootCommand : Command
     {
         private static Assembly? _assembly;
         private static string? _executablePath;
@@ -25,11 +25,11 @@ namespace System.CommandLine
         private static string? _executableVersion;
 
         /// <param name="description">The description of the command, shown in help.</param>
-        public CliRootCommand(string description = "") : base(ExecutableName, description)
+        public RootCommand(string description = "") : base(ExecutableName, description)
         {
             Options.Add(new HelpOption());
             Options.Add(new VersionOption()); 
-            Directives = new ChildSymbolList<CliDirective>(this)
+            Directives = new ChildSymbolList<Directive>(this)
             {
                 new SuggestDirective()
             };
@@ -38,12 +38,12 @@ namespace System.CommandLine
         /// <summary>
         /// Represents all of the directives that are valid under the root command.
         /// </summary>
-        public IList<CliDirective> Directives { get; }
+        public IList<Directive> Directives { get; }
 
         /// <summary>
-        /// Adds a <see cref="CliDirective"/> to the command.
+        /// Adds a <see cref="Directive"/> to the command.
         /// </summary>
-        public void Add(CliDirective directive) => Directives.Add(directive);
+        public void Add(Directive directive) => Directives.Add(directive);
 
         internal static Assembly GetAssembly()
             => _assembly ??= (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly());

--- a/src/System.CommandLine/Symbol.cs
+++ b/src/System.CommandLine/Symbol.cs
@@ -10,9 +10,9 @@ namespace System.CommandLine
     /// <summary>
     /// Defines a named symbol that resides in a hierarchy with parent and child symbols.
     /// </summary>
-    public abstract class CliSymbol
+    public abstract class Symbol
     {
-        private protected CliSymbol(string name, bool allowWhitespace = false)
+        private protected Symbol(string name, bool allowWhitespace = false)
         {
             Name = ThrowIfEmptyOrWithWhitespaces(name, nameof(name), allowWhitespace);
         }
@@ -32,7 +32,7 @@ namespace System.CommandLine
         /// </summary>
         internal SymbolNode? FirstParent { get; private set; }
 
-        internal void AddParent(CliSymbol symbol)
+        internal void AddParent(Symbol symbol)
         {
             if (FirstParent == null)
             {
@@ -57,7 +57,7 @@ namespace System.CommandLine
         /// <summary>
         /// Gets the parent symbols.
         /// </summary>
-        public IEnumerable<CliSymbol> Parents
+        public IEnumerable<Symbol> Parents
         {
             get
             {

--- a/src/System.CommandLine/SymbolExtensions.cs
+++ b/src/System.CommandLine/SymbolExtensions.cs
@@ -10,18 +10,18 @@ namespace System.CommandLine
     /// </summary>
     internal static class SymbolExtensions
     {
-        internal static IList<CliArgument> Arguments(this CliSymbol symbol)
+        internal static IList<Argument> Arguments(this Symbol symbol)
         {
             switch (symbol)
             {
-                case CliOption option:
+                case Option option:
                     return new[]
                     {
                         option.Argument
                     };
-                case CliCommand command:
+                case Command command:
                     return command.Arguments;
-                case CliArgument argument:
+                case Argument argument:
                     return new[]
                     {
                         argument

--- a/src/System.CommandLine/SymbolNode.cs
+++ b/src/System.CommandLine/SymbolNode.cs
@@ -5,9 +5,9 @@ namespace System.CommandLine
 {
     internal sealed class SymbolNode
     {
-        internal SymbolNode(CliSymbol symbol) => Symbol = symbol;
+        internal SymbolNode(Symbol symbol) => Symbol = symbol;
 
-        internal CliSymbol Symbol { get; }
+        internal Symbol Symbol { get; }
 
         internal SymbolNode? Next { get; set; }
     }

--- a/src/System.CommandLine/VersionOption.cs
+++ b/src/System.CommandLine/VersionOption.cs
@@ -10,29 +10,29 @@ namespace System.CommandLine
     /// <summary>
     /// A standard option that indicates that version information should be displayed for the app.
     /// </summary>
-    public sealed class VersionOption : CliOption<bool>
+    public sealed class VersionOption : Option<bool>
     {
-        private CliAction? _action;
+        private CommandLineAction? _action;
 
         /// <summary>
-        /// When added to a <see cref="CliCommand"/>, it enables the use of a <c>--version</c> option, which when specified in command line input will short circuit normal command handling and instead write out version information before exiting.
+        /// When added to a <see cref="Command"/>, it enables the use of a <c>--version</c> option, which when specified in command line input will short circuit normal command handling and instead write out version information before exiting.
         /// </summary>
         public VersionOption() : this("--version", Array.Empty<string>())
         {
         }
 
         /// <summary>
-        /// When added to a <see cref="CliCommand"/>, it enables the use of a provided option name and aliases, which when specified in command line input will short circuit normal command handling and instead write out version information before exiting.
+        /// When added to a <see cref="Command"/>, it enables the use of a provided option name and aliases, which when specified in command line input will short circuit normal command handling and instead write out version information before exiting.
         /// </summary>
         public VersionOption(string name, params string[] aliases)
-            : base(name, aliases, new CliArgument<bool>("--version") { Arity = ArgumentArity.Zero })
+            : base(name, aliases, new Argument<bool>("--version") { Arity = ArgumentArity.Zero })
         {
             Description = LocalizationResources.VersionOptionDescription();
             AddValidators();
         }
 
         /// <inheritdoc />
-        public override CliAction? Action
+        public override CommandLineAction? Action
         {
             get => _action ??= new VersionOptionAction();
             set => _action = value ?? throw new ArgumentNullException(nameof(value));
@@ -52,11 +52,11 @@ namespace System.CommandLine
 
         internal override bool Greedy => false;
 
-        private sealed class VersionOptionAction : SynchronousCliAction
+        private sealed class VersionOptionAction : SynchronousCommandLineAction
         {
             public override int Invoke(ParseResult parseResult)
             {
-                parseResult.Configuration.Output.WriteLine(CliRootCommand.ExecutableVersion);
+                parseResult.Configuration.Output.WriteLine(RootCommand.ExecutableVersion);
                 return 0;
             }
         }


### PR DESCRIPTION
Cli prefix changes:
- remove it for symbol types, Token and TokenType
- replace it with full word CommandLine for Action, Parser and Configuration

All changes except of the approval test files were fully automated with the help of Visual Studio.

Please don't merge this PR, as I need to prepare few other repos for the incoming changes and I am not sure if it would not break the VMR (cc @ViktorHofer )