### PR TITLE
Log cancellation exceptions in the default handler

### DIFF
--- a/src/System.CommandLine.Tests/UseExceptionHandlerTests.cs
+++ b/src/System.CommandLine.Tests/UseExceptionHandlerTests.cs
@@ -35,19 +35,23 @@ namespace System.CommandLine.Tests
             error.ToString().Should().Contain("System.Exception: oops!");
         }
 
-        [Fact]
-        public async Task When_thrown_exception_is_from_cancelation_no_output_is_generated()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UseExceptionHandler_writes_cancellation_exception_details_to_standard_error(bool taskCanceled)
         {
             Command command = new("the-command");
-            command.SetAction((_, __) => throw new OperationCanceledException());
+            Exception exception = taskCanceled
+                                      ? new TaskCanceledException("task canceled")
+                                      : new OperationCanceledException("operation canceled");
+            command.SetAction((_, __) => throw exception);
 
-            var output = new StringWriter();
             var error = new StringWriter();
 
-            int resultCode = await command.Parse("the-command").InvokeAsync(new() { Output = output, Error = error }, CancellationToken.None);
+            int resultCode = await command.Parse("the-command").InvokeAsync(new() { Error = error }, CancellationToken.None);
 
-            output.ToString().Should().BeEmpty();
-            resultCode.Should().NotBe(0);
+            error.ToString().Should().Contain(exception.ToString());
+            resultCode.Should().Be(1);
         }
 
         [Theory]

--- a/src/System.CommandLine/Invocation/InvocationPipeline.cs
+++ b/src/System.CommandLine/Invocation/InvocationPipeline.cs
@@ -138,18 +138,15 @@ namespace System.CommandLine.Invocation
 
         private static int DefaultExceptionHandler(Exception exception, ParseResult parseResult)
         {
-            if (exception is not OperationCanceledException)
-            {
-                ConsoleHelpers.ResetTerminalForegroundColor();
-                ConsoleHelpers.SetTerminalForegroundRed();
+            ConsoleHelpers.ResetTerminalForegroundColor();
+            ConsoleHelpers.SetTerminalForegroundRed();
 
-                var error = parseResult.InvocationConfiguration.Error;
+            var error = parseResult.InvocationConfiguration.Error;
 
-                error.Write(LocalizationResources.ExceptionHandlerHeader());
-                error.WriteLine(exception.ToString());
+            error.Write(LocalizationResources.ExceptionHandlerHeader());
+            error.WriteLine(exception.ToString());
 
-                ConsoleHelpers.ResetTerminalForegroundColor();
-            }
+            ConsoleHelpers.ResetTerminalForegroundColor();
             return 1;
         }
 


### PR DESCRIPTION
## Summary

- I report `OperationCanceledException` through the default exception handler instead of suppressing its diagnostics.
- I cover both `OperationCanceledException` and `TaskCanceledException` with regression tests.
- I preserve the existing exit code of 1.

## Validation

- `./build.sh --test`
- `git diff --check upstream/main...HEAD`

Fixes #2808
