### PR TITLE
Fix ArgumentConverted for nullable args

### DIFF
--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -270,6 +270,23 @@ namespace System.CommandLine.Tests.Binding
                 .Be(null);
         }
 
+        [Theory]
+        [InlineData("-x", true)]
+        [InlineData("-x:true", true)]
+        [InlineData("-x:false", false)]
+        public void Nullable_bool_option_result_casts_to_nullable_bool(string command, bool expectedValue)
+        {
+            var option = new Option<bool?>("-x");
+
+            var value = new RootCommand { option }
+                .Parse(command)
+                .GetResult(option)
+                .GetValueOrDefault<object>();
+
+            value.Should().BeAssignableTo<bool?>();
+            value.Should().Be(expectedValue);
+        }
+
         [Fact]
         public void When_exactly_one_argument_is_expected_and_none_are_provided_then_getting_value_throws()
         {

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -172,6 +172,12 @@ namespace System.CommandLine.Binding
                     continue;
                 }
 
+                if (type.TryGetNullableType(out Type? nullableType))
+                {
+                    type = nullableType;
+                    continue;
+                }
+
                 return false;
             }
         }
@@ -189,7 +195,7 @@ namespace System.CommandLine.Binding
 
                 ArgumentConversionResultType.NoArgument when conversionResult.ArgumentResult.Argument.IsBoolean() =>
                     Success(conversionResult.ArgumentResult, true),
-                        
+
                 _ => conversionResult
             };
         }


### PR DESCRIPTION
This fixes cases where conversion of tokens in options of nullable scalar-bindable values with Artities that are not {1,1} like `Option<bool?>` but conversion is still well known.

Alternatively, if this is the only case that's a `ZeroOrOne` arity that we care about, it might be faster to elide branches and do what the  `{1, 1}` branch does.