### PR TITLE
fix #2640

### DIFF
--- a/src/System.CommandLine.Tests/HelpOptionTests.cs
+++ b/src/System.CommandLine.Tests/HelpOptionTests.cs
@@ -6,7 +6,6 @@ using System.CommandLine.Help;
 using System.CommandLine.Invocation;
 using System.CommandLine.Tests.Utility;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -273,13 +272,10 @@ public class HelpOptionTests
                 {
                     result.AddError("Oops!");
                     return null;
-                    
                 }
             }
         };
-        subcommand.SetAction(_ =>
-        {
-        });
+        subcommand.SetAction(_ => { });
         RootCommand rootCommand = new()
         {
             subcommand

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -112,7 +112,11 @@ namespace System.CommandLine
         /// <returns>Returns the default value for the argument, if defined. Null otherwise.</returns>
         public object? GetDefaultValue()
         {
-            return GetDefaultValue(new ArgumentResult(this, null!, null));
+            var command = Parents.FlattenBreadthFirst(x => x.Parents)
+                                 .OfType<Command>()
+                                 .FirstOrDefault();
+
+            return GetDefaultValue(new ArgumentResult(this, new SymbolResultTree(command), null));
         }
 
         internal abstract object? GetDefaultValue(ArgumentResult argumentResult);

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.Parsing
 
         private protected SymbolResult(SymbolResultTree symbolResultTree, SymbolResult? parent)
         {
-            SymbolResultTree = symbolResultTree;
+            SymbolResultTree = symbolResultTree ?? throw new ArgumentNullException(nameof(symbolResultTree));
             Parent = parent;
         }
 

--- a/src/System.CommandLine/Parsing/SymbolResultTree.cs
+++ b/src/System.CommandLine/Parsing/SymbolResultTree.cs
@@ -7,14 +7,14 @@ namespace System.CommandLine.Parsing
 {
     internal sealed class SymbolResultTree : Dictionary<Symbol, SymbolResult>
     {
-        private readonly Command _rootCommand;
+        private readonly Command? _rootCommand;
         internal List<ParseError>? Errors;
         internal List<Token>? UnmatchedTokens;
         private Dictionary<string, SymbolNode>? _symbolsByName;
 
         internal SymbolResultTree(
-            Command rootCommand, 
-            List<string>? tokenizeErrors)
+            Command? rootCommand = null, 
+            List<string>? tokenizeErrors = null)
         {
             _rootCommand = rootCommand;
 
@@ -78,13 +78,13 @@ namespace System.CommandLine.Parsing
 
         public SymbolResult? GetResult(string name)
         {
-            if (_symbolsByName is null)
+            if (_symbolsByName is null && _rootCommand is not null)
             {
                 _symbolsByName = new();  
                 PopulateSymbolsByName(_rootCommand);
             }
           
-            if (!_symbolsByName.TryGetValue(name, out SymbolNode? node))
+            if (!_symbolsByName!.TryGetValue(name, out SymbolNode? node))
             {
                 throw new ArgumentException($"No symbol result found with name \"{name}\".");
             }


### PR DESCRIPTION
This fixes #2640 by ensuring a null `SymbolResultTree` is never passed to the `SymbolResult` constructor.