### PR TITLE
Update global.json to include SDK settings

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,4 +1,9 @@
 {
+  "sdk": {
+    "version": "9.0.111",
+    "allowPrerelease": true,
+    "rollForward": "major"
+  },
   "tools": {
     "dotnet": "9.0.111",
     "runtimes": {


### PR DESCRIPTION
The `tools` section is proprietary and only used by arcade.

The `sdk` section is used by dotnet to ensure this SDK version is used, and also what the publicly available AzDo build tasks use when installing dotnet.

@jeffhandley 