### PR TITLE
Remove manual symbol conversion and dead property

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,10 +4,7 @@
     <!-- Default version number to global tool. -->
     <VersionPrefix>0.1.0</VersionPrefix>
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
-    <PreReleaseVersionLabel>
-    </PreReleaseVersionLabel>
-    <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
-    <PublishWindowsPdb>true</PublishWindowsPdb>
+    <PreReleaseVersionLabel></PreReleaseVersionLabel>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseGlobalToolVersion)' == 'true'">
     <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>


### PR DESCRIPTION
The `UsingToolSymbolUploader` property is dead and doesn't do anything anymore.

The `PublishWindowsPdb` property doesn't need to be set here as the conversion happens automatically as part of the Maestro publishing. No other repo sets this anymore (in the VMR).