### PR TITLE
Re-add default value on ProcessTerminationTimeout (#2671)

### DIFF
--- a/src/System.CommandLine/InvocationConfiguration.cs
+++ b/src/System.CommandLine/InvocationConfiguration.cs
@@ -18,7 +18,7 @@ public class InvocationConfiguration
     /// that can be passed to a <see cref="CommandLineAction"/> during invocation.
     /// If not provided, a default timeout of 2 seconds is enforced.
     /// </summary>
-    public TimeSpan? ProcessTerminationTimeout { get; set; }
+    public TimeSpan? ProcessTerminationTimeout { get; set; } = TimeSpan.FromSeconds(2); 
 
     /// <summary>
     /// The standard output. Used by Help and other facilities that write non-error information.


### PR DESCRIPTION
This update re-introduces a default 2s value to `InvocationConfiguration.ProcessTerminationTimeout` to ensure that `OperationCanceledException` is thrown on `Ctrl+C` in apps using async commands. See detailed bug report #2671 for analysis and reproduction steps.