### PR TITLE
Handle empty argv in RootCommand.ExecutablePath

### DIFF
--- a/src/System.CommandLine.Tests/RootCommandTests.cs
+++ b/src/System.CommandLine.Tests/RootCommandTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Reflection;
 using FluentAssertions;
 using Xunit;
 
@@ -48,5 +50,22 @@ namespace System.CommandLine.Tests
 
             rootCommand.Name.Should().Be(RootCommand.ExecutableName);
         }
+
+        [Fact]
+        public void ExecutablePath_falls_back_to_empty_string_when_command_line_args_are_empty()
+        {
+            GetExecutablePath(Array.Empty<string>()).Should().Be("");
+        }
+
+        [Fact]
+        public void ExecutablePath_uses_first_command_line_arg()
+        {
+            GetExecutablePath(new[] { "my-tool", "--help" }).Should().Be("my-tool");
+        }
+
+        private static string GetExecutablePath(string[] commandLineArgs)
+            => (string)typeof(RootCommand)
+                .GetMethod("GetExecutablePath", BindingFlags.NonPublic | BindingFlags.Static)!
+                .Invoke(null, new object[] { commandLineArgs })!;
     }
 }

--- a/src/System.CommandLine/RootCommand.cs
+++ b/src/System.CommandLine/RootCommand.cs
@@ -74,7 +74,10 @@ namespace System.CommandLine
         /// <summary>
         /// The path to the currently running executable.
         /// </summary>
-        public static string ExecutablePath => _executablePath ??= Environment.GetCommandLineArgs()[0];
+        public static string ExecutablePath => _executablePath ??= GetExecutablePath(Environment.GetCommandLineArgs());
+
+        private static string GetExecutablePath(IReadOnlyList<string> commandLineArgs)
+            => commandLineArgs.Count > 0 ? commandLineArgs[0] : string.Empty;
 
         private static string? ToolCommandName
         {


### PR DESCRIPTION
Fixes #2812.

`RootCommand.ExecutablePath` currently indexes `Environment.GetCommandLineArgs()[0]` directly. Some NativeAOT hosts can report an empty argv array, which makes constructing or otherwise touching `RootCommand` throw `IndexOutOfRangeException` before user code can run.

This change routes executable path extraction through a small helper and falls back to `string.Empty` when the runtime exposes no argv entries. The normal non-empty argv behavior is unchanged.

Validation:
- `git diff --check`
- `dotnet test src/System.CommandLine.Tests/System.CommandLine.Tests.csproj --filter RootCommandTests --no-restore` was attempted locally but blocked because `global.json` requires SDK `11.0.100-preview.4.26210.111` and this machine has `10.0.202` installed.