### PR TITLE
Make dotnet-suggest follow the repo versioning

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -3,6 +3,5 @@
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
     <PreReleaseVersionLabel>beta7</PreReleaseVersionLabel>
-    <AutoGenerateAssemblyVersion>false</AutoGenerateAssemblyVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.CommandLine.Suggest/dotnet-suggest.csproj
+++ b/src/System.CommandLine.Suggest/dotnet-suggest.csproj
@@ -11,9 +11,6 @@
     <PackAsToolShimRuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' != 'true'">win-x64;win-x86;osx-x64;osx-arm64;linux-x64</PackAsToolShimRuntimeIdentifiers>
     <PackagedShimOutputRootDirectory>$(OutputPath)</PackagedShimOutputRootDirectory>
 
-    <VersionPrefix>1.1.1</VersionPrefix>
-    <PreReleaseVersionLabel />
-
     <!-- No warning for the scripts, it is part of the content, not to execute -->
     <NoWarn>$(NoWarn);NU5110;NU5111</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Make dotnet-suggest follow the same versioning as the rest of the repo. Also removet the AutoGenerateAssemblyVersion=false property which was incorrectly set.

This fixes the failing official build on the main branch.