### PR TITLE
Improve command-line completion handling.

### DIFF
--- a/src/System.CommandLine/Command.cs
+++ b/src/System.CommandLine/Command.cs
@@ -265,6 +265,13 @@ namespace System.CommandLine
 
             if (context.WordToComplete is { } textToMatch)
             {
+                // If the text to match is the command name, we should suggest all possible completions (subcommands, options, arguments).
+                var textToMatchIsCommandName = context.ParseResult.CommandResult.Command.Name.Equals(textToMatch, StringComparison.OrdinalIgnoreCase);
+                if (textToMatchIsCommandName)
+                {
+                    textToMatch = null;
+                }
+
                 if (HasSubcommands)
                 {
                     var commands = Subcommands;
@@ -291,7 +298,7 @@ namespace System.CommandLine
                         var argument = arguments[i];
                         foreach (var completion in argument.GetCompletions(context))
                         {
-                            if (completion.Label.ContainsCaseInsensitive(textToMatch))
+                            if (textToMatch is null || completion.Label.ContainsCaseInsensitive(textToMatch))
                             {
                                 completions.Add(completion);
                             }
@@ -335,7 +342,7 @@ namespace System.CommandLine
             {
                 if (!identifier.Hidden)
                 {
-                    if (identifier.Name.ContainsCaseInsensitive(textToMatch))
+                    if (textToMatch is null || identifier.Name.ContainsCaseInsensitive(textToMatch))
                     {
                         completions.Add(new CompletionItem(identifier.Name, CompletionItem.KindKeyword, detail: identifier.Description));
                     }
@@ -344,7 +351,7 @@ namespace System.CommandLine
                     {
                         foreach (string alias in aliases)
                         {
-                            if (alias.ContainsCaseInsensitive(textToMatch))
+                            if (textToMatch is null || alias.ContainsCaseInsensitive(textToMatch))
                             {
                                 completions.Add(new CompletionItem(alias, CompletionItem.KindKeyword, detail: identifier.Description));
                             }

--- a/src/System.CommandLine/Completions/CompletionAction.cs
+++ b/src/System.CommandLine/Completions/CompletionAction.cs
@@ -24,7 +24,7 @@ internal sealed class CompletionAction : SynchronousCommandLineAction
 
         int position = !string.IsNullOrEmpty(parsedValues) ? int.Parse(parsedValues) : rawInput?.Length ?? 0;
 
-        var commandLineToComplete = parseResult.Tokens.LastOrDefault(t => t.Type != TokenType.Directive)?.Value ?? "";
+        var commandLineToComplete = parseResult.Tokens.Where(t => t.Type != TokenType.Directive).Select(t => t.Value).ToArray();
 
         var completionParseResult = parseResult.RootCommandResult.Command.Parse(commandLineToComplete, parseResult.Configuration);
 


### PR DESCRIPTION
If you specify the complete name of a command that contains subcommands and options, the expected behavior for completions is:
•	Subcommands: All direct subcommands of the specified command should be suggested as completions.
•	Options: All options available for that command (including inherited/global options, if any) should also be suggested as completions.

For example, if you have a command structure like:
```
root
└── parentcmd
    ├── subcmd1
    ├── subcmd2
    └── --option1
```

When you type:
```
parentcmd [TAB]
```
or use the `[suggest]` directive with `parentcmd`, the completion list should include:
```
subcmd1
subcmd2
--option1
```

**Changes:**

- enhanced completion logic to handle cases where the text to match is the command name or is `null`, ensuring all relevant completions (subcommands, options, arguments) are suggested.

- updated `CompletionAction` in `CompletionAction.cs` to process multiple tokens for command-line completion, improving support for multi-token inputs.