### PR TITLE
Update Argument.HelpName and SymbolResult.GetResult API docs

### DIFF
--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -45,8 +45,21 @@ namespace System.CommandLine
         }
 
         /// <summary>
-        /// The name used in help output to describe the argument. 
+        /// Gets or sets the placeholder name shown in usage help for the argument's value.
+        /// The value will be wrapped in angle brackets (<c>&lt;</c> and <c>&gt;</c>).
         /// </summary>
+        /// <remarks>
+        /// If <c>null</c>, the <see cref="Symbol.Name"/> of the argument will be used.
+        /// </remarks>
+        /// <example>
+        /// An argument with <see cref="Symbol.Name"/> of <c>argument</c> and a
+        /// <see cref="HelpName"/> of <c>Value</c> will be shown in usage help as:
+        /// <c>&lt;Value&gt;</c>. If <see cref="HelpName"/> is not set,
+        /// help output will show: <c>&lt;argument&gt;</c>.
+        /// </example>
+        /// <value>
+        /// The name to show as the placeholder for the argument's value.
+        /// </value>
         public string? HelpName { get; set; }
 
         internal TryConvertArgument? ConvertArguments

--- a/src/System.CommandLine/Parsing/SymbolResult.cs
+++ b/src/System.CommandLine/Parsing/SymbolResult.cs
@@ -91,10 +91,13 @@ namespace System.CommandLine.Parsing
         public DirectiveResult? GetResult(Directive directive) => SymbolResultTree.GetResult(directive);
 
         /// <summary>
-        /// Finds a result for a symbol having the specified name anywhere in the parse tree.
+        /// Finds a result for a <see cref="Symbol" /> having the specified <paramref name="name" /> anywhere in the parse tree.
         /// </summary>
-        /// <param name="name">The name of the symbol for which to find a result.</param>
-        /// <returns>An argument result if the argument was matched by the parser or has a default value; otherwise, <c>null</c>.</returns>
+        /// <param name="name">The name of the <see cref="Symbol" /> for which to find a result.</param>
+        /// <returns>
+        /// A <see cref="SymbolResult" /> if the <see cref="Symbol" /> was matched by the parser or has a default value;
+        /// otherwise, <see langword="null" />.
+        /// </returns>
         public SymbolResult? GetResult(string name) => 
             SymbolResultTree.GetResult(name);
 


### PR DESCRIPTION
Fixes #2678 and builds on #2687, applying the same HelpName docs improvements to Argument.