### PR TITLE
Enable ControlFlowGuard on the NativeAOT test

### DIFF
--- a/src/System.CommandLine.Tests/TestApps/NativeAOT/NativeAOT.csproj
+++ b/src/System.CommandLine.Tests/TestApps/NativeAOT/NativeAOT.csproj
@@ -1,21 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>$(TargetFrameworkForNETSDK)</TargetFramework>
-		<!-- producing more detailed log output -->
-		<TrimmerSingleWarn>false</TrimmerSingleWarn>
-    <PublishAot>true</PublishAot>
-	</PropertyGroup>
 
-	<PropertyGroup>
-		<SystemCommandLineDllPath Condition="'$(SystemCommandLineDllPath)'==''">..\..\..\System.CommandLine\bin\Release\$(TargetFrameworkForNETSDK)\System.CommandLine.dll</SystemCommandLineDllPath>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>$(TargetFrameworkForNETSDK)</TargetFramework>
+        <!-- producing more detailed log output -->
+        <TrimmerSingleWarn>false</TrimmerSingleWarn>
+        <PublishAot>true</PublishAot>
+        <ControlFlowGuard>Guard</ControlFlowGuard>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<Reference Include="SystemCommandLineDll">
-			<HintPath>$(SystemCommandLineDllPath)</HintPath>
-		</Reference>
-	</ItemGroup>
+    <PropertyGroup>
+        <SystemCommandLineDllPath Condition="'$(SystemCommandLineDllPath)'==''">..\..\..\System.CommandLine\bin\Release\$(TargetFrameworkForNETSDK)\System.CommandLine.dll</SystemCommandLineDllPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Reference Include="SystemCommandLineDll">
+            <HintPath>$(SystemCommandLineDllPath)</HintPath>
+        </Reference>
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Lots of whitespace differences in this edit, but the only real change is adding `<ControlFlowGuard>Guard</ControlFlowGuard>` to address a binskim diagnostic.