### PR TITLE
Helper property to easily check if tokens are provided for a symbol

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -233,6 +233,7 @@ System.CommandLine.Parsing
     public System.String ToString()
   public abstract class SymbolResult
     public System.Collections.Generic.IEnumerable<ParseError> Errors { get; }
+    public System.Boolean IsProvided { get; }
     public SymbolResult Parent { get; }
     public System.Collections.Generic.IReadOnlyList<Token> Tokens { get; }
     public System.Void AddError(System.String errorMessage)

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1686,5 +1686,45 @@ namespace System.CommandLine.Tests
 
             result.GetValue(option).Should().BeEmpty();
         }
+        
+        [Fact]
+        public void Parsed_result_is_provided_should_be_true_for_provided_tokens()
+        {
+            const string optionName = "--test-option";
+
+            var option = new Option<string>(optionName);
+
+            var rootCommand = new RootCommand
+            {
+                option
+            };
+
+            var result = rootCommand.Parse([optionName, "test-value", optionName, "test-value-2"]);
+
+            var parseResult = result.GetResult(option);
+
+            parseResult.Should().NotBeNull();
+            parseResult!.IsProvided.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Parsed_result_is_provided_should_be_false_for_not_provided_tokens()
+        {
+            const string optionName = "--test-option";
+
+            var option = new Option<string>(optionName);
+
+            var rootCommand = new RootCommand
+            {
+                option
+            };
+
+            var result = rootCommand.Parse([optionName]);
+
+            var parseResult = result.GetResult(option);
+
+            parseResult.Should().NotBeNull();
+            parseResult!.IsProvided.Should().BeFalse();
+        }
     }
 }

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -53,6 +53,8 @@ namespace System.CommandLine.Parsing
         /// The list of tokens associated with this symbol result during parsing.
         /// </summary>
         public IReadOnlyList<Token> Tokens => _tokens is not null ? _tokens : Array.Empty<Token>();
+        
+        public bool IsProvided => _tokens is not null && _tokens.Count > 0;
 
         internal void AddToken(Token token) => (_tokens ??= new()).Add(token);
 


### PR DESCRIPTION
I want to propose a clearer way to check if a SymbolResult has any provided tokens with this small pull request.

This should help in custom validators, and leads to better readability.

It's really only a convenience property, the name is just a suggestion, it could also be named "HasTokens" or something.

Example validator:

```
var option1Result = x.GetResult(_option1);
var option2Result = x.GetResult(_option2);

// null checks 
[..]

// before
if(option1Result.Tokens.Count > 0 && option2Result.Tokens.Count > 0)
{
    x.AddError($"{_option1.Name} and {_option2} can not be set together.");
}

// after
if(option1Result.IsProvided && option2Result.IsProvided)
{
    x.AddError($"{_option1.Name} and {_option2} can not be set together.");
}
```