### PR TITLE
Expect NativeAOT lib prefix on Unix for .NET 11 SDK

### DIFF
--- a/src/System.CommandLine.Tests/CompilationTests.cs
+++ b/src/System.CommandLine.Tests/CompilationTests.cs
@@ -121,8 +121,11 @@ public class CompilationTests
 
     private static string NativeLibraryFileName(string assemblyName) =>
         OperatingSystem.IsWindows() ? $"{assemblyName}.dll"
-            : OperatingSystem.IsMacOS() ? $"{assemblyName}.dylib"
-            : $"{assemblyName}.so";
+            // NativeAOT applies the "lib" prefix to native library outputs on Unix by
+            // default starting with the .NET 11 SDK (see dotnet/docs#52324). This repo
+            // pins an 11.x SDK via global.json, so the prefix is always present.
+            : OperatingSystem.IsMacOS() ? $"lib{assemblyName}.dylib"
+            : $"lib{assemblyName}.so";
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
     private delegate int GetExecutableNameDelegate(IntPtr buffer, int bufferLength);

--- a/src/System.CommandLine.Tests/TestApps/NativeLibrary/NativeLibrary.csproj
+++ b/src/System.CommandLine.Tests/TestApps/NativeLibrary/NativeLibrary.csproj
@@ -18,6 +18,8 @@
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
     <ControlFlowGuard>Guard</ControlFlowGuard>
     <IsTestUtilityProject>true</IsTestUtilityProject>
+    <!-- This is the default in net11.0, remove this once NetMinimum is bumped -->
+    <_UseNativeLibPrefix Condition="'$(NetMinimum)' == 'net10.0'">true</_UseNativeLibPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Follow-up to #2820, addressing @akoeplinger's review feedback.

Starting with the .NET 11 SDK, NativeAOT applies the `lib` prefix by default to native library outputs on Unix (dotnet/docs#52324). This repo pins an 11.x SDK via `global.json`, so the published shared library is `libNativeLibrary.so` / `libNativeLibrary.dylib`. The `CompilationTests` helper still looked for `NativeLibrary.so` / `.dylib`, which would fail `File.Exists` on Linux/macOS CI.

This updates the expected native library filename to include the `lib` prefix on Unix.