### PR TITLE
Fix FirstArgumentIsRootCommand falsely matching option values

### DIFF
--- a/src/System.CommandLine.Tests/ParserTests.RootCommandAndArg0.cs
+++ b/src/System.CommandLine.Tests/ParserTests.RootCommandAndArg0.cs
@@ -101,6 +101,39 @@ public partial class ParserTests
             result3.RootCommandResult.Command.Should().BeSameAs(result1.RootCommandResult.Command);
         }
 
+        [Fact]
+        public void When_parsing_a_string_array_option_values_containing_command_name_after_slash_are_not_treated_as_root_command()
+        {
+            // Path.GetFileName("/p:Key=something/myapp") returns "myapp",
+            // which should not be matched as the root command name.
+            var option = new Option<string>("--property", "/p") { Arity = ArgumentArity.ExactlyOne };
+            var command = new Command("myapp");
+            command.Options.Add(option);
+
+            var result = command.Parse(Split("/p:Key=something/myapp"));
+
+            result.Errors.Should().BeEmpty();
+            result.GetResult(option).Should().NotBeNull();
+        }
+
+        [Theory]
+        [InlineData("/p:DockerImage=registry.example.com/project/dotnet")]
+        [InlineData("-p:DockerImage=registry.example.com/project/dotnet")]
+        [InlineData("--property:DockerImage=registry.example.com/project/dotnet")]
+        public void When_parsing_a_string_array_option_values_ending_with_slash_command_name_are_preserved(string arg)
+        {
+            // Regression test: Path.GetFileName extracts the last segment after '/',
+            // so option values like ".../dotnet" falsely matched a command named "dotnet".
+            var option = new Option<string>("--property", "/p", "-p") { Arity = ArgumentArity.ExactlyOne };
+            var command = new Command("dotnet");
+            command.Options.Add(option);
+
+            var result = command.Parse(Split(arg));
+
+            result.Errors.Should().BeEmpty();
+            result.GetResult(option).Should().NotBeNull();
+        }
+
         string[] Split(string value) => CommandLineParser.SplitCommandLine(value).ToArray();
     }
 }

--- a/src/System.CommandLine/Parsing/StringExtensions.cs
+++ b/src/System.CommandLine/Parsing/StringExtensions.cs
@@ -275,18 +275,9 @@ namespace System.CommandLine.Parsing
                     return true;
                 }
 
-                try
+                if (rootCommand.EqualsNameOrAlias(args[0]))
                 {
-                    var potentialRootCommand = Path.GetFileName(args[0]);
-
-                    if (rootCommand.EqualsNameOrAlias(potentialRootCommand))
-                    {
-                        return true;
-                    }
-                }
-                catch (ArgumentException)
-                {
-                    // possible exception for illegal characters in path on .NET Framework
+                    return true;
                 }
             }
 


### PR DESCRIPTION
 ### Problem

  `FirstArgumentIsRootCommand` used `Path.GetFileName(args[0])` to extract a potential command name from the first argument. Since `Path.GetFileName`
  returns the last segment after `/`, option values like `/p:DockerImage=registry.example.com/project/dotnet` would extract `dotnet` — falsely matching a
  root command named `dotnet`.

  This caused the parser to skip `args[0]` (treating it as the root command invocation), losing the option value entirely.

  ### Approach

  Replaced the `Path.GetFileName` heuristic with a direct `rootCommand.EqualsNameOrAlias(args[0])` check. Only an exact name or alias match should identify
  `args[0]` as the root command. The existing `inferRootCommand` + `ExecutablePath` check for unsplit string parsing is unchanged.

  ### FirstArgumentIsRootCommand behavior

  | `args[0]` | Before | After | Notes |
  |---|---|---|---|
  | `dotnet` | ✅ match | ✅ match | Exact name match, unchanged |
  | `ExecutablePath` (unsplit string) | ✅ match | ✅ match | `inferRootCommand` path, unchanged |
  | `/p:DockerImage=.../dotnet` | 🐛 match | ✅ no match | `Path.GetFileName` extracted `dotnet` |
  | `/p:Key=something/myapp` | 🐛 match | ✅ no match | `Path.GetFileName` extracted `myapp` |
  | `-p:DockerImage=.../dotnet` | 🐛 match | ✅ no match | Same extraction issue with `-p:` prefix |
  | `./myapp` | ✅ match | ⚠️ no match | Narrow edge case; .NET `Main(args)` never includes exe path |

  ### Testing

  Added regression tests covering:
  - Option value containing the command name after `/` (e.g., `/p:Key=something/myapp`)
  - Three property option formats (`/p:`, `-p:`, `--property:`) with docker image paths ending in the command name