### PR TITLE
Move from FluentAssertions to AwesomeAssertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <!-- external dependencies -->
     <PackageVersion Include="ApprovalTests" Version="7.0.0-beta.3" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageVersion Include="FluentAssertions" Version="5.10.3" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />

--- a/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
+++ b/src/System.CommandLine.DragonFruit.Tests/ConfigureFromMethodTests.cs
@@ -28,7 +28,7 @@ namespace System.CommandLine.DragonFruit.Tests
 
             await config.InvokeAsync($"{RootCommand.ExecutableName} --value");
 
-            _receivedValues.Should().BeEquivalentTo(true);
+            _receivedValues.Should().BeEquivalentTo(new object[] { true });
         }
 
         [Theory]
@@ -47,7 +47,7 @@ namespace System.CommandLine.DragonFruit.Tests
 
             await config.InvokeAsync(commandLine);
 
-            _receivedValues.Should().BeEquivalentTo(expected);
+            _receivedValues.Should().BeEquivalentTo(new [] { expected });
         }
 
         [Fact]
@@ -220,7 +220,7 @@ namespace System.CommandLine.DragonFruit.Tests
 
             await command.Parse("--value").InvokeAsync();
 
-            _receivedValues.Should().BeEquivalentTo(true);
+            _receivedValues.Should().BeEquivalentTo(new [] { true });
         }
 
         [Fact]
@@ -231,7 +231,7 @@ namespace System.CommandLine.DragonFruit.Tests
 
             await command.Parse("").InvokeAsync();
 
-            _receivedValues.Should().BeEquivalentTo(1, 2);
+            _receivedValues.Should().BeEquivalentTo(new [] { 1, 2 });
         }
 
         internal void Method_taking_bool(bool value = false)

--- a/src/System.CommandLine.DragonFruit.Tests/System.CommandLine.DragonFruit.Tests.csproj
+++ b/src/System.CommandLine.DragonFruit.Tests/System.CommandLine.DragonFruit.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   

--- a/src/System.CommandLine.Generator.Tests/System.CommandLine.Generator.Tests.csproj
+++ b/src/System.CommandLine.Generator.Tests/System.CommandLine.Generator.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>
 

--- a/src/System.CommandLine.Hosting.Tests/System.CommandLine.Hosting.Tests.csproj
+++ b/src/System.CommandLine.Hosting.Tests/System.CommandLine.Hosting.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
   </ItemGroup>
 

--- a/src/System.CommandLine.NamingConventionBinder.Tests/System.CommandLine.NamingConventionBinder.Tests.csproj
+++ b/src/System.CommandLine.NamingConventionBinder.Tests/System.CommandLine.NamingConventionBinder.Tests.csproj
@@ -19,7 +19,7 @@
   
   <ItemGroup>
     <PackageReference Include="ApprovalTests" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>

--- a/src/System.CommandLine.Suggest.Tests/GlobalToolsSuggestionRegistrationTests.cs
+++ b/src/System.CommandLine.Suggest.Tests/GlobalToolsSuggestionRegistrationTests.cs
@@ -50,11 +50,11 @@ namespace System.CommandLine.Suggest.Tests
 
             registrationPairs
                 .Should()
-                .BeEquivalentTo(
+                .BeEquivalentTo( new [] {
                     new Registration(
                         Path.Combine(dotnetProfileDirectory, "tools", "dotnet-suggest")),
                     new Registration(
-                        Path.Combine(dotnetProfileDirectory, "tools", "t-rex")));
+                        Path.Combine(dotnetProfileDirectory, "tools", "t-rex"))});
         }
     }
 }

--- a/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
+++ b/src/System.CommandLine.Suggest.Tests/dotnet-suggest.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -689,7 +689,7 @@ namespace System.CommandLine.Tests.Binding
 
         [Fact]
         public void Values_can_be_correctly_converted_to_array_of_int_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new Option<int[]>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
+            => GetValue(new Option<int[]>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(new[] { 1, 2, 3 });
 
         [Theory]
         [InlineData(0, 100_000, typeof(string[]))]
@@ -734,11 +734,11 @@ namespace System.CommandLine.Tests.Binding
 
         [Fact]
         public void Values_can_be_correctly_converted_to_List_of_int_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new Option<List<int>>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
+            => GetValue(new Option<List<int>>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(new[] {1, 2, 3});
 
         [Fact]
         public void Values_can_be_correctly_converted_to_IEnumerable_of_int_without_the_parser_specifying_a_custom_converter()
-            => GetValue(new Option<IEnumerable<int>>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(1, 2, 3);
+            => GetValue(new Option<IEnumerable<int>>("-x"), "-x 1 -x 2 -x 3").Should().BeEquivalentTo(new[] { 1, 2, 3 });
 
         [Fact]
         public void Enum_values_can_be_correctly_converted_based_on_enum_value_name_without_the_parser_specifying_a_custom_converter()
@@ -826,6 +826,6 @@ namespace System.CommandLine.Tests.Binding
         }
 
         private void AssertParsedValueIsEmpty<T>(Argument<T> argument) where T : IEnumerable
-            => GetValue(argument, "").Should().BeEmpty();
+            => GetValue(argument, "").Should().BeEquivalentTo(Enumerable.Empty<T>());
     }
 }

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -311,6 +311,7 @@ namespace System.CommandLine.Tests
             var result = rootCommand.Parse("cherry ", simpleConfig);
 
             result.GetCompletions()
+                  .Select(item => item.Label)
                   .Should()
                   .NotContain(new[]{"apple", "banana", "cherry"});
         }
@@ -381,6 +382,7 @@ namespace System.CommandLine.Tests
 
             parseResult
                 .GetCompletions(commandLine.Length + 1)
+                .Select(item => item.Label)
                 .Should()
                 .NotContain("--parent-option");
         }

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1030,12 +1030,12 @@ namespace System.CommandLine.Tests
                   .Children
                   .Select(s => ((OptionResult)s).Option)
                   .Should()
-                  .BeEquivalentTo(option1);
+                  .BeEquivalentTo(new[] { option1 });
             parser.Parse("--a").CommandResult
                   .Children
                   .Select(s => ((OptionResult)s).Option)
                   .Should()
-                  .BeEquivalentTo(option2);
+                  .BeEquivalentTo(new[] { option2 });
         }
 
         [Theory]
@@ -1398,10 +1398,10 @@ namespace System.CommandLine.Tests
                    .CommandResult
                    .Tokens
                    .Should()
-                   .BeEquivalentTo(
+                   .BeEquivalentTo(new [] {
                        new Token("1", TokenType.Argument, argument),
                        new Token("2", TokenType.Argument, argument),
-                       new Token("3", TokenType.Argument, argument));
+                       new Token("3", TokenType.Argument, argument)});
         }
 
         [Fact]
@@ -1420,20 +1420,20 @@ namespace System.CommandLine.Tests
                    .CommandResult
                    .Tokens
                    .Should()
-                   .BeEquivalentTo(
+                   .BeEquivalentTo(new [] {
                        new Token("1", TokenType.Argument, argument),
                        new Token("2", TokenType.Argument, argument),
-                       new Token("3", TokenType.Argument, argument));
+                       new Token("3", TokenType.Argument, argument)});
             command.Parse("1 2 3 4 5")
                    .CommandResult
                    .Tokens
                    .Should()
-                   .BeEquivalentTo(
+                   .BeEquivalentTo(new [] {
                        new Token("1", TokenType.Argument, argument),
                        new Token("2", TokenType.Argument, argument),
                        new Token("3", TokenType.Argument, argument),
                        new Token("4", TokenType.Argument, argument),
-                       new Token("5", TokenType.Argument, argument));
+                       new Token("5", TokenType.Argument, argument)});
         }
 
         [Fact]
@@ -1489,10 +1489,10 @@ namespace System.CommandLine.Tests
                    .GetResult(option)
                    .Tokens
                    .Should()
-                   .BeEquivalentTo(
+                   .BeEquivalentTo(new [] {
                        new Token("1", TokenType.Argument, default),
                        new Token("2", TokenType.Argument, default),
-                       new Token("3", TokenType.Argument, default));
+                       new Token("3", TokenType.Argument, default)});
         }
 
         [Fact]
@@ -1509,20 +1509,20 @@ namespace System.CommandLine.Tests
                    .GetResult(option)
                    .Tokens
                    .Should()
-                   .BeEquivalentTo(
+                   .BeEquivalentTo(new [] {
                        new Token("1", TokenType.Argument, default),
                        new Token("2", TokenType.Argument, default),
-                       new Token("3", TokenType.Argument, default));
+                       new Token("3", TokenType.Argument, default)});
             command.Parse("-x 1 -x 2 -x 3 -x 4 -x 5")
                    .GetResult(option)
                    .Tokens
                    .Should()
-                   .BeEquivalentTo(
+                   .BeEquivalentTo(new [] {
                        new Token("1", TokenType.Argument, default),
                        new Token("2", TokenType.Argument, default),
                        new Token("3", TokenType.Argument, default),
                        new Token("4", TokenType.Argument, default),
-                       new Token("5", TokenType.Argument, default));
+                       new Token("5", TokenType.Argument, default)});
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -25,7 +25,7 @@
   
   <ItemGroup>
     <PackageReference Include="ApprovalTests" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>

--- a/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
+++ b/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Collections;
@@ -38,7 +39,7 @@ public static class AssertionExtensions
         return new AndConstraint<GenericCollectionAssertions<T>>(assertions);
     }
 
-    public static AndConstraint<StringCollectionAssertions> BeEquivalentSequenceTo(
+    public static AndConstraint<StringCollectionAssertions<IEnumerable<string>>> BeEquivalentSequenceTo(
         this StringCollectionAssertions assertions,
         params string[] expectedValues)
     {


### PR DESCRIPTION
Fixes #2545 

Moves from FluentAssertions 6.x to AwesomeAssertions 8.x. 
Addressed subtle differences in API. 