### PR TITLE
Omit empty description from help output

### DIFF
--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.Customization.cs
@@ -466,7 +466,6 @@ public partial class HelpBuilderTests
             command.Parse("test -h").Invoke(new() { Output = output });
 
             output.ToString().Should().Be(
-                $"Description:{NewLine}{NewLine}" +
                 $"Usage:{NewLine}  test [options]{NewLine}{NewLine}" +
                 $"Options:{NewLine}" +
                 $"  --option   option {NewLine}" +

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -74,6 +74,19 @@ namespace System.CommandLine.Tests.Help
             _console.ToString().Should().Contain(expected);
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Synopsis_section_is_omitted_when_description_is_missing(string? description)
+        {
+            var command = new RootCommand(description);
+
+            _helpBuilder.Write(command, _console);
+
+            _console.ToString().Should().NotContain(LocalizationResources.HelpDescriptionTitle());
+        }
+
         [Fact]
         public void Command_name_in_synopsis_can_be_specified()
         {

--- a/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
+++ b/src/System.CommandLine.Tests/Help/HelpBuilderTests.cs
@@ -84,7 +84,9 @@ namespace System.CommandLine.Tests.Help
 
             _helpBuilder.Write(command, _console);
 
-            _console.ToString().Should().NotContain(LocalizationResources.HelpDescriptionTitle());
+            _console.ToString().Should()
+                .NotContain(LocalizationResources.HelpDescriptionTitle())
+                .And.Contain(LocalizationResources.HelpUsageTitle());
         }
 
         [Fact]

--- a/src/System.CommandLine.Tests/HelpOptionTests.cs
+++ b/src/System.CommandLine.Tests/HelpOptionTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
+using System.CommandLine.Tests.Utility;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -56,7 +57,7 @@ public class HelpOptionTests
     [InlineData("/?")]
     public async Task Help_option_accepts_default_values(string value)
     {
-        var command = new Command("command")
+        var command = new Command("command", "command description")
         {
             new HelpOption()
         };
@@ -65,20 +66,20 @@ public class HelpOptionTests
 
         await command.Parse($"command {value}").InvokeAsync(new() { Output = output }, CancellationToken.None);
 
-        output.ToString().Should().Contain("--help");
+        output.ToString().Should().ShowHelp();
     }
 
     [Fact]
     public async Task Help_option_does_not_display_when_option_defined_with_same_alias()
     {
-        var command = new Command("command");
+        var command = new Command("command", "command description");
         command.Options.Add(new Option<bool>("-h"));
         
         var output = new StringWriter();
 
         await command.Parse("command -h").InvokeAsync(new() { Output = output }, CancellationToken.None);
 
-        output.ToString().Should().BeNullOrWhiteSpace();
+        output.ToString().Should().NotShowHelp();
     }
 
     [Fact]
@@ -142,7 +143,7 @@ public class HelpOptionTests
     [InlineData("--confused")]
     public async Task HelpOption_with_custom_aliases_uses_aliases(string helpAlias)
     {
-        RootCommand command = new()
+        RootCommand command = new("root description")
         {
             new HelpOption("/lost", "--confused")
         };
@@ -150,7 +151,7 @@ public class HelpOptionTests
 
         await command.Parse(helpAlias).InvokeAsync(new() { Output = output }, CancellationToken.None);
 
-        output.ToString().Should().Contain(helpAlias);
+        output.ToString().Should().ShowHelp();
     }
 
     [Theory]

--- a/src/System.CommandLine.Tests/HelpOptionTests.cs
+++ b/src/System.CommandLine.Tests/HelpOptionTests.cs
@@ -4,7 +4,6 @@
 using FluentAssertions;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
-using System.CommandLine.Tests.Utility;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -66,7 +65,7 @@ public class HelpOptionTests
 
         await command.Parse($"command {value}").InvokeAsync(new() { Output = output }, CancellationToken.None);
 
-        output.ToString().Should().ShowHelp();
+        output.ToString().Should().Contain("--help");
     }
 
     [Fact]
@@ -79,7 +78,7 @@ public class HelpOptionTests
 
         await command.Parse("command -h").InvokeAsync(new() { Output = output }, CancellationToken.None);
 
-        output.ToString().Should().NotShowHelp();
+        output.ToString().Should().BeNullOrWhiteSpace();
     }
 
     [Fact]
@@ -151,7 +150,7 @@ public class HelpOptionTests
 
         await command.Parse(helpAlias).InvokeAsync(new() { Output = output }, CancellationToken.None);
 
-        output.ToString().Should().ShowHelp();
+        output.ToString().Should().Contain(helpAlias);
     }
 
     [Theory]

--- a/src/System.CommandLine.Tests/ParseErrorReportingTests.cs
+++ b/src/System.CommandLine.Tests/ParseErrorReportingTests.cs
@@ -4,7 +4,6 @@
 using FluentAssertions;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
-using System.CommandLine.Tests.Utility;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -31,7 +30,7 @@ public class ParseErrorReportingTests
         var result = parseResult.Invoke(new() { Output = output });
 
         result.Should().Be(1);
-        output.ToString().Should().ShowHelp();
+        output.ToString().Should().Contain("--help");
     }
 
     [Fact]
@@ -53,7 +52,7 @@ public class ParseErrorReportingTests
 
         result.Invoke(new() { Output = output });
 
-        output.ToString().Should().NotShowHelp();
+        output.ToString().Should().BeNullOrWhiteSpace();
     }
 
     [Theory] // https://github.com/dotnet/command-line-api/issues/2226
@@ -110,7 +109,7 @@ public class ParseErrorReportingTests
         
         rootCommand.Parse("oops").Invoke(new() { Output = output } );
 
-        output.ToString().Should().NotShowHelp();
+        output.ToString().Should().BeNullOrWhiteSpace();
     }
 
     [Fact]

--- a/src/System.CommandLine.Tests/ParseErrorReportingTests.cs
+++ b/src/System.CommandLine.Tests/ParseErrorReportingTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using System.CommandLine.Help;
 using System.CommandLine.Invocation;
+using System.CommandLine.Tests.Utility;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,7 +17,7 @@ public class ParseErrorReportingTests
     [Fact] // https://github.com/dotnet/command-line-api/issues/817
     public void Help_is_shown_when_required_subcommand_is_missing()
     {
-        var root = new RootCommand
+        var root = new RootCommand("root description")
         {
             new Command("inner"),
             new HelpOption()
@@ -30,13 +31,13 @@ public class ParseErrorReportingTests
         var result = parseResult.Invoke(new() { Output = output });
 
         result.Should().Be(1);
-        output.ToString().Should().Contain("--help");
+        output.ToString().Should().ShowHelp();
     }
 
     [Fact]
     public void Help_display_can_be_disabled()
     {
-        RootCommand rootCommand = new()
+        RootCommand rootCommand = new("root description")
         {
             new Option<bool>("--verbose")
         };
@@ -52,7 +53,7 @@ public class ParseErrorReportingTests
 
         result.Invoke(new() { Output = output });
 
-        output.ToString().Should().BeNullOrWhiteSpace();
+        output.ToString().Should().NotShowHelp();
     }
 
     [Theory] // https://github.com/dotnet/command-line-api/issues/2226
@@ -103,13 +104,13 @@ public class ParseErrorReportingTests
     [Fact]
     public void When_no_help_option_is_present_then_help_is_not_shown_for_parse_errors()
     {
-        RootCommand rootCommand = new();
+        RootCommand rootCommand = new("root description");
         rootCommand.Options.Clear();
         var output = new StringWriter();
         
         rootCommand.Parse("oops").Invoke(new() { Output = output } );
 
-        output.ToString().Should().BeNullOrWhiteSpace();
+        output.ToString().Should().NotShowHelp();
     }
 
     [Fact]

--- a/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
+++ b/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Collections;
 using FluentAssertions.Execution;
-using FluentAssertions.Primitives;
 
 namespace System.CommandLine.Tests.Utility;
 
@@ -45,10 +44,4 @@ public static class AssertionExtensions
     {
         return assertions.BeEquivalentTo(expectedValues, c => c.WithStrictOrderingFor(s => s));
     }
-
-    public static AndConstraint<StringAssertions> ShowHelp(this StringAssertions output) => 
-        output.Subject.Should().Match("*Usage:*Options:*");
-
-    public static AndConstraint<StringAssertions> NotShowHelp(this StringAssertions output) => 
-        output.Subject.Should().NotMatch("*Usage:*Options:*");
 }

--- a/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
+++ b/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using FluentAssertions;
 using FluentAssertions.Collections;
 using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
 
 namespace System.CommandLine.Tests.Utility;
 
@@ -44,4 +45,10 @@ public static class AssertionExtensions
     {
         return assertions.BeEquivalentTo(expectedValues, c => c.WithStrictOrderingFor(s => s));
     }
+
+    public static AndConstraint<StringAssertions> ShowHelp(this StringAssertions output) =>
+        output.Subject.Should().Match("*Description:*Usage:*");
+
+    public static AndConstraint<StringAssertions> NotShowHelp(this StringAssertions output) =>
+        output.Subject.Should().NotMatch("*Description:*Usage:*");
 }

--- a/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
+++ b/src/System.CommandLine.Tests/Utility/AssertionExtensions.cs
@@ -47,8 +47,8 @@ public static class AssertionExtensions
     }
 
     public static AndConstraint<StringAssertions> ShowHelp(this StringAssertions output) => 
-        output.Subject.Should().Match("*Description:*Usage:*");
+        output.Subject.Should().Match("*Usage:*Options:*");
 
     public static AndConstraint<StringAssertions> NotShowHelp(this StringAssertions output) => 
-        output.Subject.Should().NotMatch("*Description:*Usage:*");
+        output.Subject.Should().NotMatch("*Usage:*Options:*");
 }

--- a/src/System.CommandLine/Help/HelpBuilder.Default.cs
+++ b/src/System.CommandLine/Help/HelpBuilder.Default.cs
@@ -185,7 +185,13 @@ internal partial class HelpBuilder
         public static Func<HelpContext, bool> SynopsisSection() =>
             ctx =>
             {
-                ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpDescriptionTitle(), ctx.Command.Description, ctx.Output);
+                string? description = ctx.Command.Description;
+                if (string.IsNullOrWhiteSpace(description))
+                {
+                    return false;
+                }
+
+                ctx.HelpBuilder.WriteHeading(LocalizationResources.HelpDescriptionTitle(), description, ctx.Output);
                 return true;
             };
 


### PR DESCRIPTION
## Summary
  - omit the Description section when the command description is null, empty, or whitespace
  - update help-output assertions
  - add regression coverage

  Fixes #2114

  ## Testing
  - affected tests on net10.0 and net472
  - full net10.0 test suite