### PR TITLE
Remove illegal string manipulation

### DIFF
--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -5,7 +5,6 @@
     <PackageId>System.CommandLine</PackageId>
     <TargetFrameworks>$(TargetFrameworkForNETSDK);netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <Description>Support for parsing command lines, supporting both POSIX and Windows conventions and shell-agnostic command line completions.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Part of the "reduce unsafe" effort across .NET.

The command line parsing code previously manipulated string instances in-place, which is not a legal operation on any .NET runtime. Removing this logic and falling back to a standard allocation.

@adamsitnik, when you get a chance, please make a **reduce-unsafe** label similar to what runtime and winforms already have, and assign that label to this PR. We're using that label to track this effort across repos.

I have not perf-tested this change, but I don't expect it to be too bad, especially since all the other perf improvements Adam introduced several years ago will remain in place. If this change does end up unacceptably impacting perf, we can work together on a safer solution if needed.