### PR TITLE
Bump from 'beta4' to 'beta5'

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseBetaVersion)' == 'true'">
     <VersionPrefix>2.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>beta4</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>beta5</PreReleaseVersionLabel>
     <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseAlphaVersion)' == 'true'">


### PR DESCRIPTION
Since we've solidified the API changes we want to keep, and they are breaking, we should change our prerelease label from beta4 to beta5.