### PR TITLE
Use source-build-assets repo

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23217.1">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>8a91992a869b6e4dccd49b1c3246486e963595af</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-assets" Version="8.0.0-alpha.1.26208.5">
+      <Uri>https://github.com/dotnet/source-build-assets</Uri>
+      <Sha>e726d9647b47c6635533d8eebfc2992749128d7e</Sha>
+      <SourceBuild RepoName="source-build-assets" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
`source-build-reference-packages` repo was renamed to `source-build-assets`. To enable VMR/source-build scenarios this reference needs to be updated. This also updates the version as the new repo produced a new package.