### PR TITLE
fix #2628: don't generate parse error when `--version` is invoked on a root command that has subcommands

### DIFF
--- a/src/System.CommandLine.Tests/VersionOptionTests.cs
+++ b/src/System.CommandLine.Tests/VersionOptionTests.cs
@@ -37,13 +37,28 @@ namespace System.CommandLine.Tests
         {
             var wasCalled = false;
             var rootCommand = new RootCommand();
-            rootCommand.SetAction((_) => wasCalled = true);
+            rootCommand.SetAction(_ => wasCalled = true);
 
             var output = new StringWriter();
 
             await rootCommand.Parse("--version").InvokeAsync(new() { Output = output }, CancellationToken.None);
 
             wasCalled.Should().BeFalse();
+        }
+
+        [Fact] // https://github.com/dotnet/command-line-api/issues/2628
+        public void When_the_version_option_is_specified_then_there_are_no_parse_errors_due_to_unspecified_subcommand()
+        {
+            Command subcommand = new("subcommand");
+            RootCommand root = new()
+            {
+                subcommand
+            };
+            subcommand.SetAction(_ => 0);
+
+            var parseResult = root.Parse("--version");
+
+            parseResult.Errors.Should().BeEmpty();
         }
 
         [Fact]

--- a/src/System.CommandLine/ParserConfiguration.cs
+++ b/src/System.CommandLine/ParserConfiguration.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Parsing;
-using System.Linq;
 
 namespace System.CommandLine
 {

--- a/src/System.CommandLine/Parsing/CommandResult.cs
+++ b/src/System.CommandLine/Parsing/CommandResult.cs
@@ -43,17 +43,10 @@ namespace System.CommandLine.Parsing
         internal override bool UseDefaultValueFor(ArgumentResult argumentResult)
             => argumentResult.Argument.HasDefaultValue && argumentResult.Tokens.Count == 0;
 
-        /// <param name="completeValidation">Only the inner most command goes through complete validation.</param>
-        internal void Validate(bool completeValidation)
+        internal void Validate(bool isInnermostCommand)
         {
-            if (completeValidation)
+            if (isInnermostCommand)
             {
-                if (Command.Action is null && Command.HasSubcommands)
-                {
-                    SymbolResultTree.InsertFirstError(
-                        new ParseError(LocalizationResources.RequiredCommandWasNotProvided(), this));
-                }
-
                 if (Command.HasValidators)
                 {
                     int errorCountBefore = SymbolResultTree.ErrorCount;
@@ -71,12 +64,12 @@ namespace System.CommandLine.Parsing
 
             if (Command.HasOptions)
             {
-                ValidateOptionsAndAddDefaultResults(completeValidation);
+                ValidateOptionsAndAddDefaultResults(isInnermostCommand);
             }
 
             if (Command.HasArguments)
             {
-                ValidateArgumentsAndAddDefaultResults(completeValidation);
+                ValidateArgumentsAndAddDefaultResults(isInnermostCommand);
             }
         }
 

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -63,6 +63,7 @@ namespace System.CommandLine.Parsing
 
             ValidateAndAddDefaultResults();
 
+
             if (_isHelpRequested)
             {
                 _symbolResultTree.Errors?.Clear();
@@ -373,16 +374,23 @@ namespace System.CommandLine.Parsing
 
         private void ValidateAndAddDefaultResults()
         {
-            // Only the inner most command goes through complete validation,
+            // Only the innermost command goes through complete validation,
             // for other commands only a subset of options is checked.
-            _innermostCommandResult.Validate(completeValidation: true);
+            _innermostCommandResult.Validate(isInnermostCommand: true);
 
             CommandResult? currentResult = _innermostCommandResult.Parent as CommandResult;
             while (currentResult is not null)
             {
-                currentResult.Validate(completeValidation: false);
+                currentResult.Validate(isInnermostCommand: false);
 
                 currentResult = currentResult.Parent as CommandResult;
+            }
+
+            if (_primaryAction is null &&
+                _innermostCommandResult is { Command: { Action: null, HasSubcommands: true } })
+            {
+                _symbolResultTree.InsertFirstError(
+                    new ParseError(LocalizationResources.RequiredCommandWasNotProvided(), _innermostCommandResult));
             }
         }
     }


### PR DESCRIPTION
This fixes #2628. 