### PR TITLE
Update branding to beta6

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseBetaVersion)' == 'true'">
     <VersionPrefix>2.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>beta5</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>beta6</PreReleaseVersionLabel>
     <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(UseAlphaVersion)' == 'true'">


### PR DESCRIPTION
Will be changed to beta7 in main after we created an official build with the P6 branding and the source updates.