### PR TITLE
Revert "Update ApprovalTests to 7.0.0 and revert workaround"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <!-- Runtime dependencies -->
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.6" />
     <!-- external dependencies -->
-    <PackageVersion Include="ApprovalTests" Version="7.0.0" />
+    <PackageVersion Include="ApprovalTests" Version="7.0.0-beta.3" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
     <PackageVersion Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />

--- a/src/System.CommandLine.Tests/Help/ApprovalTests.Config.cs
+++ b/src/System.CommandLine.Tests/Help/ApprovalTests.Config.cs
@@ -1,8 +1,12 @@
-using ApprovalTests.Reporters;
-using ApprovalTests.Reporters.TestFrameworks;
+// Alias workaround for https://github.com/approvals/ApprovalTests.Net/issues/768
+extern alias ApprovalTests;
+
+using ApprovalTests.ApprovalTests.Reporters;
+using ApprovalTests.ApprovalTests.Reporters.TestFrameworks;
 
 // Use globally defined Reporter for ApprovalTests. Please see
 // https://github.com/approvals/ApprovalTests.Net/blob/master/docs/ApprovalTests/Reporters.md
 
 [assembly: UseReporter(typeof(FrameworkAssertReporter))]
-[assembly: ApprovalTests.Namers.UseApprovalSubdirectory("Approvals")]
+
+[assembly: ApprovalTests.ApprovalTests.Namers.UseApprovalSubdirectory("Approvals")]

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Approval.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Alias workaround for https://github.com/approvals/ApprovalTests.Net/issues/768
+extern alias ApprovalTests;
+
 using Xunit;
 using System.IO;
-using ApprovalTests;
-using ApprovalTests.Reporters;
+using ApprovalTests.ApprovalTests;
+using ApprovalTests.ApprovalTests.Reporters;
 
 namespace System.CommandLine.Tests.Help
 {

--- a/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/src/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -30,7 +30,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" />
+    <!-- Alias workaround for https://github.com/approvals/ApprovalTests.Net/issues/768 -->
+    <PackageReference Include="ApprovalTests" Aliases="ApprovalTests" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" />


### PR DESCRIPTION
This reverts commit 3676a9eafea1f7c6abc987741fc0d5e078cb16f8.