### PR TITLE
make the non-generic Option and Argument ctors non-private

### DIFF
--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -19,7 +19,11 @@ namespace System.CommandLine
         private List<Func<CompletionContext, IEnumerable<CompletionItem>>>? _completionSources = null;
         private List<Action<ArgumentResult>>? _validators = null;
 
-        private protected Argument(string name) : base(name, allowWhitespace: true)
+        /// <summary>
+        /// Initializes a new instance of the Argument class.
+        /// </summary>
+        /// <param name="name">The name of the argument. This can be used to look up the parsed value and is displayed in help</param>
+        protected Argument(string name) : base(name, allowWhitespace: true)
         {
         }
 

--- a/src/System.CommandLine/Argument{T}.cs
+++ b/src/System.CommandLine/Argument{T}.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine
         /// <summary>
         /// Initializes a new instance of the Argument class.
         /// </summary>
-        /// <param name="name">The name of the argument. It's not used for parsing, only when displaying Help or creating parse errors.</param>>
+        /// <param name="name">The name of the argument. This can be used to look up the parsed value and is displayed in help</param>
         public Argument(string name) : base(name)
         {
         }

--- a/src/System.CommandLine/Option.cs
+++ b/src/System.CommandLine/Option.cs
@@ -17,7 +17,12 @@ namespace System.CommandLine
         internal AliasSet? _aliases;
         private List<Action<OptionResult>>? _validators;
 
-        private protected Option(string name, string[] aliases) : base(name)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Option"/> class.
+        /// </summary>
+        /// <param name="name">The name of the option. This is used during parsing and is displayed in help.</param>
+        /// <param name="aliases">Optional aliases by which the option can be specified on the command line.</param>
+        protected Option(string name, string[] aliases) : base(name)
         {
             if (aliases is { Length: > 0 }) 
             {

--- a/src/System.CommandLine/Option{T}.cs
+++ b/src/System.CommandLine/Option{T}.cs
@@ -14,8 +14,8 @@ namespace System.CommandLine
         /// <summary>
         /// Initializes a new instance of the <see cref="Option"/> class.
         /// </summary>
-        /// <param name="name">The name of the option. It's used for parsing, displaying Help and creating parse errors.</param>>
-        /// <param name="aliases">Optional aliases. Used for parsing, suggestions and displayed in Help.</param>
+        /// <param name="name">The name of the option. This is used during parsing and is displayed in help.</param>
+        /// <param name="aliases">Optional aliases by which the option can be specified on the command line.</param>
         public Option(string name, params string[] aliases) 
             : this(name, aliases, new Argument<T>(name))
         {


### PR DESCRIPTION
This allows these untyped `Option` and `Argument` classes to be inherited in code referencing System.CommandLine. This pattern was used by `HelpOption` and `VersionOption` in order to implement flag-style option behavior (with zero arity and no parseable return types). This same capability is useful beyond the scope of System.CommandLine's internals. 