### PR TITLE
fix: complete Korean(ko) translations in Resources.kr.xlf

### DIFF
--- a/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
+++ b/src/System.CommandLine/Properties/xlf/Resources.ko.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="ArgumentConversionCannotParse">
         <source>Cannot parse argument '{0}' as expected type '{1}'.</source>
-        <target state="new">Cannot parse argument '{0}' as expected type '{1}'.</target>
+        <target state="translated">'{0}' 인수를 지정된 형식 '{1}'(으)로 변환할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand">
         <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'.</target>
+        <target state="translated">'{1}' 명령의 '{0}' 인수를 지정된 형식 '{2}'(으)로 변환할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForCommand_Completions">
         <source>Cannot parse argument '{0}' for command '{1}' as expected type '{2}'. Did you mean one of the following?{3}</source>
-        <target state="new">Cannot parse argument '{0}' for command '{1}' as expected type '{2}'. Did you mean one of the following?{3}</target>
+        <target state="translated">'{1}' 명령의 '{0}' 인수를 지정된 형식 '{2}'(으)로 변환할 수 없습니다. 아래 항목 중 하나를 입력하려던 것은 아니셨나요?{3}</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption">
         <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'.</target>
+        <target state="translated">'{1}' 옵션에 대한 '{0}' 인수를 지정된 형식 '{2}'(으)로 변환할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ArgumentConversionCannotParseForOption_Completions">
         <source>Cannot parse argument '{0}' for option '{1}' as expected type '{2}'. Did you mean one of the following?{3}</source>
-        <target state="new">Cannot parse argument '{0}' for option '{1}' as expected type '{2}'. Did you mean one of the following?{3}</target>
+        <target state="translated">'{1}' 옵션에 대한 '{0}' 인수를 지정된 형식 '{2}'(으)로 변환할 수 없습니다. 아래 항목 중 하나를 입력하려던 것은 아니셨나요?{3}</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandRequiredArgumentMissing">
         <source>Required argument '{0}' missing for command: '{1}'.</source>
-        <target state="translated">명령 '{1}'에 대한 필수 인수 '{0}'이(가) 없습니다.</target>
+        <target state="translated">'{1}' 명령에 대한 필수 인수 '{0}'이(가) 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DirectoryDoesNotExist">
         <source>Directory does not exist: '{0}'.</source>
-        <target state="translated">디렉터리 '{0}'이(가) 없습니다.</target>
+        <target state="translated">디렉터리가 존재하지 않음: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ErrorReadingResponseFile">
         <source>Error reading response file '{0}': {1}</source>
-        <target state="translated">지시 파일 '{0}'을(를) 읽는 동안 오류가 발생했습니다. {1}</target>
+        <target state="translated">지시 파일 '{0}'을(를) 읽는 중 오류가 발생함: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ExceptionHandlerHeader">
         <source>Unhandled exception: </source>
-        <target state="new">Unhandled exception: </target>
+        <target state="translated">처리되지 않은 예외 발생: </target>
         <note />
       </trans-unit>
       <trans-unit id="FileDoesNotExist">
         <source>File does not exist: '{0}'.</source>
-        <target state="translated">파일이 없습니다. '{0}'.</target>
+        <target state="translated">파일이 존재하지 않음: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileOrDirectoryDoesNotExist">
         <source>File or directory does not exist: '{0}'.</source>
-        <target state="translated">파일 또는 디렉터리가 없음: '{0}'.</target>
+        <target state="translated">파일 또는 디렉터리가 존재하지 않음: '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsDescription">
         <source>Arguments passed to the application that is being run.</source>
-        <target state="new">Arguments passed to the application that is being run.</target>
+        <target state="translated">실행될 애플리케이션에 전달될 인수.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpAdditionalArgumentsTitle">
@@ -69,7 +69,7 @@
       </trans-unit>
       <trans-unit id="HelpArgumentDefaultValueLabel">
         <source>default</source>
-        <target state="new">default</target>
+        <target state="translated">기본값</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpArgumentsTitle">
@@ -84,32 +84,32 @@
       </trans-unit>
       <trans-unit id="HelpDescriptionTitle">
         <source>Description:</source>
-        <target state="new">Description:</target>
+        <target state="translated">설명:</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionDescription">
         <source>Show help and usage information</source>
-        <target state="new">Show help and usage information</target>
+        <target state="translated">도움말 및 사용 방법 출력</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsRequiredLabel">
         <source>(REQUIRED)</source>
-        <target state="new">(REQUIRED)</target>
+        <target state="translated">(필수)</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpUsageCommand">
         <source>[command]</source>
-        <target state="new">[command]</target>
+        <target state="translated">[명령]</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpUsageOptions">
         <source>[options]</source>
-        <target state="new">[options]</target>
+        <target state="translated">[옵션]</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidCharactersInFileName">
         <source>Character not allowed in a file name: '{0}'.</source>
-        <target state="new">Character not allowed in a file name: '{0}'.</target>
+        <target state="translated">문자 '{0}'은(는) 파일 이름에 사용될 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpOptionsTitle">
@@ -119,7 +119,7 @@
       </trans-unit>
       <trans-unit id="HelpUsageAdditionalArguments">
         <source>[[--] &lt;additional arguments&gt;...]]</source>
-        <target state="new">[[--] &lt;additional arguments&gt;...]]</target>
+        <target state="translated">[[--] &lt;추가 인수&gt;...]]</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpUsageTitle">
@@ -129,52 +129,52 @@
       </trans-unit>
       <trans-unit id="InvalidCharactersInPath">
         <source>Character not allowed in a path: '{0}'.</source>
-        <target state="translated">경로에 사용할 수 없는 문자: '{0}'.</target>
+        <target state="translated">문자 '{0}'은(는) 경로에 사용될 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionExpectsOneArgument">
         <source>Option '{0}' expects a single argument but {1} were provided.</source>
-        <target state="new">Option '{0}' expects a single argument but {1} were provided.</target>
+        <target state="translated">'{0}' 옵션에는 단일 값만 허용되지만 {1}개의 값이 입력되었습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OptionRequiredArgumentMissing">
         <source>Required argument missing for option: '{0}'.</source>
-        <target state="translated">옵션 '{0}'에 대한 필수 인수가 없습니다.</target>
+        <target state="translated">필수 인수가 '{0}' 옵션에 주어지지 않았습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredCommandWasNotProvided">
         <source>Required command was not provided.</source>
-        <target state="translated">필수 명령을 제공하지 않았습니다.</target>
+        <target state="translated">필수 명령이 주어지지 않았습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredOptionWasNotProvided">
         <source>Option '{0}' is required.</source>
-        <target state="new">Option '{0}' is required.</target>
+        <target state="translated">'{0}' 옵션은 반드시 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResponseFileNotFound">
         <source>Response file not found '{0}'.</source>
-        <target state="translated">'{0}'에서 지시 파일을 찾을 수 없음.</target>
+        <target state="translated">'{0}'에서 지시 파일을 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="SuggestionsTokenNotMatched">
         <source>'{0}' was not matched. Did you mean one of the following?</source>
-        <target state="new">'{0}' was not matched. Did you mean one of the following?</target>
+        <target state="translated">'{0}'와(과) 일치하는 항목이 없습니다. 아래 항목 중 하나를 입력하려던 것은 아니셨나요?</target>
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedArgument">
         <source>Argument '{0}' not recognized. Must be one of:{1}</source>
-        <target state="translated">'{0}' 인수를 인식할 수 없습니다. 다음 중 하나여야 합니다. {1}</target>
+        <target state="translated">'{0}' 인수를 인식할 수 없습니다. 다음 중 하나여야 합니다: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnrecognizedCommandOrArgument">
         <source>Unrecognized command or argument '{0}'.</source>
-        <target state="translated">인식할 수 없는 명령 또는 인수 '{0}'.</target>
+        <target state="translated">'{0}'은(는) 인식할 수 없는 명령 또는 인수입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionCannotBeCombinedWithOtherArguments">
         <source>{0} option cannot be combined with other arguments.</source>
-        <target state="new">{0} option cannot be combined with other arguments.</target>
+        <target state="translated">{0} 옵션은 다른 인수들과 함께 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">


### PR DESCRIPTION
## Summary

This PR completes the Korean translation in `Resources.ko.xlf` by translating untranslated strings and refining existing ones. Unlike English, which follows an SVO word order, Korean uses an SOV structure; as a result, the order of placeholders for string interpolation has been modified in some strings.

## Testing

Verified by setting `CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.GetCultureInfo("ko-KR")` before parsing and running the app without the required `--input` option.