### PR TITLE
Use source-build-assets repo

### DIFF
--- a/.vsts-ci-official.yml
+++ b/.vsts-ci-official.yml
@@ -137,7 +137,7 @@ extends:
                 sudo apt-add-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-9 main"
                 sudo apt-get update
             - bash: |
-                sudo apt-get install cmake clang-9 libicu66 uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev
+                sudo apt-get install cmake clang-9 libicu70 uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev
             - script: eng/common/cibuild.sh
                 --configuration $(_BuildConfig)
                 --prepareMachine

--- a/.vsts-ci-official.yml
+++ b/.vsts-ci-official.yml
@@ -118,7 +118,7 @@ extends:
             displayName: Ubuntu
             pool:
               name: NetCore1ESPool-Svc-Internal
-              demands: ImageOverride -equals 1es-ubuntu-2004
+              demands: ImageOverride -equals 1es-ubuntu-2204
               os: linux
             strategy:
               matrix:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -80,7 +80,7 @@ stages:
         displayName: Ubuntu
         pool:
           name: NetCore-Svc-Public
-          demands: ImageOverride -equals 1es-ubuntu-2004-open
+          demands: ImageOverride -equals 1es-ubuntu-2204-open
         strategy:
           matrix:
             ${{ if in(variables['Build.Reason'], 'PullRequest') }}:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -98,7 +98,7 @@ stages:
             sudo apt-add-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-9 main"
             sudo apt-get update
         - bash: |
-            sudo apt-get install cmake clang-9 libicu66 uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev
+            sudo apt-get install cmake clang-9 libicu70 uuid-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -2,10 +2,10 @@
 <Dependencies>
   <ProductDependencies>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.24257.2">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>6ed73280a6d70f7e7ac39c86f2abe8c10983f0bb</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-assets" Version="8.0.0-alpha.1.26208.5">
+      <Uri>https://github.com/dotnet/source-build-assets</Uri>
+      <Sha>e726d9647b47c6635533d8eebfc2992749128d7e</Sha>
+      <SourceBuild RepoName="source-build-assets" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,14 +9,14 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24321.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24359.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a95bcc256e9bdf47394e4dab04872811c16daaea</Sha>
+      <Sha>db87887481d4110c09a1004191002482fdd7e4f2</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="8.0.0-beta.24321.3">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="8.0.0-beta.24359.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>a95bcc256e9bdf47394e4dab04872811c16daaea</Sha>
+      <Sha>db87887481d4110c09a1004191002482fdd7e4f2</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <!-- Don't declare a separate xliff-tasks intermediate as Arcade 8.0 does not have xliff intermediate declared. -->

--- a/eng/common/templates-official/job/source-build.yml
+++ b/eng/common/templates-official/job/source-build.yml
@@ -54,7 +54,7 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore-Svc-Public' ), False, 'NetCore-Public')]
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+        demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -54,11 +54,11 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore-Svc-Public' ), False, 'NetCore-Public')]
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+        demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
 
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: $[replace(replace(eq(contains(coalesce(variables['System.PullRequest.TargetBranch'], variables['Build.SourceBranch'], 'refs/heads/main'), 'release'), 'true'), True, 'NetCore1ESPool-Svc-Internal'), False, 'NetCore1ESPool-Internal')]
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+        demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
 
   ${{ if ne(parameters.platform.pool, '') }}:
     pool: ${{ parameters.platform.pool }}

--- a/global.json
+++ b/global.json
@@ -10,6 +10,6 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24321.3"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24359.3"
   }
 }


### PR DESCRIPTION
`source-build-reference-packages` repo was renamed to `source-build-assets`. To enable VMR/source-build scenarios this reference needs to be updated. This also updates the version as the new repo produced a new package.