### PR TITLE
Adds simple gitops integration for `untriaged` label

### DIFF
--- a/.github/policies/untriaged-label.yml
+++ b/.github/policies/untriaged-label.yml
@@ -1,0 +1,38 @@
+id: untriaged
+name: GitOps.PullRequestIssueManagement
+description: Manage the 'untriaged' label on issues
+resource: repository
+
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - description: Add untriaged label to new/reopened issues without a milestone
+      if:
+      - payloadType: Issues
+      - isOpen
+      - not:
+          isPartOfAnyMilestone
+      - or:
+        - isAction:
+            action: Opened
+        - isAction:
+            action: Reopened
+      - not:
+          hasLabel:
+            label: untriaged
+      then:
+      - addLabel:
+          label: untriaged
+
+    - description: Remove untriaged label from issues when closed or added to a milestone
+      if:
+      - payloadType: Issues
+      - or:
+        - isAction:
+            action: Closed
+        - isPartOfAnyMilestone
+      - hasLabel:
+          label: untriaged
+      then:
+      - removeLabel:
+          label: untriaged


### PR DESCRIPTION
This does both of
* add untriaged label to new/non-milestoned issues
* adds issue to Triage milestone

but we can change the behaviors around easily.