### PR TITLE
Fix OnlyTake token redistribution order

### DIFF
--- a/src/System.CommandLine.Tests/CustomParsingTests.cs
+++ b/src/System.CommandLine.Tests/CustomParsingTests.cs
@@ -780,6 +780,68 @@ public class CustomParsingTests
                                    options => options.WithStrictOrdering());
     }
 
+    [Fact] // https://github.com/dotnet/command-line-api/issues/2734
+    public void OnlyTake_preserves_token_order_when_multiple_arguments_pass_on_tokens()
+    {
+        static string[] TakeTwo(ArgumentResult result)
+        {
+            result.OnlyTake(2);
+
+            return result.Tokens.Select(t => t.Value).ToArray();
+        }
+
+        var argument1 = new Argument<string[]>("arg1")
+        {
+            Arity = new(1, 15),
+            CustomParser = TakeTwo
+        };
+        var argument2 = new Argument<string[]>("arg2")
+        {
+            Arity = new(1, 3),
+            CustomParser = TakeTwo
+        };
+        var argument3 = new Argument<string[]>("arg3")
+        {
+            Arity = new(1, 3),
+            CustomParser = TakeTwo
+        };
+        var argument4 = new Argument<string[]>("arg4")
+        {
+            Arity = new(1, 3),
+            CustomParser = TakeTwo
+        };
+        var argument5 = new Argument<string[]>("arg5")
+        {
+            Arity = new(1, 3),
+            CustomParser = TakeTwo
+        };
+        var argument6 = new Argument<string[]>("arg6")
+        {
+            Arity = new(1, 10)
+        };
+
+        var command = new RootCommand
+        {
+            argument1,
+            argument2,
+            argument3,
+            argument4,
+            argument5,
+            argument6
+        };
+
+        var parseResult = command.Parse(Enumerable.Range(1, 20).Select(i => i.ToString()).ToArray());
+
+        parseResult.GetRequiredValue(argument1).Should().BeEquivalentSequenceTo("1", "2");
+        parseResult.GetRequiredValue(argument2).Should().BeEquivalentSequenceTo("3", "4");
+        parseResult.GetRequiredValue(argument3).Should().BeEquivalentSequenceTo("5", "6");
+        parseResult.GetRequiredValue(argument4).Should().BeEquivalentSequenceTo("7", "8");
+        parseResult.GetRequiredValue(argument5).Should().BeEquivalentSequenceTo("9", "10");
+        parseResult.GetRequiredValue(argument6)
+                   .Should()
+                   .BeEquivalentSequenceTo("11", "12", "13", "14", "15", "16", "17", "18", "19", "20");
+    }
+
     [Fact]
     public void OnlyTake_throws_when_called_with_a_negative_value()
     {

--- a/src/System.CommandLine/Parsing/ArgumentResult.cs
+++ b/src/System.CommandLine/Parsing/ArgumentResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.CommandLine.Binding;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace System.CommandLine.Parsing
@@ -27,8 +28,6 @@ namespace System.CommandLine.Parsing
         /// Gets the argument to which the result applies.
         /// </summary>
         public Argument Argument { get; }
-
-        internal bool ArgumentLimitReached => Argument.Arity.MaximumNumberOfValues == (_tokens?.Count ?? 0);
 
         public bool Implicit { get; private set; }
 
@@ -98,9 +97,10 @@ namespace System.CommandLine.Parsing
             var arguments = parent.Command.Arguments;
             int argumentIndex = arguments.IndexOf(Argument);
             int nextArgumentIndex = argumentIndex + 1;
-            int tokensToPass = _tokens.Count - numberOfTokens;
+            List<Token> tokensToPass = _tokens.GetRange(numberOfTokens, _tokens.Count - numberOfTokens);
+            _tokens.RemoveRange(numberOfTokens, tokensToPass.Count);
 
-            while (tokensToPass > 0 && nextArgumentIndex < arguments.Count)
+            while (tokensToPass.Count > 0 && nextArgumentIndex < arguments.Count)
             {
                 Argument nextArgument = parent.Command.Arguments[nextArgumentIndex];
                 ArgumentResult nextArgumentResult;
@@ -116,25 +116,28 @@ namespace System.CommandLine.Parsing
                     SymbolResultTree.Add(nextArgument, nextArgumentResult);
                 }
 
-                while (!nextArgumentResult.ArgumentLimitReached && tokensToPass > 0)
+                if (nextArgumentResult._tokens is not null)
                 {
-                    Token toPass = _tokens[numberOfTokens];
-                    _tokens.RemoveAt(numberOfTokens);
-                    nextArgumentResult.AddToken(toPass);
-                    --tokensToPass;
+                    tokensToPass.AddRange(nextArgumentResult._tokens);
                 }
 
+                int tokensToTake = Math.Min(nextArgument.Arity.MaximumNumberOfValues, tokensToPass.Count);
+
+                nextArgumentResult._tokens = tokensToTake > 0
+                    ? tokensToPass.GetRange(0, tokensToTake)
+                    : null;
+                nextArgumentResult._conversionResult = null;
+                nextArgumentResult._validatorsHaveBeenRun = false;
+
+                tokensToPass.RemoveRange(0, tokensToTake);
                 nextArgumentIndex++;
             }
 
             CommandResult rootCommand = parent;
             // When_tokens_are_passed_on_by_custom_parser_on_last_argument_then_they_become_unmatched_tokens
-            while (tokensToPass > 0)
+            for (var i = 0; i < tokensToPass.Count; i++)
             {
-                Token unmatched = _tokens[numberOfTokens];
-                _tokens.RemoveAt(numberOfTokens);
-                SymbolResultTree.AddUnmatchedToken(unmatched, parent, rootCommand);
-                --tokensToPass;
+                SymbolResultTree.AddUnmatchedToken(tokensToPass[i], parent, rootCommand);
             }
         }
 


### PR DESCRIPTION
## Summary
- preserve command-line token order when `ArgumentResult.OnlyTake` passes tokens through multiple positional arguments
- redistribute passed-on tokens before each later argument's existing tokens, while respecting each argument's max arity
- add regression coverage for issue #2734 with six positional arguments and repeated `OnlyTake(2)` custom parsers

Fixes dotnet/command-line-api#2734.

## Tests
- `./build.cmd -projects src\System.CommandLine.Tests\System.CommandLine.Tests.csproj`
- `.\.dotnet\dotnet.exe test src\System.CommandLine.Tests\System.CommandLine.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~OnlyTake_preserves_token_order_when_multiple_arguments_pass_on_tokens"`
- `.\.dotnet\dotnet.exe test src\System.CommandLine.Tests\System.CommandLine.Tests.csproj --framework net10.0 --no-build --filter "FullyQualifiedName~OnlyTake"`
- `.\.dotnet\dotnet.exe test src\System.CommandLine.Tests\System.CommandLine.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~CustomParsingTests"`
- `.\.dotnet\dotnet.exe test src\System.CommandLine.Tests\System.CommandLine.Tests.csproj --framework net10.0`
- `.\.dotnet\dotnet.exe test src\System.CommandLine.Tests\System.CommandLine.Tests.csproj --framework net472 --filter "FullyQualifiedName~OnlyTake"`
- `.\.dotnet\dotnet.exe test src\System.CommandLine.Tests\System.CommandLine.Tests.csproj --framework net472`
- `git diff --check`

---
Written by an agent (OpenAI Codex, GPT-5).