### PR TITLE
fix: omit empty help description section

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
@@ -466,7 +466,6 @@ public partial class HelpBuilderTests
             command.Parse("test -h").Invoke(new() { Output = output });
 
             output.ToString().Should().Be(
-                $"Description:{NewLine}{NewLine}" +
                 $"Usage:{NewLine}  test [options]{NewLine}{NewLine}" +
                 $"Options:{NewLine}" +
                 $"  --option   option {NewLine}" +

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -74,6 +74,20 @@ namespace System.CommandLine.Tests.Help
             _console.ToString().Should().Contain(expected);
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void Synopsis_section_is_omitted_when_description_is_empty(string? description)
+        {
+            var command = new Command("the-command", description);
+
+            _helpBuilder.Write(command, _console);
+
+            _console.ToString().Should().NotContain("Description:");
+            _console.ToString().Should().Contain("Usage:");
+        }
+
         [Fact]
         public void Command_name_in_synopsis_can_be_specified()
         {

--- a/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
+++ b/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
@@ -46,9 +46,9 @@ public static class AssertionExtensions
         return assertions.BeEquivalentTo(expectedValues, c => c.WithStrictOrderingFor(s => s));
     }
 
-    public static AndConstraint<StringAssertions> ShowHelp(this StringAssertions output) => 
-        output.Subject.Should().Match("*Description:*Usage:*");
+    public static AndConstraint<StringAssertions> ShowHelp(this StringAssertions output) =>
+        output.Subject.Should().Contain("Usage:");
 
-    public static AndConstraint<StringAssertions> NotShowHelp(this StringAssertions output) => 
-        output.Subject.Should().NotMatch("*Description:*Usage:*");
+    public static AndConstraint<StringAssertions> NotShowHelp(this StringAssertions output) =>
+        output.Subject.Should().NotContain("Usage:");
 }

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -185,6 +185,11 @@ internal partial class HelpBuilder
         public static Func<HelpContext, bool> SynopsisSection() =>
             ctx =>
             {
+                if (string.IsNullOrWhiteSpace(ctx.Command.Description))
+                {
+                    return false;
+                }
+
                 ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpDescriptionTitle(), ctx.Command.Description, ctx.Output);
                 return true;
             };


### PR DESCRIPTION
﻿## Summary

Omits the default help `Description:` section when a command description is null, empty, or whitespace.

## Why

Fixes #2114. Descriptions are optional, but the default help layout always wrote a description heading. That produced an empty section such as:

```text
Description:

```

## Changes

- Makes the default synopsis section return `false` when there is no description to render
- Adds a regression test for null, empty, and whitespace descriptions

## Validation

- `git diff --check`

I attempted to run:

```bash
dotnet test src/System.CommandLine.Tests/System.CommandLine.Tests.csproj --filter "FullyQualifiedName~Synopsis_section_is_omitted_when_description_is_empty|FullyQualifiedName~Synopsis_section_properly_wraps_description"
```

but the local machine only has .NET SDK 10.0.203 and this repository's `global.json` currently requests `11.0.100-preview.4.26210.111`, so the SDK could not be resolved.

## AI assistance disclosure

This PR was prepared with assistance from OpenAI Codex. The change was reviewed locally and kept to a focused bug fix with a regression test.
