### PR TITLE
Update to .NET 8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,10 @@
 <Project>
-
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <!-- Using multiple feeds isn't supported by Maestro: https://github.com/dotnet/arcade/issues/14155. -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Roslyn dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.0.1" />
@@ -14,24 +12,22 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1" />
     <!-- Runtime dependencies -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <!-- external dependencies -->
     <PackageVersion Include="ApprovalTests" Version="7.0.0-beta.3" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageVersion Include="AwesomeAssertions" Version="8.0.2" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageVersion Include="System.Memory" Version="4.5.4" />
-    <PackageVersion Include="system.reactive.core" Version="5.0.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
+    <PackageVersion Include="system.reactive.core" Version="6.0.0" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(DisableArcade)' == '1'">
     <!-- The xunit version should be kept in sync with the one that Arcade promotes -->
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
-  
 </Project>

--- a/src/System.CommandLine.Tests/CompletionTests.cs
+++ b/src/System.CommandLine.Tests/CompletionTests.cs
@@ -784,12 +784,12 @@ namespace System.CommandLine.Tests
         {
             var command = new RootCommand
             {
-                CreateOptionWithAcceptOnlyFromAmong(name: "--framework", "net7.0"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "--framework", "net8.0"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "--language", "C#"),
                 new Option<string>("--langVersion")
             };
             var configuration = new CommandLineConfiguration(command);
-            var completions = command.Parse("--framework net7.0 --l", configuration).GetCompletions();
+            var completions = command.Parse("--framework net8.0 --l", configuration).GetCompletions();
 
             completions.Select(item => item.Label)
                        .Should()
@@ -801,12 +801,12 @@ namespace System.CommandLine.Tests
         {
             var command = new RootCommand
             {
-                CreateOptionWithAcceptOnlyFromAmong(name: "--framework", "net7.0"),
+                CreateOptionWithAcceptOnlyFromAmong(name: "--framework", "net8.0"),
                 CreateOptionWithAcceptOnlyFromAmong(name: "--language", "C#"),
                 new Option<string>("--langVersion")
             };
             var configuration = new CommandLineConfiguration(command);
-            var completions = command.Parse(new[]{"--framework","net7.0","--l"}, configuration).GetCompletions();
+            var completions = command.Parse(new[]{"--framework","net8.0","--l"}, configuration).GetCompletions();
 
             completions.Select(item => item.Label)
                        .Should()

--- a/src/System.CommandLine/ArgumentValidation.cs
+++ b/src/System.CommandLine/ArgumentValidation.cs
@@ -171,7 +171,7 @@ namespace System.CommandLine
 
                 if (checkFile && checkDirectory)
                 {
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
                     if (!Path.Exists(token.Value))
 #else
                     if (!Directory.Exists(token.Value) && !File.Exists(token.Value))

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -88,7 +88,7 @@ namespace System.CommandLine
         {
             if (default(T) is null && typeof(T) != typeof(string))
             {
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 if (typeof(T).IsSZArray)
 #else
                 if (typeof(T).IsArray && typeof(T).GetArrayRank() == 1)

--- a/src/System.CommandLine/Binding/ArgumentConverter.cs
+++ b/src/System.CommandLine/Binding/ArgumentConverter.cs
@@ -61,7 +61,7 @@ namespace System.CommandLine.Binding
 
             if (type.IsEnum)
             {
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
                 if (Enum.TryParse(type, value, ignoreCase: true, out var converted))
                 {
                     return Success(argumentResult, converted);

--- a/src/System.CommandLine/ConsoleHelpers.cs
+++ b/src/System.CommandLine/ConsoleHelpers.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine
         private static readonly bool ColorsAreSupported = GetColorsAreSupported();
 
         private static bool GetColorsAreSupported()
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
             => !(OperatingSystem.IsBrowser() || OperatingSystem.IsAndroid() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS())
 #else
             => !(RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"))

--- a/src/System.CommandLine/Invocation/ProcessTerminationHandler.cs
+++ b/src/System.CommandLine/Invocation/ProcessTerminationHandler.cs
@@ -16,7 +16,7 @@ internal sealed class ProcessTerminationHandler : IDisposable
     private readonly CancellationTokenSource _handlerCancellationTokenSource;
     private readonly Task<int> _startedHandler;
     private readonly TimeSpan _processTerminationTimeout;
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
     private readonly IDisposable? _sigIntRegistration, _sigTermRegistration;
 #endif
         
@@ -30,7 +30,7 @@ internal sealed class ProcessTerminationHandler : IDisposable
         _startedHandler = startedHandler;
         _processTerminationTimeout = processTerminationTimeout;
 
-#if NET7_0_OR_GREATER // we prefer the new API as they allow for cancelling SIGTERM
+#if NET8_0_OR_GREATER // we prefer the new API as they allow for cancelling SIGTERM
         if (!OperatingSystem.IsAndroid() 
             && !OperatingSystem.IsIOS() 
             && !OperatingSystem.IsTvOS()
@@ -48,7 +48,7 @@ internal sealed class ProcessTerminationHandler : IDisposable
 
     public void Dispose()
     {
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
         if (_sigIntRegistration is not null)
         {
             _sigIntRegistration.Dispose();
@@ -61,7 +61,7 @@ internal sealed class ProcessTerminationHandler : IDisposable
         AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;    
     }
         
-#if NET7_0_OR_GREATER
+#if NET8_0_OR_GREATER
     void OnPosixSignal(PosixSignalContext context)
     {
         context.Cancel = true;


### PR DESCRIPTION
Since .NET 7.0 EOL, it's better to stick to LTS version that is till supported. I used LTS instead of LTS to minimize friction between new versions.