### PR TITLE
Mark that S.CL is trim compatible

### DIFF
--- a/src/System.CommandLine/System.CommandLine.csproj
+++ b/src/System.CommandLine/System.CommandLine.csproj
@@ -14,6 +14,7 @@
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
    
   <ItemGroup>


### PR DESCRIPTION
IsAotCompatible is what's checked to drive the `IL3058` [diagnostic](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/warnings/il3058), so we need to add it to make this library not false report.