### PR TITLE
Fix parent non-recursive arguments leaking into subcommands (#2785)

### DIFF
--- a/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
+++ b/src/System.CommandLine.ApiCompatibility.Tests/ApiCompatibilityApprovalTests.System_CommandLine_api_is_not_changed.approved.txt
@@ -5,6 +5,7 @@
     public System.Collections.Generic.List<System.Func<System.CommandLine.Completions.CompletionContext,System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem>>> CompletionSources { get; }
     public System.Boolean HasDefaultValue { get; }
     public System.String HelpName { get; set; }
+    public System.Boolean Recursive { get; set; }
     public System.Collections.Generic.List<System.Action<System.CommandLine.Parsing.ArgumentResult>> Validators { get; }
     public System.Type ValueType { get; }
     public System.Collections.Generic.IEnumerable<System.CommandLine.Completions.CompletionItem> GetCompletions(System.CommandLine.Completions.CompletionContext context)

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -212,6 +212,30 @@ namespace System.CommandLine.Tests.Help
         }
 
         [Fact]
+        public void Usage_section_for_subcommand_omits_non_recursive_parent_arguments()
+        {
+            var inner = new Command("inner", "command help")
+            {
+                new Option<string>("-v") { Description = "Sets the verbosity" },
+                new Argument<string[]>("inner-args")
+            };
+            _ = new Command("outer", "command help")
+            {
+                inner,
+                new Argument<string[]>("outer-args") { Recursive = false }
+            };
+
+            _helpBuilder.Write(inner, _console);
+
+            var expected =
+                $"Usage:{NewLine}" +
+                $"{_indentation}outer inner [<inner-args>...] [options]";
+
+            _console.ToString().Should().Contain(expected);
+            _console.ToString().Should().NotContain("<outer-args>");
+        }
+
+        [Fact]
         public void Usage_section_does_not_show_additional_arguments_when_TreatUnmatchedTokensAsErrors_is_not_specified()
         {
             var command = new Command(

--- a/src/System.CommandLine.Tests/ParserTests.cs
+++ b/src/System.CommandLine.Tests/ParserTests.cs
@@ -1227,6 +1227,26 @@ namespace System.CommandLine.Tests
                   .BeEquivalentSequenceTo("one", "two", "three", "subcommand", "four");
         }
 
+        [Fact]
+        public void Non_recursive_parent_argument_is_unmatched_when_subcommand_is_invoked()
+        {
+            var rootArg = new Argument<string>("rootArg") { Recursive = false };
+            var subcommand = new Command("subcommand");
+            var root = new RootCommand
+            {
+                rootArg,
+                subcommand
+            };
+
+            var result = root.Parse("value subcommand");
+
+            result.CommandResult.Command.Should().BeSameAs(subcommand);
+            result.UnmatchedTokens.Should().BeEquivalentTo("value");
+            result.Errors.Should().ContainSingle(e =>
+                e.Message == LocalizationResources.UnrecognizedCommandOrArgument("value"));
+            result.GetValue(rootArg).Should().BeNull();
+        }
+
         [Theory]
         [InlineData("-x=-y")]
         [InlineData("-x:-y")]

--- a/src/System.CommandLine/Argument.cs
+++ b/src/System.CommandLine/Argument.cs
@@ -182,5 +182,11 @@ namespace System.CommandLine
 
             public override bool HasDefaultValue => false;
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this argument is inherited by child commands.
+        /// </summary>
+        public bool Recursive { get; set; } = true;  
+
     }
 }

--- a/src/System.CommandLine/Help/HelpBuilder.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.cs
@@ -137,9 +137,12 @@ namespace System.CommandLine.Help
 
                     yield return (parentCommand is RootCommand root ? root.HelpName : null) ?? parentCommand.Name;
 
-                    if (parentCommand.Arguments.Any())
+                    var argumentToDisplay = parentCommand == command
+                        ? parentCommand.Arguments.Where(a => !a.Hidden).ToList()
+                        : parentCommand.Arguments.Where(a => a.Recursive && !a.Hidden).ToList();
+                    if (argumentToDisplay.Any())
                     {
-                        yield return FormatArgumentUsage(parentCommand.Arguments);
+                        yield return FormatArgumentUsage(argumentToDisplay);
                     }
                 }
 
@@ -168,7 +171,7 @@ namespace System.CommandLine.Help
             command
                 .RecurseWhileNotNull(c => c.Parents.OfType<Command>().FirstOrDefault())
                 .Reverse()
-                .SelectMany(cmd => cmd.Arguments.Where(a => !a.Hidden))
+                .SelectMany(cmd => cmd.Arguments.Where(a => !a.Hidden && (cmd == command || a.Recursive)))
                 .Select(a => GetTwoColumnRow(a, context))
                 .Distinct();
 

--- a/src/System.CommandLine/Parsing/ParseOperation.cs
+++ b/src/System.CommandLine/Parsing/ParseOperation.cs
@@ -77,18 +77,48 @@ namespace System.CommandLine.Parsing
         private void ParseSubcommand()
         {
             Command command = (Command)CurrentToken.Symbol!;
+            var parentCommandResult = _innermostCommandResult;
 
             _innermostCommandResult = new CommandResult(
                 command,
                 CurrentToken,
                 _symbolResultTree,
-                _innermostCommandResult);
+                parentCommandResult);
 
             _symbolResultTree.Add(command, _innermostCommandResult);
+
+            MoveNonRecursiveParentArgumentsToUnmatched(parentCommandResult, _innermostCommandResult);
 
             Advance();
 
             ParseCommandChildren();
+        }
+
+        private void MoveNonRecursiveParentArgumentsToUnmatched(CommandResult parent, CommandResult innermost)
+        {
+            if (!parent.Command.HasArguments)
+            {
+                return;
+            }
+
+            var arguments = parent.Command.Arguments;
+            for (var i = 0; i < arguments.Count; i++)
+            {
+                Argument argument = arguments[i];
+
+                if (!argument.Recursive &&
+                    _symbolResultTree.TryGetValue(argument, out SymbolResult? parsedResult) &&
+                    parsedResult is ArgumentResult argumentResult &&
+                    ReferenceEquals(argumentResult.Parent, parent))
+                {
+                    foreach (var token in argumentResult.Tokens)
+                    {
+                        _symbolResultTree.AddUnmatchedToken(token, innermost, _rootCommandResult);
+                    }
+
+                    _symbolResultTree.Remove(argument);
+                }
+            }
         }
 
         private void ParseCommandChildren()
@@ -411,7 +441,6 @@ namespace System.CommandLine.Parsing
             while (currentResult is not null)
             {
                 currentResult.Validate(isInnermostCommand: false);
-
                 currentResult = currentResult.Parent as CommandResult;
             }
 


### PR DESCRIPTION
## Description
This PR resolves issue #2785 where non-recursive positional arguments from parent commands were incorrectly inherited, validated, and displayed in subcommands.

### Key Changes
- **Early Interception in `ParseOperation`**: Introduced `MoveNonRecursiveParentArgumentsToUnmatched` inside `ParseSubcommand()`. When entering a subcommand, the parser immediately intercepts parent arguments configured with `Recursive = false`, purges them from the `SymbolResultTree`, and registers their tokens as `UnmatchedTokens` under the root command result. This completely prevents validation leaks and downstream crashes.
- **Help Architecture Alignment**: Updated `HelpBuilder.cs` (`GetUsageParts` and `GetCommandArgumentRows`) to filter out parent arguments where `Recursive == false` when rendering usage strings and argument tables for subcommands.
- **Public API Contract**: Added the `Recursive` property to the `Argument` class (defaulting to `true` to avoid breaking changes) and updated the alphabetical baseline file for API compatibility checks.
- **Test Coverage**: Added dedicated unit tests for both parsing telemetry (`ParserTests.cs`) and layout rendering accuracy (`HelpBuilderTests.cs`).

### Verification
- Tested locally on `net10.0` target.
- All 929 test cases passing successfully.