### PR TITLE
Add ValueType to Option

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -1,4 +1,4 @@
-System.CommandLine
+﻿System.CommandLine
   public abstract class Argument : Symbol
     public ArgumentArity Arity { get; set; }
     public System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> CompletionSources { get; }
@@ -98,11 +98,13 @@ System.CommandLine
     public System.Boolean Recursive { get; set; }
     public System.Boolean Required { get; set; }
     public System.Collections.Generic.List<System.Action<System.CommandLine.Parsing.OptionResult>> Validators { get; }
+    public System.Type ValueType { get; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
   public class Option<T> : Option
     .ctor(System.String name, System.String[] aliases)
     public Func<System.CommandLine.Parsing.ArgumentResult,T> CustomParser { get; set; }
     public Func<System.CommandLine.Parsing.ArgumentResult,T> DefaultValueFactory { get; set; }
+    public System.Type ValueType { get; }
     public System.Void AcceptLegalFileNamesOnly()
     public System.Void AcceptLegalFilePathsOnly()
     public System.Void AcceptOnlyFromAmong(System.String[] values)

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -63,6 +63,11 @@ namespace System.CommandLine
         public bool Recursive { get; set; }
 
         /// <summary>
+        /// Gets the <see cref="Type" /> that the option's parsed tokens will be converted to.
+        /// </summary>
+        public abstract Type ValueType { get; }
+
+        /// <summary>
         /// Validators that will be called when the option is matched by the parser.
         /// </summary>
         public List<Action<OptionResult>> Validators => _validators ??= new();

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -44,6 +44,9 @@ namespace System.CommandLine
         
         internal sealed override Argument Argument => _argument;
 
+        /// <inheritdoc />
+        public override Type ValueType => _argument.ValueType;
+
         /// <summary>
         /// Configures the option to accept only the specified values, and to suggest them as command line completions.
         /// </summary>


### PR DESCRIPTION
## Summary

When using the exposed surface of S.CL to create a JSON document that represents the dotnet CLI (via [this issue](https://github.com/dotnet/sdk/issues/46345)), I realized there was no way to get the System.Type of an Option. I looked at the S.CL class hierarchy and realized that information existed in the composed Argument within Option. (I used reflection [here](https://github.com/MiYanni/sdk/commit/b5b98619d8d71fdbb3fb56dc35a1f99512fc0ef4#diff-0e0732e037481ba444a5015df3d0c74184716f314d8b0b3db2402ef41c2bf31cR152-R153) to get at that information)

What I've done is added a `ValueType` property to `Option` that is exposed in the same way it is for `Argument`. For Options, a majority of the data is stored in the composed Argument, so to keep that design, I simply expose `_argument.ValueType` within `Option`.