### PR TITLE
Fix some help and `GetRequiredValue` issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Contributing
 ============
 
-Please read [.NET Guidelines](https://github.com/dotnet/runtime/blob/master/CONTRIBUTING.md) for more general information about coding styles, source structure, making pull requests, and more.
+Please read [.NET Guidelines](https://github.com/dotnet/runtime/blob/main/CONTRIBUTING.md) for more general information about coding styles, source structure, making pull requests, and more.
 
 ## Developer guide
 
@@ -9,7 +9,7 @@ This project can be developed on any platform. To get started, follow instructio
 
 ### Prerequisites
 
-This project depends on .NET 7. Before working on the project, check that the [.NET SDK](https://dotnet.microsoft.com/en-us/download) is installed.
+This project depends on the .NET 9 SDK. Before working on the project, check that the [.NET SDK](https://dotnet.microsoft.com/en-us/download) is installed.
 
 ### Visual Studio
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,13 +1,17 @@
 <Project>
+
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <!-- Using multiple feeds isn't supported by Maestro: https://github.com/dotnet/arcade/issues/14155. -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
+
   <ItemGroup>
     <!-- Roslyn dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1" />
+    <!-- Runtime dependencies -->
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.6" />
     <!-- external dependencies -->
     <PackageVersion Include="ApprovalTests" Version="7.0.0-beta.3" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
@@ -16,10 +20,12 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(DisableArcade)' == '1'">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <!-- The xunit version should be kept in sync with the one that Arcade promotes -->
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,12 +1,10 @@
 <Project>
-
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <!-- Using multiple feeds isn't supported by Maestro: https://github.com/dotnet/arcade/issues/14155. -->
     <NoWarn>$(NoWarn);NU1507</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Roslyn dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.0.1" />
@@ -18,11 +16,10 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(DisableArcade)' == '1'">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <!-- The xunit version should be kept in sync with the one that Arcade promotes -->
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>
-
 </Project>

--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -153,10 +153,11 @@
     public System.Collections.Generic.IEnumerable<Symbol> Parents { get; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)
     public System.String ToString()
-  public class VersionOption : Option<System.Boolean>
+  public class VersionOption : Option
     .ctor()
     .ctor(System.String name, System.String[] aliases)
     public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
+    public System.Type ValueType { get; }
 System.CommandLine.Completions
   public class CompletionContext
     public static CompletionContext Empty { get; }
@@ -185,10 +186,11 @@ System.CommandLine.Help
   public class HelpAction : System.CommandLine.Invocation.SynchronousCommandLineAction
     .ctor()
     public System.Int32 Invoke(System.CommandLine.ParseResult parseResult)
-  public class HelpOption : System.CommandLine.Option<System.Boolean>
+  public class HelpOption : System.CommandLine.Option
     .ctor()
     .ctor(System.String name, System.String[] aliases)
     public System.CommandLine.Invocation.CommandLineAction Action { get; set; }
+    public System.Type ValueType { get; }
 System.CommandLine.Invocation
   public abstract class AsynchronousCommandLineAction : CommandLineAction
     public System.Threading.Tasks.Task<System.Int32> InvokeAsync(System.CommandLine.ParseResult parseResult, System.Threading.CancellationToken cancellationToken = null)

--- a/src/System.CommandLine.Tests/ArgumentTests.cs
+++ b/src/System.CommandLine.Tests/ArgumentTests.cs
@@ -3,6 +3,7 @@
 
 using FluentAssertions;
 using System.Linq;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace System.CommandLine.Tests;
@@ -39,6 +40,53 @@ public class ArgumentTests
                 .Message
                 .Should()
                 .Be("Argument \"the-arg\" does not have a default value");
+    }
+
+    [Fact]
+    public void GetRequiredValue_does_not_throw_when_help_is_requested_and_DefaultValueFactory_is_set()
+    {
+        var argument = new Argument<string>("the-arg")
+        {
+            DefaultValueFactory = _ => "default"
+        };
+
+        var result = new RootCommand { argument }.Parse("-h");
+
+        using var _ = new AssertionScope();
+
+        result.Invoking(r => r.GetRequiredValue(argument)).Should().NotThrow();
+        result.GetRequiredValue(argument).Should().Be("default");
+
+        result.Invoking(r => r.GetRequiredValue<string>("the-arg")).Should().NotThrow();
+        result.GetRequiredValue<string>("the-arg").Should().Be("default");
+
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void When_there_is_no_default_value_then_GetDefaultValue_does_not_throw_for_bool()
+    {
+        var argument = new Argument<bool>("the-arg");
+
+        argument.GetDefaultValue().Should().Be(false);
+    }
+
+    [Fact]
+    public void When_there_is_no_default_value_then_GetRequiredValue_does_not_throw_for_bool()
+    {
+        var argument = new Argument<bool>("the-arg");
+
+        var result = new RootCommand { argument }.Parse("");
+
+        using var _ = new AssertionScope();
+
+        result.Invoking(r => r.GetRequiredValue(argument)).Should().NotThrow();
+        result.GetRequiredValue(argument).Should().BeFalse();
+
+        result.Invoking(r => r.GetRequiredValue<bool>("the-arg")).Should().NotThrow();
+        result.GetRequiredValue<bool>("the-arg").Should().BeFalse();
+
+        result.Errors.Should().BeEmpty();
     }
 
     [Fact]

--- a/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
+++ b/src/System.CommandLine.Tests/Binding/TypeConversionTests.cs
@@ -8,6 +8,7 @@ using System.CommandLine.Utility;
 using System.IO;
 using System.Linq;
 using System.Net;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace System.CommandLine.Tests.Binding
@@ -585,6 +586,7 @@ namespace System.CommandLine.Tests.Binding
         [Fact]
         public void Options_with_arguments_specified_can_be_correctly_converted_to_bool_without_the_parser_specifying_a_custom_converter()
         {
+            using var _ = new AssertionScope();
             GetValue(new Option<bool>("-x"), "-x false").Should().BeFalse();
             GetValue(new Option<bool>("-x"), "-x true").Should().BeTrue();
         }

--- a/src/System.CommandLine.Tests/DirectiveTests.cs
+++ b/src/System.CommandLine.Tests/DirectiveTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Parsing;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -22,14 +23,14 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Raw_tokens_still_hold_directives()
+        public void Tokens_still_hold_directives()
         {
             Directive directive = new ("parse");
 
             ParseResult result = Parse(new Option<bool>("-y"), directive, "[parse] -y");
 
             result.GetResult(directive).Should().NotBeNull();
-            result.Tokens.Should().Contain(t => t.Value == "[parse]");
+            result.Tokens.Should().Contain(t => t.Value == "[parse]" && t.Type == TokenType.Directive);
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/GetValueByNameParserTests.cs
+++ b/src/System.CommandLine.Tests/GetValueByNameParserTests.cs
@@ -368,4 +368,30 @@ public class GetValueByNameTests
 
         result.GetValue<string>("--opt").Should().Be("hello");
     }
+
+    [Fact]
+    public void When_argument_type_is_unknown_then_named_lookup_can_be_used_to_get_value_as_supertype()
+    {
+        var command = new RootCommand
+        {
+            new Argument<string>("arg")
+        };
+
+        var result = command.Parse("value");
+
+        result.GetValue<object>("arg").Should().Be("value");
+    }
+
+    [Fact]
+    public void When_option_type_is_unknown_then_named_lookup_can_be_used_to_get_value_as_supertype()
+    {
+        var command = new RootCommand
+        {
+            new Option<string>("-x")
+        };
+
+        var result = command.Parse("-x value");
+
+        result.GetValue<object>("-x").Should().Be("value");
+    }
 }

--- a/src/System.CommandLine.Tests/GlobalOptionTests.cs
+++ b/src/System.CommandLine.Tests/GlobalOptionTests.cs
@@ -25,8 +25,8 @@ namespace System.CommandLine.Tests
         {
             var command = new Command("child");
             var rootCommand = new RootCommand { command };
-            command.SetAction((_) => { });
-            var requiredOption = new Option<bool>("--i-must-be-set")
+            command.SetAction(_ => { });
+            var requiredOption = new Option<string>("--i-must-be-set")
             {
                 Required = true,
                 Recursive = true
@@ -45,7 +45,7 @@ namespace System.CommandLine.Tests
         public void When_a_required_global_option_has_multiple_aliases_the_error_message_uses_the_name()
         {
             var rootCommand = new RootCommand();
-            var requiredOption = new Option<bool>("-i", "--i-must-be-set")
+            var requiredOption = new Option<string>("-i", "--i-must-be-set")
             {
                 Required = true,
                 Recursive = true

--- a/src/System.CommandLine.Tests/Help/ApprovalTests.Config.cs
+++ b/src/System.CommandLine.Tests/Help/ApprovalTests.Config.cs
@@ -1,9 +1,12 @@
-using ApprovalTests.Reporters;
-using ApprovalTests.Reporters.TestFrameworks;
+// Alias workaround for https://github.com/approvals/ApprovalTests.Net/issues/768
+extern alias ApprovalTests;
+
+using ApprovalTests.ApprovalTests.Reporters;
+using ApprovalTests.ApprovalTests.Reporters.TestFrameworks;
 
 // Use globally defined Reporter for ApprovalTests. Please see
 // https://github.com/approvals/ApprovalTests.Net/blob/master/docs/ApprovalTests/Reporters.md
 
 [assembly: UseReporter(typeof(FrameworkAssertReporter))]
 
-[assembly: ApprovalTests.Namers.UseApprovalSubdirectory("Approvals")]
+[assembly: ApprovalTests.ApprovalTests.Namers.UseApprovalSubdirectory("Approvals")]

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Alias workaround for https://github.com/approvals/ApprovalTests.Net/issues/768
+extern alias ApprovalTests;
+
 using Xunit;
 using System.IO;
-using ApprovalTests;
-using ApprovalTests.Reporters;
+using ApprovalTests.ApprovalTests;
+using ApprovalTests.ApprovalTests.Reporters;
 
 namespace System.CommandLine.Tests.Help
 {

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
@@ -328,7 +328,6 @@ public partial class HelpBuilderTests
             config.Output.ToString().Should().MatchRegex(expected);
         }
 
-
         [Fact]
         public void Individual_symbols_can_be_customized()
         {

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -778,13 +778,15 @@ namespace System.CommandLine.Tests.Help
             help.Should().Contain("[default: the-arg-value]");
         }
 
-        [Fact]
-        public void Help_does_not_show_default_value_for_argument_when_default_value_is_empty()
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Help_does_not_show_default_value_for_argument_when_default_value_is_null_or_empty(string defaultValue)
         {
             var argument = new Argument<string>("the-arg")
             {
                 Description = "The argument description",
-                DefaultValueFactory = (_) => ""
+                DefaultValueFactory = _ => defaultValue
             };
 
             var command = new Command("the-command", "The command description")
@@ -798,7 +800,32 @@ namespace System.CommandLine.Tests.Help
 
             var help = _console.ToString();
 
-            help.Should().NotContain("[default");
+            help.Should().NotContain("[]");
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Help_does_not_show_default_value_for_option_when_default_value_is_null_or_empty(string defaultValue)
+        {
+            var argument = new Option<string>("--opt")
+            {
+                Description = "The option description",
+                DefaultValueFactory = _ => defaultValue
+            };
+
+            var command = new Command("the-command", "The command description")
+            {
+                argument
+            };
+
+            var helpBuilder = GetHelpBuilder(SmallMaxWidth);
+
+            helpBuilder.Write(command, _console);
+
+            var help = _console.ToString();
+
+            help.Should().NotContain("[]");
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/ResponseFileTests.cs
+++ b/src/System.CommandLine.Tests/ResponseFileTests.cs
@@ -211,8 +211,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_response_file_does_not_exist_then_error_is_returned()
         {
-            var optionOne = new Option<bool>("--flag");
-            var optionTwo = new Option<bool>("--flag2");
+            var optionOne = new Option<string>("-x");
+            var optionTwo = new Option<string>("-y");
 
             var result = new RootCommand
                          {
@@ -229,8 +229,8 @@ namespace System.CommandLine.Tests
         [Fact]
         public void When_response_filepath_is_not_specified_then_error_is_returned()
         {
-            var optionOne = new Option<bool>("--flag");
-            var optionTwo = new Option<bool>("--flag2");
+            var optionOne = new Option<string>("-x");
+            var optionTwo = new Option<string>("-y");
 
             var result = new RootCommand
                          {
@@ -253,8 +253,8 @@ namespace System.CommandLine.Tests
         public void When_response_file_cannot_be_read_then_specified_error_is_returned()
         {
             var nonexistent = Path.GetTempFileName();
-            var optionOne = new Option<bool>("--flag");
-            var optionTwo = new Option<bool>("--flag2");
+            var optionOne = new Option<string>("--flag");
+            var optionTwo = new Option<string>("--flag2");
 
             using (File.Open(nonexistent, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
             {

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -36,13 +36,16 @@
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(DisableArcade)' == '1'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="..\System.CommandLine\Properties\Resources.resx"
-                      LogicalName="System.CommandLine.Properties.Resources.resources" />
+    <EmbeddedResource Include="..\System.CommandLine\Properties\Resources.resx" LogicalName="System.CommandLine.Properties.Resources.resources" />
   </ItemGroup>
 
 </Project>

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -30,7 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" />
+    <!-- Alias workaround for https://github.com/approvals/ApprovalTests.Net/issues/768 -->
+    <PackageReference Include="ApprovalTests" Aliases="ApprovalTests" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworkForNETSDK)</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);TestApps\**</DefaultExcludesInProjectFolder>
     <NoWarn>$(NoWarn);CS8632</NoWarn> <!-- Suppress nullable warning for files included as links -->

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(TargetFrameworkForNETSDK)</TargetFrameworks>
+    <TargetFrameworks>$(NetMinimum);$(NetFrameworkMinimum)</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
     <DefaultExcludesInProjectFolder>$(DefaultExcludesInProjectFolder);TestApps\**</DefaultExcludesInProjectFolder>
     <NoWarn>$(NoWarn);CS8632</NoWarn> <!-- Suppress nullable warning for files included as links -->
   </PropertyGroup>
-  
-  <ItemGroup>   
+
+  <ItemGroup>
     <Content Include="TestApps/**/*.csproj" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestApps/**/*.cs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\Common\ArgumentBuilder.cs" Link="Utility\ArgumentBuilder.cs" />
     <Compile Include="..\Common\OptionBuilder.cs" Link="Utility\OptionBuilder.cs" />
@@ -24,11 +24,11 @@
     <Compile Include="..\System.CommandLine\Help\HelpContext.cs" Link="Help\HelpContext.cs" />
     <Compile Include="..\System.CommandLine\Help\TwoColumnHelpRow.cs" Link="Help\TwoColumnHelpRow.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\System.CommandLine\System.CommandLine.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="ApprovalTests" />
     <PackageReference Include="AwesomeAssertions" />
@@ -41,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageReference Include="Microsoft.Bcl.Memory" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/src/System.CommandLine.Tests/VersionOptionTests.cs
+++ b/src/System.CommandLine.Tests/VersionOptionTests.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.CommandLine.Help;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Xunit;
 using static System.Environment;
 
@@ -160,16 +160,15 @@ namespace System.CommandLine.Tests
         {
             RootCommand rootCommand = new();
 
-            for (int i = 0; i < rootCommand.Options.Count; i++)
-            {
-                if (rootCommand.Options[i] is VersionOption)
-                    rootCommand.Options[i] = new VersionOption("-v", "-version");
-            }
+            rootCommand.Options.Clear();
+            rootCommand.Add(new VersionOption("-v", "-version"));
 
             CommandLineConfiguration configuration = new(rootCommand)
             {
                 Output = new StringWriter()
             };
+
+            using var _ = new AssertionScope();
 
             await configuration.InvokeAsync("-v");
             configuration.Output.ToString().Should().Be($"{version}{NewLine}");
@@ -180,18 +179,19 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
-        public void Version_is_not_valid_with_other_tokens_uses_custom_alias()
+        public void Version_is_not_valid_with_other_tokens_when_it_uses_custom_alias()
         {
             var childCommand = new Command("subcommand");
-            childCommand.SetAction((_) => { });
+            childCommand.SetAction(_ => { });
             var rootCommand = new RootCommand
             {
                 childCommand
             };
 
-            rootCommand.Options[1] = new VersionOption("-v");
+            rootCommand.Options.Clear();
+            rootCommand.Add(new VersionOption("-v"));
 
-            rootCommand.SetAction((_) => { });
+            rootCommand.SetAction(_ => { });
 
             CommandLineConfiguration configuration = new(rootCommand)
             {

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -134,7 +134,7 @@ namespace System.CommandLine
 
         internal static Argument None { get; } = new NoArgument();
 
-        internal class NoArgument : Argument
+        private sealed class NoArgument : Argument
         {
             internal NoArgument() : base("@none")
             {

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -131,5 +131,20 @@ namespace System.CommandLine
         public override string ToString() => $"{nameof(Argument)}: {Name}";
 
         internal bool IsBoolean() => ValueType == typeof(bool) || ValueType == typeof(bool?);
+
+        internal static Argument None { get; } = new NoArgument();
+
+        internal class NoArgument : Argument
+        {
+            internal NoArgument() : base("@none")
+            {
+            }
+
+            public override Type ValueType { get; } = typeof(void);
+
+            internal override object? GetDefaultValue(ArgumentResult argumentResult) => null;
+
+            public override bool HasDefaultValue => false;
+        }
     }
 }

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -10,6 +10,7 @@ namespace System.CommandLine
     public class Argument<T> : Argument
     {
         private Func<ArgumentResult, T?>? _customParser;
+        private Func<ArgumentResult, T>? _defaultValueFactory;
 
         /// <summary>
         /// Initializes a new instance of the Argument class.
@@ -27,7 +28,23 @@ namespace System.CommandLine
         /// The same instance can be set as <see cref="CustomParser"/>, in such case
         /// the delegate is also invoked when an input was provided.
         /// </remarks>
-        public Func<ArgumentResult, T>? DefaultValueFactory { get; set; }
+        public Func<ArgumentResult, T>? DefaultValueFactory
+        {
+            get
+            {
+                if (_defaultValueFactory is null)
+                {
+                    switch (this)
+                    {
+                        case Argument<bool> boolArgument:
+                            boolArgument.DefaultValueFactory = _ => false;
+                            break;
+                    }
+                }
+                return _defaultValueFactory;
+            }
+            set => _defaultValueFactory = value;
+        }
 
         /// <summary>
         /// A custom argument parser.
@@ -76,6 +93,11 @@ namespace System.CommandLine
         {
             if (DefaultValueFactory is null)
             {
+                if (IsBoolean())
+                {
+                    return false;
+                }
+
                 throw new InvalidOperationException($"Argument \"{Name}\" does not have a default value");
             }
 

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -93,11 +93,6 @@ namespace System.CommandLine
         {
             if (DefaultValueFactory is null)
             {
-                if (IsBoolean())
-                {
-                    return false;
-                }
-
                 throw new InvalidOperationException($"Argument \"{Name}\" does not have a default value");
             }
 

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -34,11 +34,9 @@ namespace System.CommandLine
             {
                 if (_defaultValueFactory is null)
                 {
-                    switch (this)
+                    if (this is Argument<bool> boolArgument)
                     {
-                        case Argument<bool> boolArgument:
-                            boolArgument.DefaultValueFactory = _ => false;
-                            break;
+                        boolArgument.DefaultValueFactory = _ => false;
                     }
                 }
                 return _defaultValueFactory;

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -18,13 +18,17 @@ internal partial class HelpBuilder
         /// <summary>
         /// Gets an argument's default value to be displayed in help.
         /// </summary>
-        /// <param name="parameter">The argument or option to get the default value for.</param>
-        public static string GetArgumentDefaultValue(Symbol parameter)
+        /// <param name="symbol">The argument or option to get the default value for.</param>
+        public static string GetArgumentDefaultValue(Symbol symbol)
         {
-            return parameter switch
+            return symbol switch
             {
-                Argument argument => argument.HasDefaultValue ? ToString(argument.GetDefaultValue()) : "",
-                Option option => option.HasDefaultValue ? ToString(option.GetDefaultValue()) : "",
+                Argument argument => ShouldShowDefaultValue(argument) 
+                                         ? ToString(argument.GetDefaultValue()) 
+                                         : "",
+                Option option => ShouldShowDefaultValue(option) 
+                                     ? ToString(option.GetDefaultValue()) 
+                                     : "",
                 _ => throw new InvalidOperationException("Symbol must be an Argument or Option.")
             };
 
@@ -36,6 +40,22 @@ internal partial class HelpBuilder
                 _ => value.ToString() ?? string.Empty
             };
         }
+
+        public static bool ShouldShowDefaultValue(Symbol symbol) =>
+            symbol switch
+            {
+                Option option => ShouldShowDefaultValue(option),
+                Argument argument => ShouldShowDefaultValue(argument),
+                _ => false
+            };
+
+        public static bool ShouldShowDefaultValue(Option option) =>
+            option.HasDefaultValue && 
+            !(option.ValueType == typeof(bool) || option.ValueType == typeof(bool?));
+
+        public static bool ShouldShowDefaultValue(Argument argument) =>
+            argument.HasDefaultValue && 
+            !(argument.ValueType == typeof(bool) || argument.ValueType == typeof(bool?));
 
         /// <summary>
         /// Gets the description for an argument (typically used in the second column text in the arguments section).

--- a/src/System.CommandLine/Help/HelpBuilderExtensions.cs
+++ b/src/System.CommandLine/Help/HelpBuilderExtensions.cs
@@ -30,21 +30,13 @@ namespace System.CommandLine.Help
 
         internal static (string? Prefix, string Alias) SplitPrefix(this string rawAlias)
         {
-            if (rawAlias[0] == '/')
+            return rawAlias[0] switch
             {
-                return ("/", rawAlias.Substring(1));
-            }
-            else if (rawAlias[0] == '-')
-            {
-                if (rawAlias.Length > 1 && rawAlias[1] == '-')
-                {
-                    return ("--", rawAlias.Substring(2));
-                }
-
-                return ("-", rawAlias.Substring(1));
-            }
-
-            return (null, rawAlias);
+                '/' => ("/", rawAlias[1..]),
+                '-' when rawAlias.Length > 1 && rawAlias[1] is '-' => ("--", rawAlias[2..]),
+                '-' => ("-", rawAlias[1..]),
+                _ => (null, rawAlias)
+            };
         }
 
         internal static IEnumerable<T> RecurseWhileNotNull<T>(this T? source, Func<T, T?> next) where T : class

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -8,7 +8,7 @@ namespace System.CommandLine.Help
     /// <summary>
     /// A standard option that indicates that command line help should be displayed.
     /// </summary>
-    public sealed class HelpOption : Option<bool?>
+    public sealed class HelpOption : Option
     {
         private CommandLineAction? _action;
 
@@ -30,10 +30,11 @@ namespace System.CommandLine.Help
         /// When added to a <see cref="Command"/>, it configures the application to show help when given name or one of the aliases are specified on the command line.
         /// </summary>
         public HelpOption(string name, params string[] aliases)
-            : base(name, aliases, new Argument<bool?>(name) { Arity = ArgumentArity.Zero })
+            : base(name, aliases)
         {
             Recursive = true;
             Description = LocalizationResources.HelpOptionDescription();
+            Arity = ArgumentArity.Zero;
         }
 
         /// <inheritdoc />
@@ -42,5 +43,9 @@ namespace System.CommandLine.Help
             get => _action ??= new HelpAction(); 
             set => _action = value ?? throw new ArgumentNullException(nameof(value));
         }
+
+        internal override Argument Argument => Argument.None;
+
+        public override Type ValueType => typeof(void);
     }
 }

--- a/src/System.CommandLine/Help/HelpOption.cs
+++ b/src/System.CommandLine/Help/HelpOption.cs
@@ -8,7 +8,7 @@ namespace System.CommandLine.Help
     /// <summary>
     /// A standard option that indicates that command line help should be displayed.
     /// </summary>
-    public sealed class HelpOption : Option<bool>
+    public sealed class HelpOption : Option<bool?>
     {
         private CommandLineAction? _action;
 
@@ -22,7 +22,7 @@ namespace System.CommandLine.Help
         ///    /?
         /// </code>
         /// </summary>
-        public HelpOption() : this("--help", new[] { "-h", "/h", "-?", "/?" })
+        public HelpOption() : this("--help", ["-h", "/h", "-?", "/?"])
         {
         }
 
@@ -30,7 +30,7 @@ namespace System.CommandLine.Help
         /// When added to a <see cref="Command"/>, it configures the application to show help when given name or one of the aliases are specified on the command line.
         /// </summary>
         public HelpOption(string name, params string[] aliases)
-            : base(name, aliases, new Argument<bool>(name) { Arity = ArgumentArity.Zero })
+            : base(name, aliases, new Argument<bool?>(name) { Arity = ArgumentArity.Zero })
         {
             Recursive = true;
             Description = LocalizationResources.HelpOptionDescription();

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -71,16 +71,16 @@ namespace System.CommandLine.Parsing
 
             if (Command.HasOptions)
             {
-                ValidateOptions(completeValidation);
+                ValidateOptionsAndAddDefaultResults(completeValidation);
             }
 
             if (Command.HasArguments)
             {
-                ValidateArguments(completeValidation);
+                ValidateArgumentsAndAddDefaultResults(completeValidation);
             }
         }
 
-        private void ValidateOptions(bool completeValidation)
+        private void ValidateOptionsAndAddDefaultResults(bool completeValidation)
         {
             var options = Command.Options;
             for (var i = 0; i < options.Count; i++)
@@ -105,7 +105,7 @@ namespace System.CommandLine.Parsing
                         argumentResult = new(optionResult.Option.Argument, SymbolResultTree, optionResult);
                         SymbolResultTree.Add(optionResult.Option.Argument, argumentResult);
 
-                        if (option.Required && !option.Argument.HasDefaultValue)
+                        if (option is { Required: true, Argument.HasDefaultValue: false })
                         {
                             argumentResult.AddError(LocalizationResources.RequiredOptionWasNotProvided(option.Name));
                             continue;
@@ -148,7 +148,7 @@ namespace System.CommandLine.Parsing
             }
         }
 
-        private void ValidateArguments(bool completeValidation)
+        private void ValidateArgumentsAndAddDefaultResults(bool completeValidation)
         {
             var arguments = Command.Arguments;
             for (var i = 0; i < arguments.Count; i++)

--- a/src/System.CommandLine/Parsing/OptionResult.cs
+++ b/src/System.CommandLine/Parsing/OptionResult.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Binding;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace System.CommandLine.Parsing

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -58,9 +58,11 @@ namespace System.CommandLine.Parsing
 
             ParseCommandChildren();
 
-            if (!_isHelpRequested)
+            ValidateAndAddDefaultResults();
+
+            if (_isHelpRequested)
             {
-                Validate();
+                _symbolResultTree.Errors?.Clear();
             }
 
             if (_primaryAction is null)
@@ -366,7 +368,7 @@ namespace System.CommandLine.Parsing
             _symbolResultTree.AddUnmatchedToken(CurrentToken, _innermostCommandResult, _rootCommandResult);
         }
 
-        private void Validate()
+        private void ValidateAndAddDefaultResults()
         {
             // Only the inner most command goes through complete validation,
             // for other commands only a subset of options is checked.

--- a/src/System.CommandLine/Parsing/SymbolResultTree.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultTree.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/System.CommandLine/System.Runtime.CompilerServices/Range.cs
+++ b/src/System.CommandLine/System.Runtime.CompilerServices/Range.cs
@@ -1,0 +1,278 @@
+﻿// https://github.com/dotnet/runtime/blob/419e949d258ecee4c40a460fb09c66d974229623/src/libraries/System.Private.CoreLib/src/System/Index.cs
+// https://github.com/dotnet/runtime/blob/419e949d258ecee4c40a460fb09c66d974229623/src/libraries/System.Private.CoreLib/src/System/Range.cs
+
+#if NETSTANDARD2_0
+#nullable enable
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
+    /// <remarks>
+    /// Index is used by the C# compiler to support the new index syntax
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 } ;
+    /// int lastElement = someArray[^1]; // lastElement = 5
+    /// </code>
+    /// </remarks>
+    internal readonly struct Index : IEquatable<Index>
+    {
+        private readonly int _value;
+
+        /// <summary>Construct an Index using a value and indicating if the index is from the start or from the end.</summary>
+        /// <param name="value">The index value. it has to be zero or positive number.</param>
+        /// <param name="fromEnd">Indicating if the index is from the start or from the end.</param>
+        /// <remarks>
+        /// If the Index constructed from the end, index value 1 means pointing at the last element and index value 0 means pointing at beyond last element.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Index(int value, bool fromEnd = false)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            if (fromEnd)
+                _value = ~value;
+            else
+                _value = value;
+        }
+
+        // The following private constructors mainly created for perf reason to avoid the checks
+        private Index(int value)
+        {
+            _value = value;
+        }
+
+        /// <summary>Create an Index pointing at first element.</summary>
+        public static Index Start => new Index(0);
+
+        /// <summary>Create an Index pointing at beyond last element.</summary>
+        public static Index End => new Index(~0);
+
+        /// <summary>Create an Index from the start at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the start.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Index FromStart(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(value);
+        }
+
+        /// <summary>Create an Index from the end at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the end.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Index FromEnd(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(~value);
+        }
+
+        /// <summary>Returns the index value.</summary>
+        public int Value
+        {
+            get
+            {
+                if (_value < 0)
+                {
+                    return ~_value;
+                }
+                else
+                {
+                    return _value;
+                }
+            }
+        }
+
+        /// <summary>Indicates whether the index is from the start or the end.</summary>
+        public bool IsFromEnd => _value < 0;
+
+        /// <summary>Calculate the offset from the start using the giving collection length.</summary>
+        /// <param name="length">The length of the collection that the Index will be used with. length has to be a positive value</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter and the returned offset value against negative values.
+        /// we don't validate either the returned offset is greater than the input length.
+        /// It is expected Index will be used with collections which always have non negative length/count. If the returned offset is negative and
+        /// then used to index a collection will get out of range exception which will be same affect as the validation.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetOffset(int length)
+        {
+            var offset = _value;
+            if (IsFromEnd)
+            {
+                // offset = length - (~value)
+                // offset = length + (~(~value) + 1)
+                // offset = length + value + 1
+
+                offset += length + 1;
+            }
+            return offset;
+        }
+
+        /// <summary>Indicates whether the current Index object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object</param>
+        public override bool Equals(object? value) => value is Index && _value == ((Index)value)._value;
+
+        /// <summary>Indicates whether the current Index object is equal to another Index object.</summary>
+        /// <param name="other">An object to compare with this object</param>
+        public bool Equals(Index other) => _value == other._value;
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode() => _value;
+
+        /// <summary>Converts integer number to an Index.</summary>
+        public static implicit operator Index(int value) => FromStart(value);
+
+        /// <summary>Converts the value of the current Index object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            if (IsFromEnd)
+                return "^" + ((uint)Value).ToString();
+
+            return ((uint)Value).ToString();
+        }
+    }
+
+    /// <summary>Represent a range has start and end indexes.</summary>
+    /// <remarks>
+    /// Range is used by the C# compiler to support the range syntax.
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 };
+    /// int[] subArray1 = someArray[0..2]; // { 1, 2 }
+    /// int[] subArray2 = someArray[1..^0]; // { 2, 3, 4, 5 }
+    /// </code>
+    /// </remarks>
+    internal readonly struct Range : IEquatable<Range>
+    {
+        /// <summary>Represent the inclusive start index of the Range.</summary>
+        public Index Start { get; }
+
+        /// <summary>Represent the exclusive end index of the Range.</summary>
+        public Index End { get; }
+
+        /// <summary>Construct a Range object using the start and end indexes.</summary>
+        /// <param name="start">Represent the inclusive start index of the range.</param>
+        /// <param name="end">Represent the exclusive end index of the range.</param>
+        public Range(Index start, Index end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        /// <summary>Indicates whether the current Range object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object</param>
+        public override bool Equals(object? value) =>
+            value is Range r &&
+            r.Start.Equals(Start) &&
+            r.End.Equals(End);
+
+        /// <summary>Indicates whether the current Range object is equal to another Range object.</summary>
+        /// <param name="other">An object to compare with this object</param>
+        public bool Equals(Range other) => other.Start.Equals(Start) && other.End.Equals(End);
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode()
+        {
+            return Start.GetHashCode() * 31 + End.GetHashCode();
+        }
+
+        /// <summary>Converts the value of the current Range object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            return Start + ".." + End;
+        }
+
+        /// <summary>Create a Range object starting from start index to the end of the collection.</summary>
+        public static Range StartAt(Index start) => new Range(start, Index.End);
+
+        /// <summary>Create a Range object starting from first element in the collection to the end Index.</summary>
+        public static Range EndAt(Index end) => new Range(Index.Start, end);
+
+        /// <summary>Create a Range object starting from first element to the end.</summary>
+        public static Range All => new Range(Index.Start, Index.End);
+
+        /// <summary>Calculate the start offset and length of range object using a collection length.</summary>
+        /// <param name="length">The length of the collection that the range will be used with. length has to be a positive value.</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter against negative values.
+        /// It is expected Range will be used with collections which always have non negative length/count.
+        /// We validate the range is inside the length scope though.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (int Offset, int Length) GetOffsetAndLength(int length)
+        {
+            int start;
+            var startIndex = Start;
+            if (startIndex.IsFromEnd)
+                start = length - startIndex.Value;
+            else
+                start = startIndex.Value;
+
+            int end;
+            var endIndex = End;
+            if (endIndex.IsFromEnd)
+                end = length - endIndex.Value;
+            else
+                end = endIndex.Value;
+
+            if ((uint)end > (uint)length || (uint)start > (uint)end)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            return (start, end - start);
+        }
+    }
+}
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class RuntimeHelpers
+    {
+        /// <summary>
+        /// Slices the specified array using the specified range.
+        /// </summary>
+        public static T[] GetSubArray<T>(T[] array, Range range)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+
+            (int offset, int length) = range.GetOffsetAndLength(array.Length);
+
+            if (default(T) != null || typeof(T[]) == array.GetType())
+            {
+                // We know the type of the array to be exactly T[].
+
+                if (length == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
+                var dest = new T[length];
+                Array.Copy(array, offset, dest, 0, length);
+                return dest;
+            }
+            else
+            {
+                // The array is actually a U[] where U:T.
+                var dest = (T[])Array.CreateInstance(array.GetType().GetElementType(), length);
+                Array.Copy(array, offset, dest, 0, length);
+                return dest;
+            }
+        }
+    }
+}
+#endif

--- a/src/System.CommandLine/VersionOption.cs
+++ b/src/System.CommandLine/VersionOption.cs
@@ -10,14 +10,14 @@ namespace System.CommandLine
     /// <summary>
     /// A standard option that indicates that version information should be displayed for the app.
     /// </summary>
-    public sealed class VersionOption : Option<bool>
+    public sealed class VersionOption : Option<bool?>
     {
         private CommandLineAction? _action;
 
         /// <summary>
         /// When added to a <see cref="Command"/>, it enables the use of a <c>--version</c> option, which when specified in command line input will short circuit normal command handling and instead write out version information before exiting.
         /// </summary>
-        public VersionOption() : this("--version", Array.Empty<string>())
+        public VersionOption() : this("--version")
         {
         }
 
@@ -25,7 +25,7 @@ namespace System.CommandLine
         /// When added to a <see cref="Command"/>, it enables the use of a provided option name and aliases, which when specified in command line input will short circuit normal command handling and instead write out version information before exiting.
         /// </summary>
         public VersionOption(string name, params string[] aliases)
-            : base(name, aliases, new Argument<bool>("--version") { Arity = ArgumentArity.Zero })
+            : base(name, aliases, new Argument<bool?>("--version") { Arity = ArgumentArity.Zero })
         {
             Description = LocalizationResources.VersionOptionDescription();
             AddValidators();
@@ -43,7 +43,9 @@ namespace System.CommandLine
             Validators.Add(static result =>
             {
                 if (result.Parent is CommandResult parent &&
-                    parent.Children.Any(r => r is not OptionResult { Option: VersionOption }))
+                    parent.Children.Any(r =>
+                                            r is not OptionResult { Option: VersionOption } &&
+                                            r is not OptionResult { Implicit: true }))
                 {
                     result.AddError(LocalizationResources.VersionOptionCannotBeCombinedWithOtherArguments(result.IdentifierToken?.Value ?? result.Option.Name));
                 }

--- a/src/System.CommandLine/VersionOption.cs
+++ b/src/System.CommandLine/VersionOption.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.CommandLine.Help;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Linq;
@@ -10,7 +11,7 @@ namespace System.CommandLine
     /// <summary>
     /// A standard option that indicates that version information should be displayed for the app.
     /// </summary>
-    public sealed class VersionOption : Option<bool?>
+    public sealed class VersionOption : Option
     {
         private CommandLineAction? _action;
 
@@ -25,10 +26,11 @@ namespace System.CommandLine
         /// When added to a <see cref="Command"/>, it enables the use of a provided option name and aliases, which when specified in command line input will short circuit normal command handling and instead write out version information before exiting.
         /// </summary>
         public VersionOption(string name, params string[] aliases)
-            : base(name, aliases, new Argument<bool?>("--version") { Arity = ArgumentArity.Zero })
+            : base(name, aliases)
         {
             Description = LocalizationResources.VersionOptionDescription();
             AddValidators();
+            Arity = ArgumentArity.Zero;
         }
 
         /// <inheritdoc />
@@ -53,6 +55,11 @@ namespace System.CommandLine
         }
 
         internal override bool Greedy => false;
+
+        internal override Argument Argument => Argument.None;
+
+        /// <inheritdoc />
+        public override Type ValueType => typeof(void);
 
         private sealed class VersionOptionAction : SynchronousCommandLineAction
         {


### PR DESCRIPTION
This fixes the following issues:

* #2592
* #2582
* #2573

The approach I took to fix #2573 makes `Argument<bool>` and `Option<bool>` have an implicit `DefaultValueFactory`. This change drove changes to the `HelpBuilder` so I also fixed #2582 while I was in there.

It's not obvious to me that this is the right fix, so I thought that the PR would help clarify the discussion.

For example, should other types than `bool` have this behavior of an implicit default value?