### PR TITLE
Add measured System.CommandLine agent skills

### DIFF
--- a/skills/system-commandline-beta-to-ga-migration/SKILL.md
+++ b/skills/system-commandline-beta-to-ga-migration/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: system-commandline-beta-to-ga-migration
+version: 2.0.0
+description: >-
+  Use when migrating a .NET CLI from System.CommandLine 2.0.0-beta (beta1–beta4) to the GA / 3.x
+  API, or when you see removed beta symbols (SetHandler, AddOption, AddCommand, AddGlobalOption,
+  BinderBase<T>, IConsole, HelpBuilder, getDefaultValue:, IsRequired, ExistingOnly). beta4 → GA was a
+  breaking redesign of the invocation and binding stack: beta code does NOT compile against GA.
+---
+
+# System.CommandLine: 2.0.0-beta → GA / 3.x migration
+
+beta4 → 2.0 GA removed the entire old invocation/binding stack. Beta code does **not** compile against
+GA, and most training-data / web snippets are beta. 3.x is additive over GA, so the **same** mapping
+carries beta code all the way to 3.x. Set the package version, then apply the table mechanically.
+
+> Do NOT `web_search` / `web_fetch` — the top results are the removed beta API. This table is the
+> authoritative rename map.
+
+## Required setup
+
+Set the package version first — beta and GA are the same package id, so the migration starts with
+`<PackageReference Include="System.CommandLine" Version="2.0.11" />` — the latest stable — or
+`Version="3.0.0-preview.7.26381.103"` for the 3.x preview. The namespace is
+unchanged (`using System.CommandLine;`); what changed is the invocation and binding stack.
+
+The GA shape every row below maps onto — declare the instance, add it to a command, read it back by
+that instance:
+
+```csharp
+using System.CommandLine;
+
+var nameOption = new Option<string>("--name") { Description = "Who to greet" };
+
+var root = new RootCommand("Greeter");
+root.Options.Add(nameOption);                          // was root.AddOption(nameOption)
+root.SetAction(parseResult =>                          // was root.SetHandler((string n) => ...)
+{
+    string name = parseResult.GetValue(nameOption)!;   // was a bound delegate parameter
+    return 0;
+});
+return await root.Parse(args).InvokeAsync();           // was root.InvokeAsync(args)
+```
+
+## Rename map
+
+| 2.0.0-beta4 | 2.x / 3.x GA |
+| ----------- | ------------ |
+| `AddOption` / `AddArgument` / `AddCommand` | `Options.Add` / `Arguments.Add` / `Subcommands.Add` |
+| `AddGlobalOption(o)` | `o.Recursive = true;` then `Options.Add(o)` |
+| `SetHandler(...)` / `Handler.SetHandler(...)` | `command.SetAction(parseResult => ...)` |
+| `command.Invoke(args)` / `InvokeAsync(args)` | `command.Parse(args).Invoke()` / `.InvokeAsync()` |
+| handler params bound by position | `parseResult.GetValue(option)` inside the action |
+| `getDefaultValue: () => v` ctor arg / `SetDefaultValue` / `SetDefaultValueFactory` | `DefaultValueFactory = _ => v` |
+| `IsRequired` | `Required` |
+| `ExistingOnly()` | `AcceptExistingOnly()` |
+| `ArgumentHelpName` | `HelpName` |
+| binding: `BinderBase<T>` / `BindingContext` / `IValueDescriptor` | `parseResult.GetValue(option)` |
+| `IConsole` / `HelpBuilder` | removed; use `Console`, customize help via `HelpAction` |
+
+## Before (beta4) → After (GA/3.x)
+
+```csharp
+// BETA4 — does NOT compile against GA
+var name = new Option<string>("--name", getDefaultValue: () => "world", description: "Name") { IsRequired = true };
+var root = new RootCommand("Greeter");
+root.AddOption(name);
+root.SetHandler((string n) => Console.WriteLine($"Hello {n}"), name);
+return await root.InvokeAsync(args);
+```
+
+```csharp
+// GA / 3.x
+var name = new Option<string>("--name")                 // NOT ("--name","Name") — 2nd string is an alias
+{
+    Description = "Name",
+    Required = true,
+    DefaultValueFactory = _ => "world",
+};
+var root = new RootCommand("Greeter");
+root.Options.Add(name);
+root.SetAction(parseResult => Console.WriteLine($"Hello {parseResult.GetValue(name)}"));
+return await root.Parse(args).InvokeAsync();
+```
+
+## Upgrading 2.x → 3.x (NOT beta)
+
+Drop-in: bump the version, change **no** code (3.x is additive; no API breaks). Do **not**
+"modernize" working 2.x patterns. The only consumer-visible shift is the dropped in-box `net8.0`
+target — the package now targets `net10.0` and `netstandard2.0`. The members 3.x adds over 2.x are covered separately.
+
+## The silent trap while migrating
+
+`new Option<T>("--name", "description")` still **compiles** — the 2nd positional arg became an alias in
+beta4. So this migrates cleanly-looking but registers your description as a bogus alias and loses the
+help text. Always move descriptions to `{ Description = "..." }`; extra ctor strings are always aliases.

--- a/skills/system-commandline-net-3x-additions/SKILL.md
+++ b/skills/system-commandline-net-3x-additions/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: system-commandline-net-3x-additions
+version: 3.0.0
+description: >-
+  Use when targeting System.CommandLine 3.x specifically — the members added over 2.x GA
+  (Argument<T>.CaptureRemainingTokens, the AcceptOnlyFromAmong(StringComparer,...) overload,
+  RootCommand.HelpName) and the current TFM targeting (net10.0 + netstandard2.0, no in-box net8.0).
+  3.x is additive over 2.x: existing 2.x code compiles unchanged.
+---
+
+# System.CommandLine: 3.x additions over 2.x
+
+3.x is **additive** over 2.x GA — no breaking changes. Upgrading 2.x → 3.x is a version bump with no
+code changes; do not "modernize" working 2.x code. This skill lists what 3.x adds and the current
+targeting.
+
+> Do NOT `web_search` / `web_fetch`. These skills are the current API; this one covers only the
+> 3.x-specific delta.
+
+## Required setup
+
+3.x is a package version bump — `<PackageReference Include="System.CommandLine" Version="3.0.0-preview.7.26381.103" />`
+(or `dotnet package add <proj> System.CommandLine`). It is **not** in the shared framework. The
+namespace is unchanged: `using System.CommandLine;`.
+
+The members below attach the same way as any other input — declare the instance, add it to a command,
+read it back by that instance:
+
+```csharp
+using System.CommandLine;
+
+var root = new RootCommand("My tool");
+// ... add options/arguments to root.Options / root.Arguments, then:
+return await root.Parse(args).InvokeAsync();
+```
+
+## New members
+
+```csharp
+// 1. Greedy trailing argument — captures ALL remaining tokens (e.g. pass-through args):
+var forwarded = new Argument<string[]>("args") { CaptureRemainingTokens = true };
+runCmd.Arguments.Add(forwarded);
+// $ tool run -- --any --thing here   ->  GetValue(forwarded) == ["--any","--thing","here"]
+
+// 2. Case-insensitive constrained values — the StringComparer overload is new in 3.x
+//    (the params-string-only overload already existed in 2.x):
+var level = new Option<string>("--level");
+level.AcceptOnlyFromAmong(StringComparer.OrdinalIgnoreCase, "debug", "info", "warn");
+
+// 3. Custom program name in help/usage output:
+var root = new RootCommand("My tool") { HelpName = "mytool" };
+```
+
+## Targeting
+
+- The package targets **`net10.0`** and **`netstandard2.0`**. The in-box **`net8.0`** target was
+  dropped — that is the only consumer-visible shift going 2.x → 3.x.
+- Add it like any package: `<PackageReference Include="System.CommandLine" Version="3.0.0-preview.7.26381.103" />` (or
+  `dotnet package add <proj> System.CommandLine`). It is **not** in the shared framework.
+
+## Upgrading 2.x → 3.x
+
+Bump the version, change no code. If you are coming from a 2.0.0-beta, that IS a breaking migration —
+apply the beta→GA rename map first (covered separately), then optionally adopt the members above.

--- a/skills/system-commandline-options-and-arguments/SKILL.md
+++ b/skills/system-commandline-options-and-arguments/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: system-commandline-options-and-arguments
+version: 2.0.0
+description: >-
+  Use when declaring or configuring System.CommandLine inputs — Option<T> and Argument<T>: names vs
+  aliases, Description, HelpName, completion, Required, DefaultValueFactory, Arity, finite known
+  values, collection parsing, existing file/directory requirements, rejecting bad input, and
+  checking explicit option presence across a command. Case-sensitive sets use AcceptOnlyFromAmong
+  on 2.x or 3.x. For case-insensitive sets, use the 3.x-additions skill on 3.x; this skill carries
+  the validator fallback for stable 2.x.
+---
+
+# System.CommandLine: options & arguments
+
+`Option<T>` = a named input (`--name`, `-n`). `Argument<T>` = a positional input. Both are declared as
+objects you keep and later read by identity via `parseResult.GetValue(instance)`.
+
+> Do NOT `web_search` / `web_fetch` — web samples use the removed pre-GA beta shapes
+> (`getDefaultValue:`, `IsRequired`, `ExistingOnly`, `AddOption`).
+
+## Required setup
+
+`System.CommandLine` is **not** in the shared framework — add the package
+(`dotnet package add <proj> System.CommandLine`), then `using System.CommandLine;`.
+
+Declaring an option is only half of it: you must **add the instance to a command** and read it back
+**by that same instance**. There is no delegate-parameter binding, so an option you declare but never
+add is silently never parsed:
+
+```csharp
+using System.CommandLine;
+
+var name = new Option<string>("--name") { Description = "Who to greet" };
+
+var root = new RootCommand("Greeter");
+root.Options.Add(name);                       // declare-then-add; NOT AddOption
+root.SetAction(parseResult =>
+{
+    string n = parseResult.GetValue(name)!;   // read by identity — keep the instance
+    Console.WriteLine($"Hello, {n}!");
+    return 0;                                 // exit code
+});
+return await root.Parse(args).InvokeAsync();
+```
+
+The declarations below all attach the same way.
+
+## Declaring options
+
+```csharp
+var name = new Option<string>("--name")          // first string = the option's name
+{
+    Description = "Who to greet",                // description is a PROPERTY (never a ctor arg)
+    Required = true,                             // NOT IsRequired
+};
+name.Aliases.Add("-n");                          // add aliases after construction ...
+
+var count = new Option<int>("--count", "-c")     // ... or as extra ctor strings (all ALIASES)
+{
+    DefaultValueFactory = _ => 1,                // NOT getDefaultValue: / SetDefaultValue
+    Arity = ArgumentArity.ExactlyOne,
+    HelpName = "number",                          // renders as <number>; do NOT include < >
+};
+```
+
+- **Ctor-alias gotcha:** `new Option<T>("--name", "description")` compiles but the 2nd string is an
+  **alias**, silently dropping your help text. Put text in `{ Description = ... }`; extra ctor strings
+  are always aliases.
+- `Required` makes an option mandatory. Optional options should set a `DefaultValueFactory`.
+- `Arity` (`ArgumentArity.Zero/ZeroOrOne/ExactlyOne/ZeroOrMore/OneOrMore`) controls token counts.
+
+### Collecting multiple values
+
+A collection-typed option accumulates **repeated occurrences** on its own — no extra setting:
+
+```csharp
+var tag = new Option<string[]>("--tag");                       // or Option<List<string>>
+
+// tool --tag a --tag b  =>  ["a", "b"]
+```
+
+Accepting **several values after one token** (`--tag a b`) is a different behavior and is off by
+default; that form is rejected until you opt in:
+
+```csharp
+var tag = new Option<string[]>("--tag") { AllowMultipleArgumentsPerToken = true };
+
+// tool --tag a b  =>  ["a", "b"]
+```
+
+Decide which command lines you mean to accept: repeating the option needs nothing, and only the
+one-token-many-values form needs the flag.
+
+Give sibling commands separate option instances. For example, `add --language` may be required while
+`edit --language` is optional; one `Option<T>` object cannot represent both contracts.
+
+## Declaring arguments (positional)
+
+```csharp
+var path = new Argument<FileInfo>("path")
+{
+    Description = "Input file",
+    Arity = ArgumentArity.ExactlyOne,
+};
+path.AcceptExistingOnly();                        // NOT ExistingOnly(); also on Argument<DirectoryInfo>
+```
+
+## Known values, completion, and version-specific case-insensitivity
+
+Choose the package-owned constraint before writing a validator:
+
+```csharp
+// 2.x or 3.x: exact, case-sensitive finite set.
+var environment = new Option<string>("--env");
+environment.AcceptOnlyFromAmong("dev", "prod");
+
+```
+
+If a 3.x task asks for case-insensitive known values, pull the 3.x-additions skill for the
+version-specific package surface. Do not substitute the stable fallback below. On stable 2.x, use a
+validator:
+
+```csharp
+string[] knownFormats = ["json", "yaml"];
+
+var format = new Option<string>("--format", "-f")
+{
+    DefaultValueFactory = _ => "json",
+    HelpName = string.Join("|", knownFormats), // generated help: <json|yaml>
+};
+format.CompletionSources.Add(knownFormats);
+format.Validators.Add(result =>
+{
+    string value = result.GetValue(format)!;
+    if (!knownFormats.Any(known => known.Equals(value, StringComparison.OrdinalIgnoreCase)))
+    {
+        result.AddError($"Unknown format '{value}'. Supported values: {string.Join(", ", knownFormats)}.");
+    }
+});
+```
+
+Derive `HelpName`, completion, and validation from one list so they cannot drift. `HelpName` is the
+text *inside* generated angle brackets: use `"json|yaml"`, not `"<json|yaml>"`. Never normalize by
+rewriting raw `args`.
+
+For a required collection that accepts several values after one token, combine the pieces:
+
+```csharp
+string[] knownTypes = ["security", "style", "performance"];
+var type = new Option<string[]>("--type", "-t")
+{
+    Required = true,
+    Arity = ArgumentArity.OneOrMore,
+    AllowMultipleArgumentsPerToken = true,
+};
+type.CompletionSources.Add(knownTypes);
+type.Validators.Add(result =>
+{
+    foreach (string value in result.GetValueOrDefault<string[]>() ?? [])
+    {
+        if (!knownTypes.Any(known => known.Equals(value, StringComparison.OrdinalIgnoreCase)))
+            result.AddError($"Unknown type '{value}'. Supported values: {string.Join(", ", knownTypes)}.");
+    }
+});
+```
+
+## Custom parsing & validation
+
+```csharp
+// Turn a raw token into T (and report parse failures):
+var port = new Option<int>("--port")
+{
+    CustomParser = result =>
+    {
+        if (int.TryParse(result.Tokens[0].Value, out var p) && p is > 0 and < 65536) return p;
+        result.AddError("--port must be 1..65535");
+        return 0;
+    },
+};
+
+// Validate ONE already-parsed value — the validator hangs off that option:
+port.Validators.Add(result =>
+{
+    if (result.GetValue(port) == 0) result.AddError("--port is required and must be valid");
+});
+
+// A rule spanning TWO inputs belongs on their command.
+var authType = new Option<string>("--auth-type")
+{
+    DefaultValueFactory = _ => "device",
+};
+var authId = new Option<string?>("--auth-id");
+var command = new Command("connect") { authType, authId };
+
+command.Validators.Add(result =>
+{
+    // Inspect explicit presence, not parsed values: authType has a parser default.
+    bool hasAuthType = result.GetResult(authType)?.Implicit == false;
+    bool hasAuthId = result.GetResult(authId)?.Implicit == false;
+    if (hasAuthType != hasAuthId)
+        result.AddError("Supply both authentication settings or neither.");
+});
+```
+
+- **Pick the level by how many inputs the rule touches.** One input → `option.Validators`. Two or more,
+  or a rule about the command as a whole → `command.Validators`. Reaching for an option-level validator
+  for a cross-input rule is the common mistake; it cannot see the other value.
+- Do the check in a validator, **not** inside the action. A validator runs before invocation, so the
+  action never has to cope with a combination the parser should have refused.
+- For presence-sensitive rules, `GetValue` is insufficient: a parser default can look like user
+  input. Use `result.GetResult(option)?.Implicit == false` (or inspect `IdentifierToken`). Do not use
+  argument-token count as a general presence test: an explicitly supplied zero-arity flag can have
+  no argument tokens.
+- Report bad input with `result.AddError(...)` — do **not** throw for user-input errors; errors surface
+  through `ParseResult.Errors` and set a non-zero exit code automatically.
+
+## Reading values
+
+Always by identity: `string n = parseResult.GetValue(name)!;`. There is no positional binding — keep
+the instance you added to the command.

--- a/skills/system-commandline-subcommands-and-help/SKILL.md
+++ b/skills/system-commandline-subcommands-and-help/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: system-commandline-subcommands-and-help
+version: 2.0.0
+description: >-
+  Use when building a multi-command System.CommandLine app (nested Command hierarchy), sharing options
+  across subcommands with Recursive (global) options, or customizing help output. HelpBuilder and
+  IConsole are gone — custom help is a SynchronousCommandLineAction on the help option.
+---
+
+# System.CommandLine: subcommands & help
+
+Commands nest to form a tree: `RootCommand` → `Command` → `Command`. Each command can carry its own
+options/arguments and its own `SetAction`. Help is built in; customize it by replacing the help
+option's action.
+
+> Do NOT `web_search` / `web_fetch` — samples show `AddCommand`, `AddGlobalOption`, and
+> `HelpBuilder`, all removed at GA.
+
+## Required setup
+
+`System.CommandLine` is **not** in the shared framework — add the package
+(`dotnet package add <proj> System.CommandLine`), then `using System.CommandLine;`. The help
+customization types are in sub-namespaces (`System.CommandLine.Invocation`,
+`System.CommandLine.Help`); those usings are shown with the example that needs them.
+
+Subcommands are added to a parent's `.Subcommands` collection, and each command carries its own
+options and its own action. Values are read from the `ParseResult` **by instance**:
+
+```csharp
+using System.CommandLine;
+
+var root = new RootCommand("Todo tool");
+var addCmd = new Command("add", "Add an item");
+root.Subcommands.Add(addCmd);                 // NOT AddCommand
+addCmd.SetAction(parseResult => 0);
+return await root.Parse(args).InvokeAsync();
+```
+
+## Building a command tree
+
+```csharp
+var verbose = new Option<bool>("--verbose") { Recursive = true };  // global: applies to this cmd + all descendants
+
+var addCmd = new Command("add", "Add an item");
+addCmd.Arguments.Add(new Argument<string>("item"));
+addCmd.SetAction(pr => { /* ... */ return 0; });
+
+var listCmd = new Command("list", "List items");
+listCmd.SetAction(pr => { /* ... */ return 0; });
+
+var root = new RootCommand("Todo tool");
+root.Options.Add(verbose);
+root.Subcommands.Add(addCmd);      // NOT AddCommand
+root.Subcommands.Add(listCmd);
+
+return await root.Parse(args).InvokeAsync();
+```
+
+- `new Command(name, description)` — here the 2nd arg **is** a description (unlike `Option`/`Argument`,
+  whose 2nd string is an alias).
+- Nest with `parent.Subcommands.Add(child)`.
+- **Global options:** set `option.Recursive = true` then add it once; it is available on that command
+  and every descendant. (Replaces `AddGlobalOption`.) Read it from whichever `ParseResult` you get.
+
+## Customizing help
+
+`HelpBuilder`/`IConsole` are gone. The help option exposes an `Action`; wrap or replace it with a
+`SynchronousCommandLineAction`. To augment (not replace) default help, capture the existing action and
+call it, then write extra content. These help types live in **sub-namespaces**, so add the usings:
+`CommandLineAction`/`SynchronousCommandLineAction` are in `System.CommandLine.Invocation` and
+`HelpOption` is in `System.CommandLine.Help`.
+
+```csharp
+using System.CommandLine.Invocation;   // CommandLineAction, SynchronousCommandLineAction
+using System.CommandLine.Help;         // HelpOption
+
+sealed class BannerHelpAction : SynchronousCommandLineAction
+{
+    readonly CommandLineAction _inner;
+    public BannerHelpAction(CommandLineAction inner) => _inner = inner;
+
+    public override int Invoke(ParseResult parseResult)
+    {
+        Console.WriteLine("my-tool — does useful things\n");
+        return (_inner as SynchronousCommandLineAction)?.Invoke(parseResult) ?? 0;
+    }
+}
+
+// Find the built-in help option and swap its action:
+var helpOption = root.Options.OfType<HelpOption>().First();
+helpOption.Action = new BannerHelpAction(helpOption.Action!);
+```
+
+- Use `RootCommand.HelpName` (3.x) to control the program name shown in usage.
+- Built-in `--help`/`-h` and `--version` are added automatically; you don't declare them.


### PR DESCRIPTION
## Purpose

Ship focused Agent Skills with System.CommandLine so coding agents use the current package API
instead of common pre-GA beta shapes. These are plain `SKILL.md` files under `skills/`; they add no
runtime dependency and do not change the product build.

## Included skills

- **Options and arguments** — current declaration, alias, default, arity, finite-value, collection,
  parser, and validator patterns.
- **3.x additions** — the additive 3.x API surface and target-framework changes.
- **Subcommands and help** — command trees, recursive options, and current help customization.
- **Beta-to-GA migration** — the mechanical rename map plus compile-clean migration traps.

The broader base skill and the actions/invocation skill are intentionally not included. Their
quality cards showed useful reliability gains but excessive target-work cost, especially on the
frontier model; they need to become smaller before being proposed upstream.

## Evaluation

The candidate shelf was evaluated against
`System.CommandLine 3.0.0-preview.7.26381.103` using 24 fixed tasks, five baseline and five grounded
trials per task, and three separate GPT-5.6 cohorts (Luna, Terra, and Sol): 720 canonical sessions.
Only deterministic graders classified `Fails < Satisfies < Delivers`; model cohorts were not pooled.

Complete-shelf task results:

| Model | Delivered | Fidelity | Shared Total-IET |
|---|---:|---:|---:|
| Luna | 71/120 -> 115/120 | 61.7% -> 95.8% | x0.94 |
| Terra | 77/120 -> 115/120 | 65.3% -> 95.8% | x0.91 |
| Sol | 100/120 -> 108/120 | 83.3% -> 90.0% | x1.09 |

Natural-activation cards for the four proposed skills:

| Skill | Target reliability delta (Luna / Terra / Sol) | Target Total-IET (Luna / Terra / Sol) |
|---|---:|---:|
| Options and arguments | +0.280 / +0.320 / +0.000 | x0.82 / x0.98 / x0.99 |
| 3.x additions | +0.667 / +0.800 / +0.400 | x0.78 / x0.65 / x0.78 |
| Subcommands and help | +0.314 / +0.171 / -0.029 | x0.85 / x0.73 / x1.03 |
| Beta-to-GA migration | +0.500 / +0.700 / +0.200 | x0.80 / x0.63 / x0.85 |

The small recorded Sol loss for subcommands/help is an evaluator exact-spelling defect, not broken
behavior: the affected implementations built and passed runtime checks using supported command
collection initializers rather than the grader's required `Subcommands.Add` spelling.

The Vally execution adapter, deterministic cards, controls, pins, and complete evidence are in
richlander/dotnet-package-skills#85. Design and certification tracking is in
richlander/dotnet-package-skills#81.

This PR includes only the selected skill payload; adopting the evaluation infrastructure is not a
prerequisite.