### PR TITLE
[release/10.0] Re-add default value on ProcessTerminationTimeout

### DIFF
--- a/src/System.CommandLine/InvocationConfiguration.cs
+++ b/src/System.CommandLine/InvocationConfiguration.cs
@@ -18,7 +18,7 @@ public class InvocationConfiguration
     /// that can be passed to a <see cref="CommandLineAction"/> during invocation.
     /// If not provided, a default timeout of 2 seconds is enforced.
     /// </summary>
-    public TimeSpan? ProcessTerminationTimeout { get; set; }
+    public TimeSpan? ProcessTerminationTimeout { get; set; } = TimeSpan.FromSeconds(2); 
 
     /// <summary>
     /// The standard output. Used by Help and other facilities that write non-error information.


### PR DESCRIPTION
## Customer Impact

The preview 7 and later releases of System.CommandLine included an API change that resulted in default cancellation behaviors for System.CommandLine-based applications changing. in preview6 and earlier, the library was configured so that Ctrl+C would cause a `System.OperationCanceledException` to be thrown, giving user code a simple hook to catch and react to that. Preview 7 and later dropped this behavior unintentionally, causing some users to report that their cleanup/cancellation code was no longer being triggered.

## How was it found

An external user, @mpatkisson, discovered the issue, did detailed investigation and analysis in https://github.com/dotnet/command-line-api/issues/2671, and then contributed a fix in https://github.com/dotnet/command-line-api/pull/2672.

## Risk

**Low**. The existing cancellation mechanisms in use are under test, but we did not have a test that covers the documented 2s cancellation default behavior, to ensure we didn't regress it. This has been manually tested, and we will shortly add a test to the repo to prevent regressions.

