### PR TITLE
Add TSA and BinSkim to the official build

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,11 @@
+{
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Libraries",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "dotnetlib@microsoft.com" ],
+    "repositoryName":"command-line-api",
+    "codebaseName": "command-line-api",
+    "serviceTreeId": "7a9b52f6-7805-416c-9390-343168c0cdb3"
+}

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -4,7 +4,7 @@
     "projectName": "DEVDIV",
     "areaPath": "DevDiv\\NET Libraries",
     "iterationPath": "DevDiv",
-    "notificationAliases": [ "dotnetlib@microsoft.com" ],
+    "notificationAliases": [ "system-commandline@microsoft.com" ],
     "repositoryName":"command-line-api",
     "codebaseName": "command-line-api",
     "serviceTreeId": "7a9b52f6-7805-416c-9390-343168c0cdb3"

--- a/.vsts-ci-official.yml
+++ b/.vsts-ci-official.yml
@@ -62,11 +62,16 @@ extends:
           enableSourceBuild: true
           helixRepo: dotnet/command-line-api
           timeoutInMinutes: 180 # increase timeout since BAR publishing might wait a long time
-          jobs:
-          - job: Windows
+          templateContext:
             sdl:
               binskim:
-                analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
+                analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;-:f|artifacts\bin\**\xunit*.dll;-:f|artifacts\bin\**\verify*.dll;
+          # WORKAROUND: BinSkim requires the folder exist prior to scanning.
+          preSteps:
+          - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
+            displayName: Create artifacts/bin directory
+          jobs:
+          - job: Windows
             pool:
               name: NetCore1ESPool-Internal
               demands: ImageOverride -equals windows.vs2022.amd64

--- a/.vsts-ci-official.yml
+++ b/.vsts-ci-official.yml
@@ -5,6 +5,11 @@ variables:
     value: .NETCore
   - name: Codeql.Enabled
     value: true
+  # CodeQL3000 needs this plumbed along as a variable to enable TSA.
+  - name: Codeql.TSAEnabled
+    value: true
+  - name: Codeql.TSAOptionsPath
+    value: '$(Build.SourcesDirectory)/.config/tsaoptions.json'
 
 # CI and PR triggers
 trigger:
@@ -12,6 +17,8 @@ trigger:
   branches:
     include:
     - main
+    - internal/release/*
+    - validation/*
 
 pr:
   autoCancel: false
@@ -35,6 +42,14 @@ extends:
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
+    sdl:
+      binskim:
+        scanOutputDirectoryOnly: true
+        preReleaseVersion: '4.3.1'
+      policheck:
+        enabled: true
+      tsa:
+        enabled: true
     stages:
     - stage: build
       displayName: Build and Test

--- a/.vsts-ci-official.yml
+++ b/.vsts-ci-official.yml
@@ -43,9 +43,6 @@ extends:
     customBuildTags:
     - ES365AIMigrationTooling
     sdl:
-      binskim:
-        scanOutputDirectoryOnly: true
-        preReleaseVersion: '4.3.1'
       policheck:
         enabled: true
       tsa:
@@ -67,6 +64,9 @@ extends:
           timeoutInMinutes: 180 # increase timeout since BAR publishing might wait a long time
           jobs:
           - job: Windows
+            sdl:
+              binskim:
+                analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
             pool:
               name: NetCore1ESPool-Internal
               demands: ImageOverride -equals windows.vs2022.amd64

--- a/.vsts-ci-official.yml
+++ b/.vsts-ci-official.yml
@@ -62,14 +62,6 @@ extends:
           enableSourceBuild: true
           helixRepo: dotnet/command-line-api
           timeoutInMinutes: 180 # increase timeout since BAR publishing might wait a long time
-          templateContext:
-            sdl:
-              binskim:
-                analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;-:f|artifacts\bin\**\xunit*.dll;-:f|artifacts\bin\**\verify*.dll;
-          # WORKAROUND: BinSkim requires the folder exist prior to scanning.
-          preSteps:
-          - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
-            displayName: Create artifacts/bin directory
           jobs:
           - job: Windows
             pool:
@@ -111,8 +103,10 @@ extends:
                   ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
                     _SignType: real
                     _BuildArgs: $(_OfficialBuildArgs)
-
             templateContext:
+              sdl:
+                binskim:
+                  analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;-:f|artifacts\bin\**\xunit*.dll;-:f|artifacts\bin\**\verify*.dll;
               outputs:
               - output: pipelineArtifact
                 displayName: Upload package artifacts
@@ -124,7 +118,10 @@ extends:
                 condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
                 targetPath: '$(Build.SourcesDirectory)\artifacts\SymStore\$(_BuildConfig)'
                 artifactName: 'NativeSymbols'
-
+            # WORKAROUND: BinSkim requires the folder exist prior to scanning.
+            preSteps:
+            - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
+              displayName: Create artifacts/bin directory
             steps:
             - checkout: self
               clean: true


### PR DESCRIPTION
## Summary

This adds the TSA and BinSkim options to the official build for the repo. It uses some workarounds that were discovered in the [dotnet/templating](https://github.com/dotnet/templating/pull/8594) repo.

## Test Run

These changes were already ran internally, and were able to produce a proper BinSkim scan with some reported issues.
- https://dev.azure.com/dnceng/internal/_build/results?buildId=2700108&view=results