### PR TITLE
Downgrade System.Memory to 4.5.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="System.Memory" Version="4.6.3" />
+    <PackageVersion Include="System.Memory" Version="4.5.4" />
     <PackageVersion Include="system.reactive.core" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Back the System.Memory update out (to unblock P6) as it's causing consumption issues in roslyn:

>   D:\a\_work\1\s\src\roslyn\src\Features\Lsif\Generator\Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj : error NU1109: Detected package downgrade: System.Memory from 4.6.3 to centrally defined 4.5.5. Update the centrally managed package version to a higher version.  [D:\a\_work\1\s\src\roslyn\Roslyn.sln]
  D:\a\_work\1\s\src\roslyn\src\Features\Lsif\Generator\Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj : error NU1109:  Microsoft.CodeAnalysis.Lsif.Generator -> System.CommandLine 2.0.0-ci -> System.Memory (>= 4.6.3)  [D:\a\_work\1\s\src\roslyn\Roslyn.sln]
  D:\a\_work\1\s\src\roslyn\src\Features\Lsif\Generator\Microsoft.CodeAnalysis.LanguageServerIndexFormat.Generator.csproj : error NU1109:  Microsoft.CodeAnalysis.Lsif.Generator -> System.Memory (>= 4.5.5) [D:\a\_work\1\s\src\roslyn\Roslyn.sln]
  D:\a\_work\1\s\src\roslyn\src\Workspaces\MSBuild\BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj : error NU1109: Detected package downgrade: System.Memory from 4.6.3 to centrally defined 4.5.5. Update the centrally managed package version to a higher version.  [D:\a\_work\1\s\src\roslyn\Roslyn.sln]
  D:\a\_work\1\s\src\roslyn\src\Workspaces\MSBuild\BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj : error NU1109:  Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.Symbols -> System.CommandLine 2.0.0-ci -> System.Memory (>= 4.6.3)  [D:\a\_work\1\s\src\roslyn\Roslyn.sln]
  D:\a\_work\1\s\src\roslyn\src\Workspaces\MSBuild\BuildHost\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.csproj : error NU1109:  Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.Symbols -> System.Memory (>= 4.5.5) [D:\a\_work\1\s\src\roslyn\Roslyn.sln]